### PR TITLE
Implement sales listing module

### DIFF
--- a/api/ventas/listar_ventas.php
+++ b/api/ventas/listar_ventas.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$query = "SELECT * FROM ventas ORDER BY fecha DESC";
+$result = $conn->query($query);
+
+if (!$result) {
+    error('Error al obtener ventas: ' . $conn->error);
+}
+
+$ventas = [];
+while ($row = $result->fetch_assoc()) {
+    $ventas[] = $row;
+}
+
+success($ventas);
+?>

--- a/config/db.php
+++ b/config/db.php
@@ -1,0 +1,12 @@
+<?php
+$host = 'localhost';
+$user = 'root';
+$pass = '';
+$db   = 'restaurante';
+
+$conn = new mysqli($host, $user, $pass, $db);
+
+if ($conn->connect_errno) {
+    die('Error de conexión: ' . $conn->connect_error);
+}
+?>

--- a/utils/response.php
+++ b/utils/response.php
@@ -1,0 +1,13 @@
+<?php
+function success($data) {
+    header('Content-Type: application/json');
+    echo json_encode(['success' => true, 'resultado' => $data]);
+    exit;
+}
+
+function error($mensaje) {
+    header('Content-Type: application/json');
+    echo json_encode(['success' => false, 'mensaje' => $mensaje]);
+    exit;
+}
+?>

--- a/vistas/ventas/ventas.html
+++ b/vistas/ventas/ventas.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Ventas</title>
+</head>
+<body>
+    <button id="cargarVentas">Cargar ventas</button>
+    <table id="tablaVentas" border="1">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Fecha</th>
+                <th>Mesa</th>
+                <th>Total</th>
+                <th>Estatus</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <script src="ventas.js"></script>
+</body>
+</html>

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -1,0 +1,32 @@
+const boton = document.getElementById('cargarVentas');
+const tabla = document.getElementById('tablaVentas').querySelector('tbody');
+
+boton.addEventListener('click', async () => {
+    try {
+        const respuesta = await fetch('../../api/ventas/listar_ventas.php');
+        const datos = await respuesta.json();
+        if (datos.success) {
+            renderVentas(datos.resultado);
+        } else {
+            alert(datos.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar las ventas');
+    }
+});
+
+function renderVentas(ventas) {
+    tabla.innerHTML = '';
+    ventas.forEach(v => {
+        const fila = document.createElement('tr');
+        fila.innerHTML = `
+            <td>${v.id}</td>
+            <td>${v.fecha}</td>
+            <td>${v.mesa}</td>
+            <td>${v.total}</td>
+            <td>${v.estatus}</td>
+        `;
+        tabla.appendChild(fila);
+    });
+}


### PR DESCRIPTION
## Summary
- add MySQL connection config
- add success/error helpers returning JSON
- implement API to list sales
- add sales table in frontend with load button
- add JS to fetch and display sales

## Testing
- `php -l config/db.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604d028ab4832bb1ab70a273fcaebc