### PR TITLE
Add ticket printing

### DIFF
--- a/vistas/ventas/ticket.html
+++ b/vistas/ventas/ticket.html
@@ -61,17 +61,13 @@
             document.getElementById('totalVenta').textContent = 'Total: $' + data.total;
         }
 
-        // Ejemplo de uso
-        const datos = {
-            venta_id: 123,
-            fecha: "2024-06-28 12:34",
-            productos: [
-                { nombre: "Taco al Pastor", cantidad: 2, precio_unitario: 45 },
-                { nombre: "Refresco", cantidad: 1, precio_unitario: 20 }
-            ],
-            total: 110
-        };
-        llenarTicket(datos);
+        document.addEventListener('DOMContentLoaded', () => {
+            const almacenado = localStorage.getItem('ticketData');
+            if (almacenado) {
+                const datos = JSON.parse(almacenado);
+                llenarTicket(datos);
+            }
+        });
     </script>
 </body>
 </html>

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -5,7 +5,9 @@ async function cargarHistorial() {
         if (data.success) {
             const tbody = document.querySelector('#historial tbody');
             tbody.innerHTML = '';
+            ventasData = {};
             data.resultado.forEach(v => {
+                ventasData[v.id] = v;
                 const row = document.createElement('tr');
                 const accion = v.estatus !== 'cancelada'
                     ? `<button class="cancelar" data-id="${v.id}">Cancelar</button>`
@@ -36,6 +38,7 @@ async function cargarHistorial() {
 }
 
 let catalogo = [];
+let ventasData = {};
 
 async function cargarMeseros() {
     try {
@@ -213,11 +216,23 @@ async function verDetalles(id) {
             data.productos.forEach(p => {
                 html += `<li>${p.nombre} - ${p.cantidad} x ${p.precio_unitario} = ${p.subtotal}</li>`;
             });
-            html += '</ul><button id="cerrarDetalle">Cerrar</button>';
+            html += '</ul><button id="imprimirTicket">Imprimir ticket</button> <button id="cerrarDetalle">Cerrar</button>';
             contenedor.innerHTML = html;
             contenedor.style.display = 'block';
             document.getElementById('cerrarDetalle').addEventListener('click', () => {
                 contenedor.style.display = 'none';
+            });
+            document.getElementById('imprimirTicket').addEventListener('click', () => {
+                const venta = ventasData[id] || {};
+                const total = venta.total || data.productos.reduce((s, p) => s + parseFloat(p.subtotal), 0);
+                const payload = {
+                    venta_id: id,
+                    fecha: venta.fecha || '',
+                    productos: data.productos,
+                    total
+                };
+                localStorage.setItem('ticketData', JSON.stringify(payload));
+                window.open('ticket.html', '_blank');
             });
         } else {
             alert(data.mensaje);


### PR DESCRIPTION
## Summary
- store sales info for reuse when rendering the history table
- add print button in detail view that sends data to `ticket.html`
- load ticket data from `localStorage` in `ticket.html`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860827e0090832ba9f6ade5f0f35044