### PR TITLE
Add cocina module

### DIFF
--- a/api/cocina/cambiar_estado_producto.php
+++ b/api/cocina/cambiar_estado_producto.php
@@ -1,0 +1,60 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['detalle_id'], $input['nuevo_estado'])) {
+    error('Datos inválidos');
+}
+
+$detalle_id = (int)$input['detalle_id'];
+$nuevo_estado = $input['nuevo_estado'];
+$permitidos = ['pendiente', 'en preparación', 'listo', 'entregado'];
+if (!in_array($nuevo_estado, $permitidos, true)) {
+    error('Estado no válido');
+}
+
+$stmt = $conn->prepare('SELECT estatus_preparacion FROM venta_detalles WHERE id = ?');
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('i', $detalle_id);
+$stmt->execute();
+$result = $stmt->get_result();
+if (!$result || $result->num_rows === 0) {
+    $stmt->close();
+    error('Detalle no encontrado');
+}
+$actual = $result->fetch_assoc()['estatus_preparacion'];
+$stmt->close();
+
+if (in_array($actual, ['listo', 'entregado'], true)) {
+    error('No se puede modificar este producto');
+}
+
+$transiciones = [
+    'pendiente'      => 'en preparación',
+    'en preparación' => 'listo'
+];
+
+if (!isset($transiciones[$actual]) || $transiciones[$actual] !== $nuevo_estado) {
+    error('Transición no permitida');
+}
+
+$upd = $conn->prepare('UPDATE venta_detalles SET estatus_preparacion = ? WHERE id = ?');
+if (!$upd) {
+    error('Error al preparar actualización: ' . $conn->error);
+}
+$upd->bind_param('si', $nuevo_estado, $detalle_id);
+if (!$upd->execute()) {
+    $upd->close();
+    error('Error al actualizar: ' . $upd->error);
+}
+$upd->close();
+
+success(true);
+?>

--- a/api/cocina/listar_pendientes.php
+++ b/api/cocina/listar_pendientes.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$query = "SELECT m.nombre AS mesa, p.nombre AS producto, d.cantidad, d.created_at AS hora, d.estatus_preparacion, d.id AS detalle_id
+          FROM venta_detalles d
+          JOIN ventas v ON v.id = d.venta_id
+          JOIN mesas m ON m.id = v.mesa_id
+          JOIN productos p ON p.id = d.producto_id
+          WHERE d.estatus_preparacion IN ('pendiente','en preparación')
+          ORDER BY m.nombre, d.created_at";
+$result = $conn->query($query);
+if (!$result) {
+    error('Error al obtener productos: ' . $conn->error);
+}
+$pendientes = [];
+while ($row = $result->fetch_assoc()) {
+    $pendientes[] = [
+        'mesa'       => $row['mesa'],
+        'producto'   => $row['producto'],
+        'cantidad'   => (int) $row['cantidad'],
+        'hora'       => $row['hora'],
+        'estatus'    => $row['estatus_preparacion'],
+        'detalle_id' => (int) $row['detalle_id']
+    ];
+}
+
+success($pendientes);
+?>

--- a/vistas/cocina/cocina.html
+++ b/vistas/cocina/cocina.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Cocina</title>
+    <link rel="stylesheet" href="../css/estilos.css">
+</head>
+<body>
+    <h1>Modulo de Cocina</h1>
+    <table id="tabla-pendientes" border="1">
+        <thead>
+            <tr>
+                <th>Mesa</th>
+                <th>Producto</th>
+                <th>Cantidad</th>
+                <th>Hora</th>
+                <th>Estado</th>
+                <th>Acciones</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <script src="cocina.js"></script>
+</body>
+</html>

--- a/vistas/cocina/cocina.js
+++ b/vistas/cocina/cocina.js
@@ -1,0 +1,59 @@
+async function cargarPendientes() {
+    try {
+        const resp = await fetch('../../api/cocina/listar_pendientes.php');
+        const data = await resp.json();
+        if (data.success) {
+            const tbody = document.querySelector('#tabla-pendientes tbody');
+            tbody.innerHTML = '';
+            data.resultado.forEach(p => {
+                const tr = document.createElement('tr');
+                const inicioVisible = p.estatus === 'pendiente';
+                const listoVisible = p.estatus === 'en preparación';
+                tr.innerHTML = `
+                    <td>${p.mesa}</td>
+                    <td>${p.producto}</td>
+                    <td>${p.cantidad}</td>
+                    <td>${p.hora}</td>
+                    <td><span class="${p.estatus.replace(/\s/g,'-')}">${p.estatus}</span></td>
+                    <td>
+                        ${inicioVisible ? `<button class="iniciar" data-id="${p.detalle_id}">Iniciar</button>` : ''}
+                        ${listoVisible ? `<button class="listo" data-id="${p.detalle_id}">Listo</button>` : ''}
+                    </td>
+                `;
+                tbody.appendChild(tr);
+            });
+            tbody.querySelectorAll('button.iniciar').forEach(btn => {
+                btn.addEventListener('click', () => cambiarEstado(btn.dataset.id, 'en preparación'));
+            });
+            tbody.querySelectorAll('button.listo').forEach(btn => {
+                btn.addEventListener('click', () => cambiarEstado(btn.dataset.id, 'listo'));
+            });
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar');
+    }
+}
+
+async function cambiarEstado(detalleId, nuevo) {
+    try {
+        const resp = await fetch('../../api/cocina/cambiar_estado_producto.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ detalle_id: parseInt(detalleId), nuevo_estado: nuevo })
+        });
+        const data = await resp.json();
+        if (data.success) {
+            cargarPendientes();
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al actualizar');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', cargarPendientes);


### PR DESCRIPTION
## Summary
- add frontend HTML and JS for the cocina view
- add API endpoints for listing pending items and updating preparation status

## Testing
- `php -l api/cocina/listar_pendientes.php` *(fails: php not installed)*
- `php -l api/cocina/cambiar_estado_producto.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68608b3b4560832bbac19fbd34109a70