### PR TITLE
Add delivery view and APIs for repartidores

### DIFF
--- a/api/repartidores/marcar_entregado.php
+++ b/api/repartidores/marcar_entregado.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$venta_id = null;
+if ($input && isset($input['venta_id'])) {
+    $venta_id = (int)$input['venta_id'];
+} elseif (isset($_POST['venta_id'])) {
+    $venta_id = (int)$_POST['venta_id'];
+}
+
+if (!$venta_id) {
+    error('Datos inválidos');
+}
+
+$stmt = $conn->prepare("UPDATE ventas SET estatus = 'cerrada', entregado = 1 WHERE id = ?");
+if (!$stmt) {
+    error('Error al preparar actualización: ' . $conn->error);
+}
+$stmt->bind_param('i', $venta_id);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al actualizar venta: ' . $stmt->error);
+}
+
+if ($stmt->affected_rows === 0) {
+    $stmt->close();
+    error('Venta no encontrada');
+}
+$stmt->close();
+
+success(true);
+?>

--- a/utils/bd.sql
+++ b/utils/bd.sql
@@ -153,3 +153,6 @@ INSERT INTO venta_detalles (venta_id, producto_id, cantidad, precio_unitario)
 VALUES
 (@venta_id, 1, 2, 45.00),
 (@venta_id, 4, 3, 20.00);
+
+-- Column to mark if delivery completed by repartidor
+ALTER TABLE ventas ADD COLUMN entregado TINYINT(1) DEFAULT 0;

--- a/vistas/repartidores/repartos.html
+++ b/vistas/repartidores/repartos.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Repartos</title>
+    <link rel="stylesheet" href="../css/estilos.css">
+</head>
+<body>
+    <h1>Repartos</h1>
+    <h2>Pendientes</h2>
+    <table id="tabla-pendientes" border="1">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Fecha</th>
+                <th>Total</th>
+                <th>Productos</th>
+                <th>Acciones</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
+    <h2>Entregadas</h2>
+    <table id="tabla-entregadas" border="1">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Fecha</th>
+                <th>Total</th>
+                <th>Productos</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
+    <script src="repartos.js"></script>
+</body>
+</html>

--- a/vistas/repartidores/repartos.js
+++ b/vistas/repartidores/repartos.js
@@ -1,0 +1,63 @@
+const params = new URLSearchParams(location.search);
+const repartidorId = params.get('id');
+
+async function cargarEntregas() {
+    if (!repartidorId) return;
+    try {
+        const resp = await fetch(`../../api/repartidores/listar_entregas.php?repartidor_id=${repartidorId}`);
+        const data = await resp.json();
+        if (data.success) {
+            const pendientesBody = document.querySelector('#tabla-pendientes tbody');
+            const entregadasBody = document.querySelector('#tabla-entregadas tbody');
+            pendientesBody.innerHTML = '';
+            entregadasBody.innerHTML = '';
+            data.resultado.forEach(v => {
+                const row = document.createElement('tr');
+                const productos = v.productos.map(p => `${p.nombre} (${p.cantidad})`).join(', ');
+                row.innerHTML = `
+                    <td>${v.id}</td>
+                    <td>${v.fecha}</td>
+                    <td>${v.total}</td>
+                    <td>${productos}</td>
+                `;
+                if (v.estatus === 'activa' && !v.entregado) {
+                    const btn = document.createElement('button');
+                    btn.textContent = 'Marcar como entregada';
+                    btn.addEventListener('click', () => marcarEntregada(v.id));
+                    const accionTd = document.createElement('td');
+                    accionTd.appendChild(btn);
+                    row.appendChild(accionTd);
+                    pendientesBody.appendChild(row);
+                } else {
+                    entregadasBody.appendChild(row);
+                }
+            });
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar repartos');
+    }
+}
+
+async function marcarEntregada(id) {
+    try {
+        const resp = await fetch('../../api/repartidores/marcar_entregado.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ venta_id: parseInt(id) })
+        });
+        const data = await resp.json();
+        if (data.success) {
+            cargarEntregas();
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al actualizar');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', cargarEntregas);


### PR DESCRIPTION
## Summary
- support tracking deliveries by repartidor
- API to list deliveries and mark sale delivered
- page for delivery staff with pending/completed tables
- SQL migration for `entregado` column

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616c66a4d0832b8ea5567a3a8e04ea