### PR TITLE
Add ventas frontend

### DIFF
--- a/frontend/vistas/ventas/ventas.html
+++ b/frontend/vistas/ventas/ventas.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Ventas</title>
+</head>
+<body>
+    <h1>Registro de Venta</h1>
+    <form id="formVenta">
+        <label for="mesa_id">Mesa:</label>
+        <select id="mesa_id" name="mesa_id">
+            <option value="1">Mesa 1</option>
+            <option value="2">Mesa 2</option>
+            <option value="3">Mesa 3</option>
+        </select>
+        <label for="usuario_id">Usuario ID:</label>
+        <input type="number" id="usuario_id" name="usuario_id" required>
+        <h2>Productos</h2>
+        <table id="productos" border="1">
+            <thead>
+                <tr>
+                    <th>Producto ID</th>
+                    <th>Cantidad</th>
+                    <th>Precio Unitario</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><input type="number" class="producto_id"></td>
+                    <td><input type="number" class="cantidad"></td>
+                    <td><input type="number" step="0.01" class="precio_unitario"></td>
+                </tr>
+                <tr>
+                    <td><input type="number" class="producto_id"></td>
+                    <td><input type="number" class="cantidad"></td>
+                    <td><input type="number" step="0.01" class="precio_unitario"></td>
+                </tr>
+                <tr>
+                    <td><input type="number" class="producto_id"></td>
+                    <td><input type="number" class="cantidad"></td>
+                    <td><input type="number" step="0.01" class="precio_unitario"></td>
+                </tr>
+            </tbody>
+        </table>
+        <button type="button" id="registrarVenta">Registrar Venta</button>
+    </form>
+
+    <h2>Historial de Ventas</h2>
+    <table id="historial" border="1">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Fecha</th>
+                <th>Total</th>
+                <th>Estatus</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
+    <script src="ventas.js"></script>
+</body>
+</html>

--- a/frontend/vistas/ventas/ventas.js
+++ b/frontend/vistas/ventas/ventas.js
@@ -1,0 +1,68 @@
+async function cargarHistorial() {
+    try {
+        const resp = await fetch('../../../api/ventas/listar_ventas.php');
+        const data = await resp.json();
+        if (data.success) {
+            const tbody = document.querySelector('#historial tbody');
+            tbody.innerHTML = '';
+            data.resultado.forEach(v => {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${v.id}</td>
+                    <td>${v.fecha}</td>
+                    <td>${v.total}</td>
+                    <td>${v.estatus}</td>
+                `;
+                tbody.appendChild(row);
+            });
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar ventas');
+    }
+}
+
+async function registrarVenta() {
+    const mesa_id = parseInt(document.getElementById('mesa_id').value);
+    const usuario_id = parseInt(document.getElementById('usuario_id').value);
+    const filas = document.querySelectorAll('#productos tbody tr');
+    const productos = [];
+
+    filas.forEach(fila => {
+        const producto_id = parseInt(fila.querySelector('.producto_id').value);
+        const cantidad = parseInt(fila.querySelector('.cantidad').value);
+        const precio_unitario = parseFloat(fila.querySelector('.precio_unitario').value);
+        if (!isNaN(producto_id) && !isNaN(cantidad) && !isNaN(precio_unitario)) {
+            productos.push({ producto_id, cantidad, precio_unitario });
+        }
+    });
+
+    const payload = { mesa_id, usuario_id, productos };
+
+    try {
+        const resp = await fetch('../../../api/ventas/crear_venta.php', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
+        });
+        const data = await resp.json();
+        if (data.success) {
+            alert('Venta registrada');
+            await cargarHistorial();
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al registrar venta');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    cargarHistorial();
+    document.getElementById('registrarVenta').addEventListener('click', registrarVenta);
+});


### PR DESCRIPTION
## Summary
- add basic ventas HTML form with products and history table
- add JS to list and create ventas using fetch API

## Testing
- `node -e "require('fs').readFileSync('frontend/vistas/ventas/ventas.js');" && echo 'js ok'`
- `php -l frontend/vistas/ventas/ventas.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605680b164832bae33fdb1c9ae4148