### PR TITLE
Implement inventory backend and frontend

### DIFF
--- a/api/inventario/actualizar_existencia.php
+++ b/api/inventario/actualizar_existencia.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['producto_id'], $input['nueva_existencia'])) {
+    error('Datos inválidos');
+}
+
+$producto_id     = (int)$input['producto_id'];
+$nueva_existencia = (int)$input['nueva_existencia'];
+
+$stmt = $conn->prepare('UPDATE productos SET existencia = ? WHERE id = ?');
+if (!$stmt) {
+    error('Error al preparar actualización: ' . $conn->error);
+}
+$stmt->bind_param('ii', $nueva_existencia, $producto_id);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al actualizar existencia: ' . $stmt->error);
+}
+$stmt->close();
+
+success(true);
+

--- a/api/inventario/agregar_producto.php
+++ b/api/inventario/agregar_producto.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    error('JSON inválido');
+}
+
+$nombre      = isset($input['nombre']) ? trim($input['nombre']) : '';
+$precio      = isset($input['precio']) ? (float)$input['precio'] : null;
+$descripcion = isset($input['descripcion']) ? trim($input['descripcion']) : '';
+$existencia  = isset($input['existencia']) ? (int)$input['existencia'] : 0;
+
+if ($nombre === '' || $precio === null) {
+    error('Datos incompletos');
+}
+
+$stmt = $conn->prepare('INSERT INTO productos (nombre, precio, descripcion, existencia, activo) VALUES (?, ?, ?, ?, 1)');
+if (!$stmt) {
+    error('Error al preparar inserción: ' . $conn->error);
+}
+$stmt->bind_param('sdsi', $nombre, $precio, $descripcion, $existencia);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al agregar producto: ' . $stmt->error);
+}
+$stmt->close();
+
+success(['mensaje' => 'Producto agregado']);
+

--- a/api/inventario/listar_productos.php
+++ b/api/inventario/listar_productos.php
@@ -2,7 +2,7 @@
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
-$query = "SELECT id, nombre, precio FROM productos ORDER BY nombre";
+$query = "SELECT id, nombre, precio, existencia, descripcion, activo FROM productos ORDER BY nombre ASC";
 $result = $conn->query($query);
 
 if (!$result) {
@@ -15,3 +15,4 @@ while ($row = $result->fetch_assoc()) {
 }
 
 success($productos);
+

--- a/vistas/inventario/inventario.html
+++ b/vistas/inventario/inventario.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Inventario</title>
+</head>
+<body>
+    <h1>Inventario</h1>
+    <button id="agregarProducto">Agregar producto</button>
+    <table id="tablaProductos" border="1">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Nombre</th>
+                <th>Precio</th>
+                <th>Existencia</th>
+                <th>Descripción</th>
+                <th>Activo</th>
+                <th>Acciones</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <script src="inventario.js"></script>
+</body>
+</html>

--- a/vistas/inventario/inventario.js
+++ b/vistas/inventario/inventario.js
@@ -1,0 +1,84 @@
+async function cargarProductos() {
+    try {
+        const resp = await fetch('../../api/inventario/listar_productos.php');
+        const data = await resp.json();
+        if (data.success) {
+            const tbody = document.querySelector('#tablaProductos tbody');
+            tbody.innerHTML = '';
+            data.resultado.forEach(p => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${p.id}</td>
+                    <td>${p.nombre}</td>
+                    <td>${p.precio}</td>
+                    <td><input type="number" class="existencia" data-id="${p.id}" value="${p.existencia}"></td>
+                    <td>${p.descripcion || ''}</td>
+                    <td>${p.activo == 1 ? 'Sí' : 'No'}</td>
+                    <td><button class="actualizar" data-id="${p.id}">Editar existencia</button></td>
+                `;
+                tbody.appendChild(tr);
+            });
+            tbody.querySelectorAll('button.actualizar').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const input = btn.closest('tr').querySelector('.existencia');
+                    actualizarExistencia(btn.dataset.id, input.value);
+                });
+            });
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar inventario');
+    }
+}
+
+async function actualizarExistencia(id, valor) {
+    try {
+        const resp = await fetch('../../api/inventario/actualizar_existencia.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ producto_id: parseInt(id), nueva_existencia: parseInt(valor) })
+        });
+        const data = await resp.json();
+        if (!data.success) {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al actualizar');
+    }
+}
+
+async function agregarProducto() {
+    const nombre = prompt('Nombre del producto:');
+    if (!nombre) return;
+    const precio = parseFloat(prompt('Precio:', '0')) || 0;
+    const descripcion = prompt('Descripción:', '');
+    const existencia = parseInt(prompt('Existencia:', '0')) || 0;
+
+    const payload = { nombre, precio, descripcion, existencia };
+    try {
+        const resp = await fetch('../../api/inventario/agregar_producto.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+        const data = await resp.json();
+        if (data.success) {
+            alert(data.resultado ? data.resultado.mensaje : 'Producto agregado');
+            cargarProductos();
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al agregar producto');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    cargarProductos();
+    document.getElementById('agregarProducto').addEventListener('click', agregarProducto);
+});
+


### PR DESCRIPTION
## Summary
- expose full product details via `listar_productos.php`
- add endpoint `agregar_producto.php`
- implement API to update stock
- create inventory view with buttons and table
- build JS logic to fetch and modify inventory

## Testing
- `php -l api/inventario/agregar_producto.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608c5d7cf0832bbdc351378c961471