### PR TITLE
Implement control types for restaurant ingredients

### DIFF
--- a/api/insumos/listar_insumos.php
+++ b/api/insumos/listar_insumos.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$query = "SELECT id, nombre, unidad, existencia, tipo_control FROM insumos ORDER BY nombre";
+$result = $conn->query($query);
+
+if (!$result) {
+    error('Error al obtener insumos: ' . $conn->error);
+}
+
+$insumos = [];
+while ($row = $result->fetch_assoc()) {
+    $insumos[] = $row;
+}
+
+success($insumos);

--- a/utils/bd.sql
+++ b/utils/bd.sql
@@ -74,7 +74,8 @@ CREATE TABLE insumos (
   id INT AUTO_INCREMENT PRIMARY KEY,
   nombre VARCHAR(100),
   unidad VARCHAR(20),
-  existencia DECIMAL(10,2)
+  existencia DECIMAL(10,2),
+  tipo_control ENUM('por_receta', 'unidad_completa', 'uso_general', 'no_controlado', 'desempaquetado') DEFAULT 'por_receta'
 );
 
 CREATE TABLE recetas (

--- a/vistas/insumos/insumos.html
+++ b/vistas/insumos/insumos.html
@@ -15,14 +15,18 @@
             <thead>
                 <tr>
                     <th>Producto</th>
+                    <th>Tipo de control</th>
                     <th>Cantidad</th>
+                    <th>Unidades</th>
                     <th>Precio unitario</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
                     <td><select class="producto"></select></td>
+                    <td class="tipo"></td>
                     <td><input type="number" class="cantidad"></td>
+                    <td><input type="number" class="unidades" style="display:none"></td>
                     <td><input type="number" class="precio"></td>
                 </tr>
             </tbody>
@@ -39,6 +43,19 @@
                 <th>Proveedor</th>
                 <th>Fecha</th>
                 <th>Total</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
+    <h2>Listado de Insumos</h2>
+    <table id="listaInsumos" border="1">
+        <thead>
+            <tr>
+                <th>Nombre</th>
+                <th>Unidad</th>
+                <th>Existencia</th>
+                <th>Tipo de control</th>
             </tr>
         </thead>
         <tbody></tbody>


### PR DESCRIPTION
## Summary
- track control type in `insumos` table
- list ingredients with API `listar_insumos.php`
- support unpacked entries in `crear_entrada.php`
- show ingredient control type in UI and validate fields

## Testing
- `php -l api/insumos/listar_insumos.php` *(fails: php not installed)*
- `php -l api/insumos/crear_entrada.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68615e7c9fc0832ba1714de3821d3df3