### PR TITLE
Add interactive mesa detail modal

### DIFF
--- a/api/mesas/agregar_producto_venta.php
+++ b/api/mesas/agregar_producto_venta.php
@@ -1,0 +1,47 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset(
+        $input['venta_id'],
+        $input['producto_id'],
+        $input['cantidad'],
+        $input['precio_unitario']
+    )) {
+    error('Datos inválidos');
+}
+
+$venta_id       = (int) $input['venta_id'];
+$producto_id    = (int) $input['producto_id'];
+$cantidad       = (int) $input['cantidad'];
+$precio_unitario = (float) $input['precio_unitario'];
+$total          = $cantidad * $precio_unitario;
+
+$stmt = $conn->prepare(
+    'INSERT INTO venta_detalles (venta_id, producto_id, cantidad, precio_unitario)
+     VALUES (?, ?, ?, ?)'
+);
+if (!$stmt) {
+    error('Error al preparar inserción: ' . $conn->error);
+}
+$stmt->bind_param('iiid', $venta_id, $producto_id, $cantidad, $precio_unitario);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al agregar producto: ' . $stmt->error);
+}
+$stmt->close();
+
+$up = $conn->prepare('UPDATE ventas SET total = total + ? WHERE id = ?');
+if ($up) {
+    $up->bind_param('di', $total, $venta_id);
+    $up->execute();
+    $up->close();
+}
+
+success(true);
+?>

--- a/api/mesas/detalle_venta.php
+++ b/api/mesas/detalle_venta.php
@@ -34,7 +34,7 @@ $info->close();
 
 // Obtener productos con estatus de preparación
 $stmt = $conn->prepare(
-    'SELECT p.nombre, vd.cantidad, vd.precio_unitario,
+    'SELECT vd.id, p.nombre, vd.cantidad, vd.precio_unitario,
             (vd.cantidad * vd.precio_unitario) AS subtotal,
             vd.estatus_preparacion
      FROM venta_detalles vd

--- a/api/mesas/eliminar_producto_venta.php
+++ b/api/mesas/eliminar_producto_venta.php
@@ -1,0 +1,56 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['detalle_id'])) {
+    error('Datos inválidos');
+}
+
+$detalle_id = (int) $input['detalle_id'];
+
+$info = $conn->prepare('SELECT venta_id, cantidad, precio_unitario, estatus_preparacion FROM venta_detalles WHERE id = ?');
+if (!$info) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$info->bind_param('i', $detalle_id);
+if (!$info->execute()) {
+    $info->close();
+    error('Error al ejecutar consulta: ' . $info->error);
+}
+$detalle = $info->get_result()->fetch_assoc();
+$info->close();
+
+if (!$detalle) {
+    error('Detalle no encontrado');
+}
+
+if (in_array($detalle['estatus_preparacion'], ['en preparación', 'entregado'])) {
+    error('No se puede eliminar el producto');
+}
+
+$del = $conn->prepare('DELETE FROM venta_detalles WHERE id = ?');
+if (!$del) {
+    error('Error al preparar eliminación: ' . $conn->error);
+}
+$del->bind_param('i', $detalle_id);
+if (!$del->execute()) {
+    $del->close();
+    error('Error al eliminar producto: ' . $del->error);
+}
+$del->close();
+
+$totalRestar = $detalle['cantidad'] * $detalle['precio_unitario'];
+$up = $conn->prepare('UPDATE ventas SET total = total - ? WHERE id = ?');
+if ($up) {
+    $up->bind_param('di', $totalRestar, $detalle['venta_id']);
+    $up->execute();
+    $up->close();
+}
+
+success(true);
+?>

--- a/api/mesas/marcar_entregado.php
+++ b/api/mesas/marcar_entregado.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['detalle_id'])) {
+    error('Datos inválidos');
+}
+
+$detalle_id = (int) $input['detalle_id'];
+
+$stmt = $conn->prepare("UPDATE venta_detalles SET estatus_preparacion = 'entregado' WHERE id = ?");
+if (!$stmt) {
+    error('Error al preparar actualización: ' . $conn->error);
+}
+$stmt->bind_param('i', $detalle_id);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al marcar entregado: ' . $stmt->error);
+}
+$stmt->close();
+
+success(true);
+?>

--- a/vistas/mesas/mesas.html
+++ b/vistas/mesas/mesas.html
@@ -10,6 +10,7 @@
         <button id="btn-unir">Unir mesas</button>
     </div>
     <div id="tablero"></div>
+    <div id="modal-detalle" style="display:none;"></div>
     <script src="mesas.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add modal markup for active sale details
- implement full client logic in `mesas.js`
- provide endpoints to manage sale details
- extend sale detail query to return row ids

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686088416064832bb1386c1fa2dcf07d