### PR TITLE
Implementar gestión de mesas con ventas activas

### DIFF
--- a/api/mesas/detalle_venta.php
+++ b/api/mesas/detalle_venta.php
@@ -1,0 +1,64 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['venta_id'])) {
+    error('Datos inválidos');
+}
+
+$venta_id = (int)$input['venta_id'];
+
+// Obtener mesa y mesero de la venta
+$info = $conn->prepare(
+    'SELECT m.nombre AS mesa, u.nombre AS mesero
+     FROM ventas v
+     JOIN mesas m ON v.mesa_id = m.id
+     JOIN usuarios u ON v.usuario_id = u.id
+     WHERE v.id = ?'
+);
+if (!$info) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$info->bind_param('i', $venta_id);
+if (!$info->execute()) {
+    $info->close();
+    error('Error al ejecutar consulta: ' . $info->error);
+}
+$datosVenta = $info->get_result()->fetch_assoc();
+$info->close();
+
+// Obtener productos con estatus de preparación
+$stmt = $conn->prepare(
+    'SELECT p.nombre, vd.cantidad, vd.precio_unitario,
+            (vd.cantidad * vd.precio_unitario) AS subtotal,
+            vd.estatus_preparacion
+     FROM venta_detalles vd
+     JOIN productos p ON vd.producto_id = p.id
+     WHERE vd.venta_id = ?'
+);
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('i', $venta_id);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al ejecutar consulta: ' . $stmt->error);
+}
+$res = $stmt->get_result();
+$productos = [];
+while ($row = $res->fetch_assoc()) {
+    $productos[] = $row;
+}
+$stmt->close();
+
+success([
+    'mesa'      => $datosVenta['mesa'] ?? '',
+    'mesero'    => $datosVenta['mesero'] ?? '',
+    'productos' => $productos
+]);
+?>

--- a/api/mesas/dividir_mesa.php
+++ b/api/mesas/dividir_mesa.php
@@ -1,0 +1,37 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['mesa_id'])) {
+    error('Datos inválidos');
+}
+
+$mesa_id = (int)$input['mesa_id'];
+
+// Liberar la mesa indicada
+$stmt = $conn->prepare('UPDATE mesas SET mesa_principal_id = NULL WHERE id = ?');
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('i', $mesa_id);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al dividir mesa: ' . $stmt->error);
+}
+$stmt->close();
+
+// Si la mesa era principal, liberar a todas las unidas a ella
+$extra = $conn->prepare('UPDATE mesas SET mesa_principal_id = NULL WHERE mesa_principal_id = ?');
+if ($extra) {
+    $extra->bind_param('i', $mesa_id);
+    $extra->execute();
+    $extra->close();
+}
+
+success(true);
+?>

--- a/api/mesas/listar_mesas.php
+++ b/api/mesas/listar_mesas.php
@@ -2,16 +2,29 @@
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
-$query = "SELECT id, nombre, estado, capacidad FROM mesas ORDER BY id ASC";
+// Obtener mesas y, en su caso, la venta activa asociada
+$query = "SELECT m.id, m.nombre, m.estado, m.capacidad, m.mesa_principal_id, v.id AS venta_id
+          FROM mesas m
+          LEFT JOIN ventas v ON v.mesa_id = m.id AND v.estatus = 'activa'
+          ORDER BY m.id ASC";
 $result = $conn->query($query);
 
 if (!$result) {
     error('Error al obtener mesas: ' . $conn->error);
 }
 
+
 $mesas = [];
 while ($row = $result->fetch_assoc()) {
-    $mesas[] = $row;
+    $mesas[] = [
+        'id'                => (int)$row['id'],
+        'nombre'            => $row['nombre'],
+        'estado'            => $row['estado'],
+        'capacidad'         => (int)$row['capacidad'],
+        'mesa_principal_id' => $row['mesa_principal_id'] ? (int)$row['mesa_principal_id'] : null,
+        'venta_activa'      => $row['venta_id'] !== null,
+        'venta_id'          => $row['venta_id'] !== null ? (int)$row['venta_id'] : null
+    ];
 }
 
 success($mesas);

--- a/api/mesas/unir_mesas.php
+++ b/api/mesas/unir_mesas.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['principal_id']) || !isset($input['mesas']) || !is_array($input['mesas'])) {
+    error('Datos inválidos');
+}
+
+$principal_id = (int)$input['principal_id'];
+$mesas = array_filter(array_map('intval', $input['mesas']));
+if (empty($mesas)) {
+    error('No hay mesas para unir');
+}
+
+$stmt = $conn->prepare('UPDATE mesas SET mesa_principal_id = ? WHERE id = ?');
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+
+foreach ($mesas as $mesa_id) {
+    $stmt->bind_param('ii', $principal_id, $mesa_id);
+    if (!$stmt->execute()) {
+        $stmt->close();
+        error('Error al unir mesa: ' . $stmt->error);
+    }
+}
+$stmt->close();
+
+success(true);
+?>

--- a/vistas/mesas/mesas.html
+++ b/vistas/mesas/mesas.html
@@ -6,6 +6,9 @@
 </head>
 <body>
     <h1>Mesas</h1>
+    <div>
+        <button id="btn-unir">Unir mesas</button>
+    </div>
     <div id="tablero"></div>
     <script src="mesas.js"></script>
 </body>

--- a/vistas/mesas/mesas.js
+++ b/vistas/mesas/mesas.js
@@ -5,18 +5,50 @@ async function cargarMesas() {
         const tablero = document.getElementById('tablero');
         if (data.success) {
             tablero.innerHTML = '';
+            // Calcular mesas unidas
+            const uniones = {};
+            data.resultado.forEach(m => {
+                if (m.mesa_principal_id) {
+                    if (!uniones[m.mesa_principal_id]) uniones[m.mesa_principal_id] = [];
+                    uniones[m.mesa_principal_id].push(m.id);
+                }
+            });
+
             data.resultado.forEach(m => {
                 const card = document.createElement('div');
                 card.className = 'mesa';
+
+                const unidas = uniones[m.id] || [];
+                let unionTxt = '';
+                if (m.mesa_principal_id) {
+                    unionTxt = `Unida a ${m.mesa_principal_id}`;
+                } else if (unidas.length) {
+                    unionTxt = `Principal de: ${unidas.join(', ')}`;
+                }
+
+                const ventaTxt = m.venta_activa ? `Venta activa: ${m.venta_id}` : 'Sin venta';
+
                 card.innerHTML = `
+                    <input type="checkbox" class="seleccionar" data-id="${m.id}">
                     <h3>${m.nombre}</h3>
                     <p>Estado: ${m.estado}</p>
-                    <button data-id="${m.id}">Cambiar estado</button>
+                    <p>${ventaTxt}</p>
+                    <p>${unionTxt}</p>
+                    <button class="detalles" data-venta="${m.venta_id}" style="display:${m.venta_activa ? 'inline' : 'none'}">Detalles</button>
+                    <button class="dividir" data-id="${m.id}">Dividir</button>
+                    <button class="cambiar" data-id="${m.id}">Cambiar estado</button>
                 `;
                 tablero.appendChild(card);
             });
-            tablero.querySelectorAll('button').forEach(btn => {
+
+            tablero.querySelectorAll('button.cambiar').forEach(btn => {
                 btn.addEventListener('click', () => mostrarMenu(btn.dataset.id));
+            });
+            tablero.querySelectorAll('button.dividir').forEach(btn => {
+                btn.addEventListener('click', () => dividirMesa(btn.dataset.id));
+            });
+            tablero.querySelectorAll('button.detalles').forEach(btn => {
+                btn.addEventListener('click', () => verVenta(btn.dataset.venta));
             });
         } else {
             alert(data.mensaje);
@@ -54,3 +86,77 @@ async function cambiarEstado(id, estado) {
 }
 
 document.addEventListener('DOMContentLoaded', cargarMesas);
+
+async function dividirMesa(id) {
+    try {
+        const resp = await fetch('../../api/mesas/dividir_mesa.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ mesa_id: parseInt(id) })
+        });
+        const data = await resp.json();
+        if (data.success) {
+            await cargarMesas();
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al dividir mesa');
+    }
+}
+
+async function unirSeleccionadas() {
+    const seleccionadas = Array.from(document.querySelectorAll('.seleccionar:checked')).map(c => parseInt(c.dataset.id));
+    if (seleccionadas.length < 2) {
+        alert('Selecciona al menos dos mesas');
+        return;
+    }
+    const principal = parseInt(prompt('ID de mesa principal', seleccionadas[0]));
+    const otras = seleccionadas.filter(id => id !== principal);
+    if (otras.length === 0) {
+        alert('Debes seleccionar mesas adicionales aparte de la principal');
+        return;
+    }
+    try {
+        const resp = await fetch('../../api/mesas/unir_mesas.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ principal_id: principal, mesas: otras })
+        });
+        const data = await resp.json();
+        if (data.success) {
+            await cargarMesas();
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al unir mesas');
+    }
+}
+
+async function verVenta(id) {
+    try {
+        const resp = await fetch('../../api/mesas/detalle_venta.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ venta_id: parseInt(id) })
+        });
+        const data = await resp.json();
+        if (data.success) {
+            let msg = `Mesa: ${data.resultado.mesa}\nMesero: ${data.resultado.mesero}\n`;
+            data.resultado.productos.forEach(p => {
+                msg += `\n${p.nombre} - ${p.cantidad} x ${p.precio_unitario} (${p.estatus_preparacion})`;
+            });
+            alert(msg);
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al obtener detalles');
+    }
+}
+
+document.getElementById('btn-unir').addEventListener('click', unirSeleccionadas);


### PR DESCRIPTION
## Resumen
- mostrar venta activa y mesas unidas al listar mesas
- API para ver detalles de venta con estatus de preparación
- API para unir y dividir mesas
- frontend de mesas para unificar/dividir mesas y ver detalles de venta

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686086262008832b8cbcc89d5c8f57ef