### PR TITLE
Implementar descarga de insumos al marcar listo

### DIFF
--- a/api/cocina/cambiar_estado_producto.php
+++ b/api/cocina/cambiar_estado_producto.php
@@ -18,7 +18,7 @@ if (!in_array($nuevo_estado, $permitidos, true)) {
     error('Estado no válido');
 }
 
-$stmt = $conn->prepare('SELECT estatus_preparacion FROM venta_detalles WHERE id = ?');
+$stmt = $conn->prepare('SELECT estatus_preparacion, producto_id, cantidad, insumos_descargados FROM venta_detalles WHERE id = ?');
 if (!$stmt) {
     error('Error al preparar consulta: ' . $conn->error);
 }
@@ -29,7 +29,8 @@ if (!$result || $result->num_rows === 0) {
     $stmt->close();
     error('Detalle no encontrado');
 }
-$actual = $result->fetch_assoc()['estatus_preparacion'];
+$detalle = $result->fetch_assoc();
+$actual   = $detalle['estatus_preparacion'];
 $stmt->close();
 
 if (in_array($actual, ['listo', 'entregado'], true)) {
@@ -45,16 +46,84 @@ if (!isset($transiciones[$actual]) || $transiciones[$actual] !== $nuevo_estado) 
     error('Transición no permitida');
 }
 
-$upd = $conn->prepare('UPDATE venta_detalles SET estatus_preparacion = ? WHERE id = ?');
-if (!$upd) {
-    error('Error al preparar actualización: ' . $conn->error);
-}
-$upd->bind_param('si', $nuevo_estado, $detalle_id);
-if (!$upd->execute()) {
-    $upd->close();
-    error('Error al actualizar: ' . $upd->error);
-}
-$upd->close();
+$warnings = [];
+$descargados = (int) $detalle['insumos_descargados'];
 
-success(true);
+if ($nuevo_estado === 'listo' && $descargados === 0) {
+    $conn->begin_transaction();
+    try {
+        $producto_id = (int) $detalle['producto_id'];
+        $cantidad    = (int) $detalle['cantidad'];
+
+        $receta = $conn->prepare('SELECT insumo_id, cantidad FROM recetas WHERE producto_id = ?');
+        if (!$receta) {
+            throw new Exception('Error al preparar receta: ' . $conn->error);
+        }
+        $receta->bind_param('i', $producto_id);
+        if (!$receta->execute()) {
+            $receta->close();
+            throw new Exception('Error al ejecutar receta: ' . $receta->error);
+        }
+        $res = $receta->get_result();
+        while ($row = $res->fetch_assoc()) {
+            $insumo_id = (int) $row['insumo_id'];
+            $total     = (float) $row['cantidad'] * $cantidad;
+
+            $check = $conn->prepare('SELECT existencia FROM insumos WHERE id = ?');
+            if ($check) {
+                $check->bind_param('i', $insumo_id);
+                $check->execute();
+                $ex = $check->get_result()->fetch_assoc();
+                if ($ex && (float) $ex['existencia'] < $total) {
+                    $warnings[] = "Insumo {$insumo_id} insuficiente";
+                }
+                $check->close();
+            }
+
+            $updIn = $conn->prepare('UPDATE insumos SET existencia = existencia - ? WHERE id = ?');
+            if (!$updIn) {
+                $receta->close();
+                throw new Exception('Error al preparar descuento: ' . $conn->error);
+            }
+            $updIn->bind_param('di', $total, $insumo_id);
+            if (!$updIn->execute()) {
+                $updIn->close();
+                $receta->close();
+                throw new Exception('Error al descontar insumo: ' . $updIn->error);
+            }
+            $updIn->close();
+        }
+        $receta->close();
+
+        $upd = $conn->prepare('UPDATE venta_detalles SET estatus_preparacion = ?, insumos_descargados = 1 WHERE id = ?');
+        if (!$upd) {
+            throw new Exception('Error al preparar actualización: ' . $conn->error);
+        }
+        $upd->bind_param('si', $nuevo_estado, $detalle_id);
+        if (!$upd->execute()) {
+            $upd->close();
+            throw new Exception('Error al actualizar: ' . $upd->error);
+        }
+        $upd->close();
+
+        $conn->commit();
+        success(['warning' => $warnings]);
+    } catch (Exception $e) {
+        $conn->rollback();
+        error($e->getMessage());
+    }
+} else {
+    $upd = $conn->prepare('UPDATE venta_detalles SET estatus_preparacion = ? WHERE id = ?');
+    if (!$upd) {
+        error('Error al preparar actualización: ' . $conn->error);
+    }
+    $upd->bind_param('si', $nuevo_estado, $detalle_id);
+    if (!$upd->execute()) {
+        $upd->close();
+        error('Error al actualizar: ' . $upd->error);
+    }
+    $upd->close();
+
+    success(true);
+}
 ?>

--- a/utils/bd.sql
+++ b/utils/bd.sql
@@ -67,6 +67,8 @@ CREATE TABLE corte_caja (
 ALTER TABLE venta_detalles
 ADD COLUMN estatus_preparacion ENUM('pendiente', 'en preparación', 'listo', 'entregado') DEFAULT 'pendiente';
 
+ALTER TABLE venta_detalles ADD COLUMN insumos_descargados TINYINT(1) DEFAULT 0;
+
 -- Agrega una columna para saber si una mesa está unida a otra
 ALTER TABLE mesas ADD COLUMN mesa_principal_id INT DEFAULT NULL;
 


### PR DESCRIPTION
## Summary
- descontar existencia de insumos cuando el detalle pasa a `listo`
- registrar la descarga para evitar doble conteo
- agregar instrucción SQL para `insumos_descargados`

## Testing
- `php -l api/cocina/cambiar_estado_producto.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686166bbfc0c832bb09074c561d837bd