### PR TITLE
Implement modulo de corte de caja

### DIFF
--- a/api/corte_caja/cerrar_corte.php
+++ b/api/corte_caja/cerrar_corte.php
@@ -1,0 +1,62 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$corte_id   = $input['corte_id'] ?? null;
+$usuario_id = $input['usuario_id'] ?? null;
+
+if (!$corte_id || !$usuario_id) {
+    error('Datos incompletos');
+}
+
+$stmt = $conn->prepare('SELECT fecha_inicio FROM corte_caja WHERE id = ? AND usuario_id = ? AND fecha_fin IS NULL');
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('ii', $corte_id, $usuario_id);
+$stmt->execute();
+$res = $stmt->get_result();
+if ($res->num_rows === 0) {
+    $stmt->close();
+    error('Corte no encontrado o ya cerrado');
+}
+$row = $res->fetch_assoc();
+$fecha_inicio = $row['fecha_inicio'];
+$stmt->close();
+
+$stmt = $conn->prepare("SELECT COUNT(* ) AS num, SUM(total) AS total FROM ventas WHERE usuario_id = ? AND fecha >= ? AND fecha <= NOW() AND estatus = 'cerrada'");
+if (!$stmt) {
+    error('Error al preparar consulta de ventas: ' . $conn->error);
+}
+$stmt->bind_param('is', $usuario_id, $fecha_inicio);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al obtener ventas: ' . $stmt->error);
+}
+$ventas = $stmt->get_result()->fetch_assoc();
+$numVentas = (int)($ventas['num'] ?? 0);
+$total = (float)($ventas['total'] ?? 0);
+$stmt->close();
+
+if ($numVentas === 0) {
+    error('No hay ventas para cerrar corte');
+}
+
+$stmt = $conn->prepare('UPDATE corte_caja SET fecha_fin = NOW(), total = ? WHERE id = ?');
+if (!$stmt) {
+    error('Error al preparar actualización: ' . $conn->error);
+}
+$stmt->bind_param('di', $total, $corte_id);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al cerrar corte: ' . $stmt->error);
+}
+$stmt->close();
+
+success(['ventas_realizadas' => $numVentas, 'total' => $total]);
+?>

--- a/api/corte_caja/iniciar_corte.php
+++ b/api/corte_caja/iniciar_corte.php
@@ -1,0 +1,41 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$usuario_id = $input['usuario_id'] ?? null;
+if (!$usuario_id) {
+    error('usuario_id requerido');
+}
+
+$stmt = $conn->prepare('SELECT id FROM corte_caja WHERE usuario_id = ? AND fecha_fin IS NULL');
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('i', $usuario_id);
+$stmt->execute();
+$stmt->store_result();
+if ($stmt->num_rows > 0) {
+    $stmt->close();
+    error('Ya existe un corte abierto para este usuario');
+}
+$stmt->close();
+
+$stmt = $conn->prepare('INSERT INTO corte_caja (usuario_id, fecha_inicio) VALUES (?, NOW())');
+if (!$stmt) {
+    error('Error al preparar inserción: ' . $conn->error);
+}
+$stmt->bind_param('i', $usuario_id);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al crear corte: ' . $stmt->error);
+}
+$corte_id = $stmt->insert_id;
+$stmt->close();
+
+success(['corte_id' => $corte_id]);
+?>

--- a/api/corte_caja/listar_cortes.php
+++ b/api/corte_caja/listar_cortes.php
@@ -1,0 +1,70 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$usuario_id = null;
+$inicio = null;
+$fin = null;
+
+if (isset($_GET['usuario_id'])) {
+    $usuario_id = (int)$_GET['usuario_id'];
+}
+if (isset($_GET['inicio'])) {
+    $inicio = $_GET['inicio'];
+}
+if (isset($_GET['fin'])) {
+    $fin = $_GET['fin'];
+}
+
+$conditions = [];
+$params = [];
+$types = '';
+if ($usuario_id) {
+    $conditions[] = 'c.usuario_id = ?';
+    $params[] = $usuario_id;
+    $types .= 'i';
+}
+if ($inicio) {
+    $conditions[] = 'c.fecha_inicio >= ?';
+    $params[] = $inicio;
+    $types .= 's';
+}
+if ($fin) {
+    $conditions[] = 'c.fecha_inicio <= ?';
+    $params[] = $fin;
+    $types .= 's';
+}
+$where = $conditions ? 'WHERE ' . implode(' AND ', $conditions) : '';
+
+$query = "SELECT c.id, c.fecha_inicio, c.fecha_fin, c.total, u.nombre AS usuario
+           FROM corte_caja c
+           JOIN usuarios u ON c.usuario_id = u.id
+           $where
+           ORDER BY c.fecha_inicio DESC";
+
+$stmt = $conn->prepare($query);
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+if ($params) {
+    $stmt->bind_param($types, ...$params);
+}
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al ejecutar consulta: ' . $stmt->error);
+}
+$res = $stmt->get_result();
+$cortes = [];
+while ($row = $res->fetch_assoc()) {
+    $cortes[] = [
+        'id' => (int)$row['id'],
+        'fecha_inicio' => $row['fecha_inicio'],
+        'fecha_fin' => $row['fecha_fin'],
+        'total' => $row['total'] !== null ? (float)$row['total'] : null,
+        'usuario' => $row['usuario']
+    ];
+}
+$stmt->close();
+
+success($cortes);
+?>

--- a/api/corte_caja/verificar_corte_abierto.php
+++ b/api/corte_caja/verificar_corte_abierto.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$usuario_id = null;
+if (isset($_GET['usuario_id'])) {
+    $usuario_id = (int)$_GET['usuario_id'];
+} else {
+    $input = json_decode(file_get_contents('php://input'), true);
+    if ($input && isset($input['usuario_id'])) {
+        $usuario_id = (int)$input['usuario_id'];
+    }
+}
+
+if (!$usuario_id) {
+    error('usuario_id requerido');
+}
+
+$stmt = $conn->prepare('SELECT id, fecha_inicio FROM corte_caja WHERE usuario_id = ? AND fecha_fin IS NULL');
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('i', $usuario_id);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al ejecutar consulta: ' . $stmt->error);
+}
+$res = $stmt->get_result();
+if ($row = $res->fetch_assoc()) {
+    success(['abierto' => true, 'corte_id' => (int)$row['id'], 'fecha_inicio' => $row['fecha_inicio']]);
+}
+$stmt->close();
+
+success(['abierto' => false]);
+?>

--- a/vistas/corte_caja/corte.html
+++ b/vistas/corte_caja/corte.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Corte de Caja</title>
+</head>
+<body>
+    <h1>Corte de Caja</h1>
+    <div id="corteActual">
+        <button id="btnIniciar">Iniciar Corte</button>
+    </div>
+
+    <h2>Historial de Cortes</h2>
+    <table id="tablaCortes" border="1">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Cajero</th>
+                <th>Fecha inicio</th>
+                <th>Fecha fin</th>
+                <th>Total</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
+    <script src="corte.js"></script>
+</body>
+</html>

--- a/vistas/corte_caja/corte.js
+++ b/vistas/corte_caja/corte.js
@@ -1,0 +1,99 @@
+let corteActual = null;
+const usuarioId = 1; // En entorno real, este valor provendría de la sesión
+
+async function verificarCorte() {
+    try {
+        const resp = await fetch('../../api/corte_caja/verificar_corte_abierto.php?usuario_id=' + usuarioId);
+        const data = await resp.json();
+        const cont = document.getElementById('corteActual');
+        cont.innerHTML = '';
+        if (data.success && data.abierto) {
+            corteActual = data.corte_id;
+            cont.innerHTML = `<p>Inicio: ${data.fecha_inicio}</p><button id="btnCerrar">Cerrar Corte</button>`;
+            document.getElementById('btnCerrar').addEventListener('click', cerrarCorte);
+        } else {
+            corteActual = null;
+            cont.innerHTML = '<button id="btnIniciar">Iniciar Corte</button>';
+            document.getElementById('btnIniciar').addEventListener('click', iniciarCorte);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al verificar corte');
+    }
+}
+
+async function iniciarCorte() {
+    try {
+        const resp = await fetch('../../api/corte_caja/iniciar_corte.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ usuario_id: usuarioId })
+        });
+        const data = await resp.json();
+        if (data.success) {
+            corteActual = data.resultado.corte_id;
+            await verificarCorte();
+            await cargarHistorial();
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al iniciar corte');
+    }
+}
+
+async function cerrarCorte() {
+    if (!corteActual) return;
+    try {
+        const resp = await fetch('../../api/corte_caja/cerrar_corte.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ corte_id: corteActual, usuario_id: usuarioId })
+        });
+        const data = await resp.json();
+        if (data.success) {
+            alert(`Ventas: ${data.resultado.ventas_realizadas}\nTotal: $${data.resultado.total}`);
+            corteActual = null;
+            await verificarCorte();
+            await cargarHistorial();
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cerrar corte');
+    }
+}
+
+async function cargarHistorial() {
+    try {
+        const resp = await fetch('../../api/corte_caja/listar_cortes.php');
+        const data = await resp.json();
+        if (data.success) {
+            const tbody = document.querySelector('#tablaCortes tbody');
+            tbody.innerHTML = '';
+            data.resultado.forEach(c => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${c.id}</td>
+                    <td>${c.usuario}</td>
+                    <td>${c.fecha_inicio}</td>
+                    <td>${c.fecha_fin || ''}</td>
+                    <td>${c.total !== null ? c.total : ''}</td>
+                `;
+                tbody.appendChild(tr);
+            });
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar historial');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    verificarCorte();
+    cargarHistorial();
+});


### PR DESCRIPTION
## Summary
- add APIs para crear, cerrar y consultar cortes de caja
- incluir endpoint para verificar si un cajero tiene un corte abierto
- crear interfaz corte de caja en HTML y JS

## Testing
- `node --check vistas/corte_caja/corte.js`
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616d8a69c8832bbe34caa598442827