### PR TITLE
Add cancel button and product lookup

### DIFF
--- a/api/inventario/listar_productos.php
+++ b/api/inventario/listar_productos.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$query = "SELECT id, nombre, precio FROM productos ORDER BY nombre";
+$result = $conn->query($query);
+
+if (!$result) {
+    error('Error al obtener productos: ' . $conn->error);
+}
+
+$productos = [];
+while ($row = $result->fetch_assoc()) {
+    $productos[] = $row;
+}
+
+success($productos);

--- a/frontend/vistas/ventas/ventas.html
+++ b/frontend/vistas/ventas/ventas.html
@@ -19,26 +19,32 @@
         <table id="productos" border="1">
             <thead>
                 <tr>
-                    <th>Producto ID</th>
+                    <th>Producto</th>
                     <th>Cantidad</th>
-                    <th>Precio Unitario</th>
+                    <th>Precio</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
-                    <td><input type="number" class="producto_id"></td>
+                    <td>
+                        <select class="producto"></select>
+                    </td>
                     <td><input type="number" class="cantidad"></td>
-                    <td><input type="number" step="0.01" class="precio_unitario"></td>
+                    <td><input type="number" step="0.01" class="precio" readonly></td>
                 </tr>
                 <tr>
-                    <td><input type="number" class="producto_id"></td>
+                    <td>
+                        <select class="producto"></select>
+                    </td>
                     <td><input type="number" class="cantidad"></td>
-                    <td><input type="number" step="0.01" class="precio_unitario"></td>
+                    <td><input type="number" step="0.01" class="precio" readonly></td>
                 </tr>
                 <tr>
-                    <td><input type="number" class="producto_id"></td>
+                    <td>
+                        <select class="producto"></select>
+                    </td>
                     <td><input type="number" class="cantidad"></td>
-                    <td><input type="number" step="0.01" class="precio_unitario"></td>
+                    <td><input type="number" step="0.01" class="precio" readonly></td>
                 </tr>
             </tbody>
         </table>
@@ -53,6 +59,7 @@
                 <th>Fecha</th>
                 <th>Total</th>
                 <th>Estatus</th>
+                <th>Acci&oacute;n</th>
             </tr>
         </thead>
         <tbody></tbody>

--- a/frontend/vistas/ventas/ventas.js
+++ b/frontend/vistas/ventas/ventas.js
@@ -7,13 +7,20 @@ async function cargarHistorial() {
             tbody.innerHTML = '';
             data.resultado.forEach(v => {
                 const row = document.createElement('tr');
+                const accion = v.estatus !== 'cancelada'
+                    ? `<button class="cancelar" data-id="${v.id}">Cancelar</button>`
+                    : '';
                 row.innerHTML = `
                     <td>${v.id}</td>
                     <td>${v.fecha}</td>
                     <td>${v.total}</td>
                     <td>${v.estatus}</td>
+                    <td>${accion}</td>
                 `;
                 tbody.appendChild(row);
+            });
+            tbody.querySelectorAll('button.cancelar').forEach(btn => {
+                btn.addEventListener('click', () => cancelarVenta(btn.dataset.id));
             });
         } else {
             alert(data.mensaje);
@@ -24,6 +31,54 @@ async function cargarHistorial() {
     }
 }
 
+let catalogo = [];
+
+async function cargarProductos() {
+    try {
+        const resp = await fetch('../../../api/inventario/listar_productos.php');
+        const data = await resp.json();
+        if (data.success) {
+            catalogo = data.resultado;
+            const selects = document.querySelectorAll('#productos select.producto');
+            selects.forEach(select => {
+                select.innerHTML = '<option value="">--Selecciona--</option>';
+                catalogo.forEach(p => {
+                    const opt = document.createElement('option');
+                    opt.value = p.id;
+                    opt.textContent = p.nombre;
+                    opt.dataset.precio = p.precio;
+                    select.appendChild(opt);
+                });
+                select.addEventListener('change', () => actualizarPrecio(select));
+            });
+            document.querySelectorAll('#productos .cantidad').forEach(inp => {
+                inp.addEventListener('input', () => {
+                    const select = inp.closest('tr').querySelector('.producto');
+                    actualizarPrecio(select);
+                });
+            });
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar productos');
+    }
+}
+
+function actualizarPrecio(select) {
+    const row = select.closest('tr');
+    const cantidad = parseFloat(row.querySelector('.cantidad').value) || 0;
+    const precioInput = row.querySelector('.precio');
+    const option = select.selectedOptions[0];
+    if (option && option.dataset.precio) {
+        const precioUnitario = parseFloat(option.dataset.precio);
+        precioInput.value = (precioUnitario * cantidad).toFixed(2);
+    } else {
+        precioInput.value = '';
+    }
+}
+
 async function registrarVenta() {
     const mesa_id = parseInt(document.getElementById('mesa_id').value);
     const usuario_id = parseInt(document.getElementById('usuario_id').value);
@@ -31,10 +86,11 @@ async function registrarVenta() {
     const productos = [];
 
     filas.forEach(fila => {
-        const producto_id = parseInt(fila.querySelector('.producto_id').value);
+        const producto_id = parseInt(fila.querySelector('.producto').value);
         const cantidad = parseInt(fila.querySelector('.cantidad').value);
-        const precio_unitario = parseFloat(fila.querySelector('.precio_unitario').value);
-        if (!isNaN(producto_id) && !isNaN(cantidad) && !isNaN(precio_unitario)) {
+        if (!isNaN(producto_id) && !isNaN(cantidad)) {
+            const prod = catalogo.find(p => p.id === producto_id);
+            const precio_unitario = prod ? parseFloat(prod.precio) : 0;
             productos.push({ producto_id, cantidad, precio_unitario });
         }
     });
@@ -62,7 +118,29 @@ async function registrarVenta() {
     }
 }
 
+async function cancelarVenta(id) {
+    if (!confirm('¿Seguro de cancelar la venta?')) return;
+    try {
+        const resp = await fetch('../../../api/ventas/cancelar_venta.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ venta_id: parseInt(id) })
+        });
+        const data = await resp.json();
+        if (data.success) {
+            alert('Venta cancelada');
+            await cargarHistorial();
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cancelar la venta');
+    }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+    cargarProductos();
     cargarHistorial();
     document.getElementById('registrarVenta').addEventListener('click', registrarVenta);
 });


### PR DESCRIPTION
## Summary
- list products with names and prices
- load product catalog in sales form and autofill price
- add cancel button to sales table
- implement sales cancellation via API

## Testing
- `php -l api/inventario/listar_productos.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68605ac4598c832ba3c1d2a2dcfe43f5