### PR TITLE
Implementar módulo de Insumos

### DIFF
--- a/api/insumos/agregar_proveedor.php
+++ b/api/insumos/agregar_proveedor.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    error('JSON inválido');
+}
+
+$nombre = isset($input['nombre']) ? trim($input['nombre']) : '';
+$telefono = isset($input['telefono']) ? trim($input['telefono']) : '';
+$direccion = isset($input['direccion']) ? trim($input['direccion']) : '';
+
+if ($nombre === '') {
+    error('Nombre requerido');
+}
+
+$stmt = $conn->prepare('INSERT INTO proveedores (nombre, telefono, direccion) VALUES (?, ?, ?)');
+if (!$stmt) {
+    error('Error al preparar inserción: ' . $conn->error);
+}
+$stmt->bind_param('sss', $nombre, $telefono, $direccion);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al agregar proveedor: ' . $stmt->error);
+}
+$stmt->close();
+
+success(['mensaje' => 'Proveedor agregado']);

--- a/api/insumos/crear_entrada.php
+++ b/api/insumos/crear_entrada.php
@@ -1,0 +1,76 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    error('JSON inválido');
+}
+
+$proveedor_id = isset($input['proveedor_id']) ? (int)$input['proveedor_id'] : 0;
+$productos = isset($input['productos']) && is_array($input['productos']) ? $input['productos'] : null;
+
+if (!$proveedor_id || !$productos) {
+    error('Datos incompletos');
+}
+
+$total = 0;
+foreach ($productos as $p) {
+    if (!isset($p['producto_id'], $p['cantidad'], $p['precio_unitario'])) {
+        error('Formato de producto incorrecto');
+    }
+    $total += $p['cantidad'] * $p['precio_unitario'];
+}
+
+$conn->begin_transaction();
+
+$stmtEntrada = $conn->prepare('INSERT INTO entradas_insumo (proveedor_id, total) VALUES (?, ?)');
+if (!$stmtEntrada) {
+    $conn->rollback();
+    error('Error al preparar entrada: ' . $conn->error);
+}
+$stmtEntrada->bind_param('id', $proveedor_id, $total);
+if (!$stmtEntrada->execute()) {
+    $stmtEntrada->close();
+    $conn->rollback();
+    error('Error al registrar entrada: ' . $stmtEntrada->error);
+}
+$entrada_id = $stmtEntrada->insert_id;
+$stmtEntrada->close();
+
+$det = $conn->prepare('INSERT INTO entradas_detalle (entrada_id, producto_id, cantidad, precio_unitario) VALUES (?, ?, ?, ?)');
+$upd = $conn->prepare('UPDATE productos SET existencia = existencia + ? WHERE id = ?');
+if (!$det || !$upd) {
+    $conn->rollback();
+    error('Error al preparar detalles: ' . $conn->error);
+}
+
+foreach ($productos as $p) {
+    $producto_id = (int)$p['producto_id'];
+    $cantidad = (int)$p['cantidad'];
+    $precio = (float)$p['precio_unitario'];
+    $det->bind_param('iiid', $entrada_id, $producto_id, $cantidad, $precio);
+    if (!$det->execute()) {
+        $conn->rollback();
+        $det->close();
+        $upd->close();
+        error('Error al insertar detalle: ' . $det->error);
+    }
+    $upd->bind_param('ii', $cantidad, $producto_id);
+    if (!$upd->execute()) {
+        $conn->rollback();
+        $det->close();
+        $upd->close();
+        error('Error al actualizar existencia: ' . $upd->error);
+    }
+}
+$det->close();
+$upd->close();
+
+$conn->commit();
+
+success(['mensaje' => 'Entrada registrada']);

--- a/api/insumos/listar_entradas.php
+++ b/api/insumos/listar_entradas.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$query = "SELECT e.id, p.nombre AS proveedor, e.fecha, e.total FROM entradas_insumo e JOIN proveedores p ON e.proveedor_id = p.id ORDER BY e.fecha DESC";
+$result = $conn->query($query);
+
+if (!$result) {
+    error('Error al obtener entradas: ' . $conn->error);
+}
+
+$entradas = [];
+while ($row = $result->fetch_assoc()) {
+    $entradas[] = $row;
+}
+
+success($entradas);

--- a/api/insumos/listar_proveedores.php
+++ b/api/insumos/listar_proveedores.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$query = "SELECT id, nombre, telefono, direccion FROM proveedores ORDER BY nombre";
+$result = $conn->query($query);
+
+if (!$result) {
+    error('Error al obtener proveedores: ' . $conn->error);
+}
+
+$proveedores = [];
+while ($row = $result->fetch_assoc()) {
+    $proveedores[] = $row;
+}
+
+success($proveedores);

--- a/utils/bd.sql
+++ b/utils/bd.sql
@@ -86,6 +86,32 @@ CREATE TABLE recetas (
   FOREIGN KEY (insumo_id) REFERENCES insumos(id)
 );
 
+CREATE TABLE proveedores (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  nombre VARCHAR(100),
+  telefono VARCHAR(20),
+  direccion TEXT
+);
+
+CREATE TABLE entradas_insumo (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  proveedor_id INT,
+  fecha DATETIME DEFAULT CURRENT_TIMESTAMP,
+  total DECIMAL(10,2),
+  FOREIGN KEY (proveedor_id) REFERENCES proveedores(id)
+);
+
+CREATE TABLE entradas_detalle (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  entrada_id INT,
+  producto_id INT,
+  cantidad INT,
+  precio_unitario DECIMAL(10,2),
+  subtotal DECIMAL(10,2) GENERATED ALWAYS AS (cantidad * precio_unitario) STORED,
+  FOREIGN KEY (entrada_id) REFERENCES entradas_insumo(id),
+  FOREIGN KEY (producto_id) REFERENCES productos(id)
+);
+
 
 --inserts de prueba 
 INSERT INTO usuarios (nombre, usuario, contrasena, rol) VALUES

--- a/vistas/insumos/insumos.html
+++ b/vistas/insumos/insumos.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Insumos</title>
+</head>
+<body>
+    <h1>Entradas de Insumos</h1>
+    <form id="formEntrada">
+        <label for="proveedor">Proveedor:</label>
+        <select id="proveedor" name="proveedor"></select>
+        <button type="button" id="btnNuevoProveedor">Nuevo proveedor</button>
+        <h2>Productos</h2>
+        <table id="tablaProductos" border="1">
+            <thead>
+                <tr>
+                    <th>Producto</th>
+                    <th>Cantidad</th>
+                    <th>Precio unitario</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><select class="producto"></select></td>
+                    <td><input type="number" class="cantidad"></td>
+                    <td><input type="number" class="precio"></td>
+                </tr>
+            </tbody>
+        </table>
+        <button type="button" id="agregarFila">Agregar producto</button>
+        <button type="button" id="registrarEntrada">Registrar entrada</button>
+    </form>
+
+    <h2>Historial de Entradas</h2>
+    <table id="historial" border="1">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Proveedor</th>
+                <th>Fecha</th>
+                <th>Total</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
+    <script src="insumos.js"></script>
+</body>
+</html>

--- a/vistas/insumos/insumos.js
+++ b/vistas/insumos/insumos.js
@@ -1,0 +1,155 @@
+let catalogo = [];
+
+async function cargarProveedores() {
+    try {
+        const resp = await fetch('../../api/insumos/listar_proveedores.php');
+        const data = await resp.json();
+        if (data.success) {
+            const select = document.getElementById('proveedor');
+            select.innerHTML = '<option value="">--Selecciona--</option>';
+            data.resultado.forEach(p => {
+                const opt = document.createElement('option');
+                opt.value = p.id;
+                opt.textContent = p.nombre;
+                select.appendChild(opt);
+            });
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar proveedores');
+    }
+}
+
+async function cargarProductos() {
+    try {
+        const resp = await fetch('../../api/inventario/listar_productos.php');
+        const data = await resp.json();
+        if (data.success) {
+            catalogo = data.resultado;
+            actualizarSelectsProducto();
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar productos');
+    }
+}
+
+function actualizarSelectsProducto() {
+    document.querySelectorAll('select.producto').forEach(sel => {
+        sel.innerHTML = '<option value="">--Selecciona--</option>';
+        catalogo.forEach(p => {
+            const opt = document.createElement('option');
+            opt.value = p.id;
+            opt.textContent = p.nombre;
+            sel.appendChild(opt);
+        });
+    });
+}
+
+function agregarFila() {
+    const tbody = document.querySelector('#tablaProductos tbody');
+    const base = tbody.querySelector('tr');
+    const nueva = base.cloneNode(true);
+    nueva.querySelectorAll('input').forEach(i => i.value = '');
+    tbody.appendChild(nueva);
+    actualizarSelectsProducto();
+}
+
+async function nuevoProveedor() {
+    const nombre = prompt('Nombre del proveedor:');
+    if (!nombre) return;
+    const telefono = prompt('Teléfono:') || '';
+    const direccion = prompt('Dirección:') || '';
+    try {
+        const resp = await fetch('../../api/insumos/agregar_proveedor.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ nombre, telefono, direccion })
+        });
+        const data = await resp.json();
+        if (data.success) {
+            alert('Proveedor agregado');
+            cargarProveedores();
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al agregar proveedor');
+    }
+}
+
+async function registrarEntrada() {
+    const proveedor_id = parseInt(document.getElementById('proveedor').value);
+    if (isNaN(proveedor_id)) {
+        alert('Selecciona un proveedor');
+        return;
+    }
+    const filas = document.querySelectorAll('#tablaProductos tbody tr');
+    const productos = [];
+    filas.forEach(f => {
+        const producto_id = parseInt(f.querySelector('.producto').value);
+        const cantidad = parseInt(f.querySelector('.cantidad').value);
+        const precio_unitario = parseFloat(f.querySelector('.precio').value) || 0;
+        if (!isNaN(producto_id) && !isNaN(cantidad)) {
+            productos.push({ producto_id, cantidad, precio_unitario });
+        }
+    });
+    const payload = { proveedor_id, productos };
+    try {
+        const resp = await fetch('../../api/insumos/crear_entrada.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+        const data = await resp.json();
+        if (data.success) {
+            alert('Entrada registrada');
+            cargarHistorial();
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al registrar entrada');
+    }
+}
+
+async function cargarHistorial() {
+    try {
+        const resp = await fetch('../../api/insumos/listar_entradas.php');
+        const data = await resp.json();
+        if (data.success) {
+            const tbody = document.querySelector('#historial tbody');
+            tbody.innerHTML = '';
+            data.resultado.forEach(e => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${e.id}</td>
+                    <td>${e.proveedor}</td>
+                    <td>${e.fecha}</td>
+                    <td>${e.total}</td>
+                `;
+                tbody.appendChild(tr);
+            });
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar historial');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    cargarProveedores();
+    cargarProductos();
+    cargarHistorial();
+    document.getElementById('agregarFila').addEventListener('click', agregarFila);
+    document.getElementById('registrarEntrada').addEventListener('click', registrarEntrada);
+    document.getElementById('btnNuevoProveedor').addEventListener('click', nuevoProveedor);
+});


### PR DESCRIPTION
## Summary
- add Insumos frontend with form, JS logic and history table
- implement Insumos APIs for CRUD and entries
- extend database schema with providers and entries tables

## Testing
- `php -l api/insumos/listar_proveedores.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686091f0361c832b814496b7f66a3516