### PR TITLE
Implement sale management APIs

### DIFF
--- a/api/ventas/cancelar_venta.php
+++ b/api/ventas/cancelar_venta.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['venta_id'])) {
+    error('Datos inválidos');
+}
+
+$venta_id = (int) $input['venta_id'];
+
+$stmt = $conn->prepare("UPDATE ventas SET estatus = 'cancelada' WHERE id = ?");
+if (!$stmt) {
+    error('Error al preparar actualización: ' . $conn->error);
+}
+$stmt->bind_param('i', $venta_id);
+if (!$stmt->execute()) {
+    error('Error al cancelar venta: ' . $stmt->error);
+}
+
+if ($stmt->affected_rows === 0) {
+    $stmt->close();
+    error('Venta no encontrada');
+}
+$stmt->close();
+
+success(['mensaje' => 'Venta cancelada correctamente']);
+

--- a/api/ventas/crear_venta.php
+++ b/api/ventas/crear_venta.php
@@ -1,0 +1,60 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    error('JSON inválido');
+}
+
+$mesa_id    = isset($input['mesa_id']) ? (int) $input['mesa_id'] : null;
+$usuario_id = isset($input['usuario_id']) ? (int) $input['usuario_id'] : null;
+$productos  = isset($input['productos']) && is_array($input['productos']) ? $input['productos'] : null;
+
+if (!$mesa_id || !$usuario_id || !$productos) {
+    error('Datos incompletos para crear la venta');
+}
+
+$total = 0;
+foreach ($productos as $p) {
+    if (!isset($p['producto_id'], $p['cantidad'], $p['precio_unitario'])) {
+        error('Formato de producto incorrecto');
+    }
+    $total += $p['cantidad'] * $p['precio_unitario'];
+}
+
+$stmt = $conn->prepare('INSERT INTO ventas (mesa_id, usuario_id, total) VALUES (?, ?, ?)');
+if (!$stmt) {
+    error('Error al preparar venta: ' . $conn->error);
+}
+$stmt->bind_param('iid', $mesa_id, $usuario_id, $total);
+if (!$stmt->execute()) {
+    error('Error al crear venta: ' . $stmt->error);
+}
+$venta_id = $stmt->insert_id;
+$stmt->close();
+
+$detalle = $conn->prepare('INSERT INTO venta_detalles (venta_id, producto_id, cantidad, precio_unitario) VALUES (?, ?, ?, ?)');
+if (!$detalle) {
+    error('Error al preparar detalle: ' . $conn->error);
+}
+
+foreach ($productos as $p) {
+    $producto_id     = (int) $p['producto_id'];
+    $cantidad        = (int) $p['cantidad'];
+    $precio_unitario = (float) $p['precio_unitario'];
+
+    $detalle->bind_param('iiid', $venta_id, $producto_id, $cantidad, $precio_unitario);
+    if (!$detalle->execute()) {
+        $detalle->close();
+        error('Error al insertar detalle: ' . $detalle->error);
+    }
+}
+$detalle->close();
+
+success(['venta_id' => $venta_id]);
+


### PR DESCRIPTION
## Summary
- implement `crear_venta.php` to create sales and their details
- implement `cancelar_venta.php` to cancel a sale

## Testing
- `php -l api/ventas/crear_venta.php` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686053ce89a4832bb275dbda3f622241