### PR TITLE
Refactor PHP endpoints to use DB routines

### DIFF
--- a/api/cocina/cambiar_estado_producto.php
+++ b/api/cocina/cambiar_estado_producto.php
@@ -46,84 +46,29 @@ if (!isset($transiciones[$actual]) || $transiciones[$actual] !== $nuevo_estado) 
     error('Transición no permitida');
 }
 
-$warnings = [];
-$descargados = (int) $detalle['insumos_descargados'];
-
-if ($nuevo_estado === 'listo' && $descargados === 0) {
-    $conn->begin_transaction();
-    try {
-        $producto_id = (int) $detalle['producto_id'];
-        $cantidad    = (int) $detalle['cantidad'];
-
-        $receta = $conn->prepare('SELECT insumo_id, cantidad FROM recetas WHERE producto_id = ?');
-        if (!$receta) {
-            throw new Exception('Error al preparar receta: ' . $conn->error);
-        }
-        $receta->bind_param('i', $producto_id);
-        if (!$receta->execute()) {
-            $receta->close();
-            throw new Exception('Error al ejecutar receta: ' . $receta->error);
-        }
-        $res = $receta->get_result();
-        while ($row = $res->fetch_assoc()) {
-            $insumo_id = (int) $row['insumo_id'];
-            $total     = (float) $row['cantidad'] * $cantidad;
-
-            $check = $conn->prepare('SELECT existencia FROM insumos WHERE id = ?');
-            if ($check) {
-                $check->bind_param('i', $insumo_id);
-                $check->execute();
-                $ex = $check->get_result()->fetch_assoc();
-                if ($ex && (float) $ex['existencia'] < $total) {
-                    $warnings[] = "Insumo {$insumo_id} insuficiente";
-                }
-                $check->close();
-            }
-
-            $updIn = $conn->prepare('UPDATE insumos SET existencia = existencia - ? WHERE id = ?');
-            if (!$updIn) {
-                $receta->close();
-                throw new Exception('Error al preparar descuento: ' . $conn->error);
-            }
-            $updIn->bind_param('di', $total, $insumo_id);
-            if (!$updIn->execute()) {
-                $updIn->close();
-                $receta->close();
-                throw new Exception('Error al descontar insumo: ' . $updIn->error);
-            }
-            $updIn->close();
-        }
-        $receta->close();
-
-        $upd = $conn->prepare('UPDATE venta_detalles SET estatus_preparacion = ?, insumos_descargados = 1 WHERE id = ?');
-        if (!$upd) {
-            throw new Exception('Error al preparar actualización: ' . $conn->error);
-        }
-        $upd->bind_param('si', $nuevo_estado, $detalle_id);
-        if (!$upd->execute()) {
-            $upd->close();
-            throw new Exception('Error al actualizar: ' . $upd->error);
-        }
-        $upd->close();
-
-        $conn->commit();
-        success(['warning' => $warnings]);
-    } catch (Exception $e) {
-        $conn->rollback();
-        error($e->getMessage());
-    }
-} else {
-    $upd = $conn->prepare('UPDATE venta_detalles SET estatus_preparacion = ? WHERE id = ?');
-    if (!$upd) {
-        error('Error al preparar actualización: ' . $conn->error);
-    }
-    $upd->bind_param('si', $nuevo_estado, $detalle_id);
-    if (!$upd->execute()) {
-        $upd->close();
-        error('Error al actualizar: ' . $upd->error);
-    }
-    $upd->close();
-
-    success(true);
+// Lógica reemplazada por base de datos: ver bd.sql (Trigger/SP)
+$upd = $conn->prepare('UPDATE venta_detalles SET estatus_preparacion = ? WHERE id = ?');
+if (!$upd) {
+    error('Error al preparar actualización: ' . $conn->error);
 }
+$upd->bind_param('si', $nuevo_estado, $detalle_id);
+if (!$upd->execute()) {
+    $upd->close();
+    error('Error al actualizar: ' . $upd->error);
+}
+$upd->close();
+
+if ($nuevo_estado === 'listo') {
+    $log = $conn->prepare('INSERT INTO logs_accion (usuario_id, modulo, accion, referencia_id) VALUES (?, ?, ?, ?)');
+    if ($log) {
+        $usuario_id = $input['usuario_id'] ?? null;
+        $mod = 'cocina';
+        $accion = 'Producto marcado como listo';
+        $log->bind_param('issi', $usuario_id, $mod, $accion, $detalle_id);
+        $log->execute();
+        $log->close();
+    }
+}
+
+success(true);
 ?>

--- a/api/corte_caja/iniciar_corte.php
+++ b/api/corte_caja/iniciar_corte.php
@@ -37,5 +37,15 @@ if (!$stmt->execute()) {
 $corte_id = $stmt->insert_id;
 $stmt->close();
 
+// Lógica reemplazada por base de datos: ver bd.sql (Logs)
+$log = $conn->prepare('INSERT INTO logs_accion (usuario_id, modulo, accion, referencia_id) VALUES (?, ?, ?, ?)');
+if ($log) {
+    $mod = 'corte_caja';
+    $accion = 'Creación de corte';
+    $log->bind_param('issi', $usuario_id, $mod, $accion, $corte_id);
+    $log->execute();
+    $log->close();
+}
+
 success(['corte_id' => $corte_id]);
 ?>

--- a/api/corte_caja/listar_cortes.php
+++ b/api/corte_caja/listar_cortes.php
@@ -20,27 +20,27 @@ $conditions = [];
 $params = [];
 $types = '';
 if ($usuario_id) {
-    $conditions[] = 'c.usuario_id = ?';
+    $conditions[] = 'cc.usuario_id = ?';
     $params[] = $usuario_id;
     $types .= 'i';
 }
 if ($inicio) {
-    $conditions[] = 'c.fecha_inicio >= ?';
+    $conditions[] = 'cc.fecha_inicio >= ?';
     $params[] = $inicio;
     $types .= 's';
 }
 if ($fin) {
-    $conditions[] = 'c.fecha_inicio <= ?';
+    $conditions[] = 'cc.fecha_inicio <= ?';
     $params[] = $fin;
     $types .= 's';
 }
 $where = $conditions ? 'WHERE ' . implode(' AND ', $conditions) : '';
 
-$query = "SELECT c.id, c.fecha_inicio, c.fecha_fin, c.total, u.nombre AS usuario
-           FROM corte_caja c
-           JOIN usuarios u ON c.usuario_id = u.id
-           $where
-           ORDER BY c.fecha_inicio DESC";
+$query = "SELECT v.corte_id AS id, v.fecha_inicio, v.fecha_fin, v.total, v.cajero AS usuario
+          FROM vw_corte_resumen v
+          JOIN corte_caja cc ON cc.id = v.corte_id
+          $where
+          ORDER BY v.fecha_inicio DESC"; // Lógica reemplazada por base de datos: ver bd.sql (Vista)
 
 $stmt = $conn->prepare($query);
 if (!$stmt) {

--- a/api/ventas/crear_venta.php
+++ b/api/ventas/crear_venta.php
@@ -70,5 +70,16 @@ foreach ($productos as $p) {
 }
 $detalle->close();
 
+// Lógica reemplazada por base de datos: ver bd.sql (Logs)
+// Registrar acción en logs
+$log = $conn->prepare('INSERT INTO logs_accion (usuario_id, modulo, accion, referencia_id) VALUES (?, ?, ?, ?)');
+if ($log) {
+    $mod = 'ventas';
+    $accion = 'Alta de venta';
+    $log->bind_param('issi', $usuario_id, $mod, $accion, $venta_id);
+    $log->execute();
+    $log->close();
+}
+
 success(['venta_id' => $venta_id]);
 

--- a/api/ventas/listar_ventas.php
+++ b/api/ventas/listar_ventas.php
@@ -2,11 +2,7 @@
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
-$query = "SELECT v.*, m.nombre AS mesa, r.nombre AS repartidor
-          FROM ventas v
-          LEFT JOIN mesas m ON v.mesa_id = m.id
-          LEFT JOIN repartidores r ON v.repartidor_id = r.id
-          ORDER BY v.fecha DESC";
+$query = "SELECT * FROM vw_ventas_detalladas ORDER BY fecha DESC"; // Lógica reemplazada por base de datos: ver bd.sql (Vista)
 $result = $conn->query($query);
 
 if (!$result) {


### PR DESCRIPTION
## Summary
- delegate insumo descuento and corte closure to DB logic
- log critical actions in `logs_accion`
- list ventas and cortes using new views

## Testing
- `php -l api/ventas/crear_venta.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617b32e23c832b80c4ea7bfd002050