### PR TITLE
Add delivery sales option

### DIFF
--- a/api/repartidores/listar_repartidores.php
+++ b/api/repartidores/listar_repartidores.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$query = "SELECT id, nombre FROM repartidores ORDER BY nombre";
+$result = $conn->query($query);
+
+if (!$result) {
+    error('Error al obtener repartidores: ' . $conn->error);
+}
+
+$repartidores = [];
+while ($row = $result->fetch_assoc()) {
+    $repartidores[] = $row;
+}
+
+success($repartidores);
+?>

--- a/api/ventas/detalle_venta.php
+++ b/api/ventas/detalle_venta.php
@@ -17,11 +17,12 @@ if (!$input || !isset($input['venta_id'])) {
 
 $venta_id = (int)$input['venta_id'];
 
-// Obtener mesa y mesero relacionados con la venta
+// Obtener datos generales de la venta
 $info = $conn->prepare(
-    'SELECT m.nombre AS mesa, u.nombre AS mesero
+    'SELECT v.tipo_entrega, m.nombre AS mesa, r.nombre AS repartidor, u.nombre AS mesero
      FROM ventas v
-     JOIN mesas m ON v.mesa_id = m.id
+     LEFT JOIN mesas m ON v.mesa_id = m.id
+     LEFT JOIN repartidores r ON v.repartidor_id = r.id
      JOIN usuarios u ON v.usuario_id = u.id
      WHERE v.id = ?'
 );
@@ -65,8 +66,10 @@ while ($row = $res->fetch_assoc()) {
 $stmt->close();
 
 echo json_encode([
-    'success'   => true,
-    'mesa'      => $datosVenta['mesa'] ?? '',
-    'mesero'    => $datosVenta['mesero'] ?? '',
-    'productos' => $productos
+    'success'      => true,
+    'tipo_entrega' => $datosVenta['tipo_entrega'] ?? '',
+    'mesa'         => $datosVenta['mesa'] ?? '',
+    'repartidor'   => $datosVenta['repartidor'] ?? '',
+    'mesero'       => $datosVenta['mesero'] ?? '',
+    'productos'    => $productos
 ]);

--- a/api/ventas/listar_ventas.php
+++ b/api/ventas/listar_ventas.php
@@ -2,7 +2,11 @@
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
-$query = "SELECT * FROM ventas ORDER BY fecha DESC";
+$query = "SELECT v.*, m.nombre AS mesa, r.nombre AS repartidor
+          FROM ventas v
+          LEFT JOIN mesas m ON v.mesa_id = m.id
+          LEFT JOIN repartidores r ON v.repartidor_id = r.id
+          ORDER BY v.fecha DESC";
 $result = $conn->query($query);
 
 if (!$result) {

--- a/utils/bd.sql
+++ b/utils/bd.sql
@@ -19,15 +19,25 @@ CREATE TABLE mesas (
     capacidad INT DEFAULT 4
 );
 
+--  Repartidores
+CREATE TABLE IF NOT EXISTS repartidores (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre VARCHAR(100),
+    telefono VARCHAR(20)
+);
+
 --  Ventas
 CREATE TABLE ventas (
     id INT AUTO_INCREMENT PRIMARY KEY,
     fecha DATETIME DEFAULT CURRENT_TIMESTAMP,
     mesa_id INT,
+    repartidor_id INT DEFAULT NULL,
+    tipo_entrega ENUM('mesa','domicilio') DEFAULT 'mesa',
     usuario_id INT,
     total DECIMAL(10, 2) DEFAULT 0.00,
     estatus ENUM('activa', 'cerrada', 'cancelada') DEFAULT 'activa',
     FOREIGN KEY (mesa_id) REFERENCES mesas(id),
+    FOREIGN KEY (repartidor_id) REFERENCES repartidores(id),
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id)
 );
 

--- a/vistas/ventas/ventas.html
+++ b/vistas/ventas/ventas.html
@@ -7,12 +7,23 @@
 <body>
     <h1>Registro de Venta</h1>
     <form id="formVenta">
-        <label for="mesa_id">Mesa:</label>
-        <select id="mesa_id" name="mesa_id">
-            <option value="1">Mesa 1</option>
-            <option value="2">Mesa 2</option>
-            <option value="3">Mesa 3</option>
+        <label for="tipo_entrega">Tipo de venta:</label>
+        <select id="tipo_entrega" name="tipo_entrega">
+            <option value="mesa">En restaurante</option>
+            <option value="domicilio">A domicilio</option>
         </select>
+        <div id="campoMesa">
+            <label for="mesa_id">Mesa:</label>
+            <select id="mesa_id" name="mesa_id">
+                <option value="1">Mesa 1</option>
+                <option value="2">Mesa 2</option>
+                <option value="3">Mesa 3</option>
+            </select>
+        </div>
+        <div id="campoRepartidor" style="display:none;">
+            <label for="repartidor_id">Repartidor:</label>
+            <select id="repartidor_id" name="repartidor_id"></select>
+        </div>
         <label for="usuario_id">Mesero:</label>
         <select id="usuario_id" name="usuario_id" required></select>
         <h2>Productos</h2>
@@ -45,6 +56,8 @@
                 <th>ID</th>
                 <th>Fecha</th>
                 <th>Total</th>
+                <th>Tipo</th>
+                <th>Destino</th>
                 <th>Estatus</th>
                 <th>Ver detalles</th>
                 <th>Acci&oacute;n</th>


### PR DESCRIPTION
## Summary
- allow `ventas` to be assigned to a delivery driver
- list delivery drivers from new API
- show delivery/restaurant orders in history table
- support delivery orders in backend
- update DB schema for drivers and order type

## Testing
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686169c2f5ac832b93fb01aa0ccbfdbe