### PR TITLE
Add detail view for sales

### DIFF
--- a/api/usuarios/listar_meseros.php
+++ b/api/usuarios/listar_meseros.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$query = "SELECT id, nombre FROM usuarios WHERE rol = 'mesero' AND activo = 1 ORDER BY nombre";
+$result = $conn->query($query);
+
+if (!$result) {
+    error('Error al obtener meseros: ' . $conn->error);
+}
+
+$meseros = [];
+while ($row = $result->fetch_assoc()) {
+    $meseros[] = $row;
+}
+
+success($meseros);

--- a/api/ventas/detalle_venta.php
+++ b/api/ventas/detalle_venta.php
@@ -1,0 +1,45 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false, 'mensaje' => 'Método no permitido']);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['venta_id'])) {
+    echo json_encode(['success' => false, 'mensaje' => 'Datos inválidos']);
+    exit;
+}
+
+$venta_id = (int)$input['venta_id'];
+
+$stmt = $conn->prepare(
+    'SELECT p.nombre, vd.cantidad, vd.precio_unitario, ' .
+    '(vd.cantidad * vd.precio_unitario) AS subtotal ' .
+    'FROM venta_detalles vd ' .
+    'JOIN productos p ON vd.producto_id = p.id ' .
+    'WHERE vd.venta_id = ?'
+);
+if (!$stmt) {
+    echo json_encode(['success' => false, 'mensaje' => 'Error al preparar consulta']);
+    exit;
+}
+
+$stmt->bind_param('i', $venta_id);
+if (!$stmt->execute()) {
+    echo json_encode(['success' => false, 'mensaje' => 'Error al ejecutar consulta']);
+    $stmt->close();
+    exit;
+}
+
+$res = $stmt->get_result();
+$productos = [];
+while ($row = $res->fetch_assoc()) {
+    $productos[] = $row;
+}
+$stmt->close();
+
+echo json_encode(['success' => true, 'productos' => $productos]);

--- a/vistas/ventas/ventas.html
+++ b/vistas/ventas/ventas.html
@@ -13,8 +13,8 @@
             <option value="2">Mesa 2</option>
             <option value="3">Mesa 3</option>
         </select>
-        <label for="usuario_id">Usuario ID:</label>
-        <input type="number" id="usuario_id" name="usuario_id" required>
+        <label for="usuario_id">Mesero:</label>
+        <select id="usuario_id" name="usuario_id" required></select>
         <h2>Productos</h2>
         <table id="productos" border="1">
             <thead>
@@ -32,22 +32,9 @@
                     <td><input type="number" class="cantidad"></td>
                     <td><input type="number" step="0.01" class="precio" readonly></td>
                 </tr>
-                <tr>
-                    <td>
-                        <select class="producto"></select>
-                    </td>
-                    <td><input type="number" class="cantidad"></td>
-                    <td><input type="number" step="0.01" class="precio" readonly></td>
-                </tr>
-                <tr>
-                    <td>
-                        <select class="producto"></select>
-                    </td>
-                    <td><input type="number" class="cantidad"></td>
-                    <td><input type="number" step="0.01" class="precio" readonly></td>
-                </tr>
             </tbody>
         </table>
+        <button type="button" id="agregarProducto">Agregar Producto</button>
         <button type="button" id="registrarVenta">Registrar Venta</button>
     </form>
 
@@ -59,11 +46,14 @@
                 <th>Fecha</th>
                 <th>Total</th>
                 <th>Estatus</th>
+                <th>Ver detalles</th>
                 <th>Acci&oacute;n</th>
             </tr>
         </thead>
         <tbody></tbody>
     </table>
+
+    <div id="modal-detalles" style="display:none;"></div>
 
     <script src="ventas.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- create endpoint to list products of a sale
- list active waiters
- improve sales HTML to show waiter names, add detail view and product adding
- update JS to fetch waiter list, add products dynamically and load sale details

## Testing
- `php -l api/ventas/detalle_venta.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68607c72e3a8832b805b3207ac6c9f5a