### PR TITLE
Fix ventas mapping and show waiter id

### DIFF
--- a/api/mesas/listar_mesas.php
+++ b/api/mesas/listar_mesas.php
@@ -3,7 +3,8 @@ require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
 // Obtener mesas y, en su caso, la venta activa asociada
-$query = "SELECT m.id, m.nombre, m.estado, m.capacidad, m.mesa_principal_id, v.id AS venta_id
+$query = "SELECT m.id, m.nombre, m.estado, m.capacidad, m.mesa_principal_id,
+                v.id AS venta_id, v.usuario_id AS mesero_id
           FROM mesas m
           LEFT JOIN ventas v ON v.mesa_id = m.id AND v.estatus = 'activa'
           ORDER BY m.id ASC";
@@ -23,7 +24,8 @@ while ($row = $result->fetch_assoc()) {
         'capacidad'         => (int)$row['capacidad'],
         'mesa_principal_id' => $row['mesa_principal_id'] ? (int)$row['mesa_principal_id'] : null,
         'venta_activa'      => $row['venta_id'] !== null,
-        'venta_id'          => $row['venta_id'] !== null ? (int)$row['venta_id'] : null
+        'venta_id'          => $row['venta_id'] !== null ? (int)$row['venta_id'] : null,
+        'mesero_id'         => $row['mesero_id'] !== null ? (int)$row['mesero_id'] : null
     ];
 }
 

--- a/vistas/mesas/mesas.js
+++ b/vistas/mesas/mesas.js
@@ -27,12 +27,14 @@ async function cargarMesas() {
                 }
 
                 const ventaTxt = m.venta_activa ? `Venta activa: ${m.venta_id}` : 'Sin venta';
+                const meseroTxt = m.mesero_id ? `Mesero ID: ${m.mesero_id}` : '';
 
                 card.innerHTML = `
                     <input type="checkbox" class="seleccionar" data-id="${m.id}">
                     <h3>${m.nombre}</h3>
                     <p>Estado: ${m.estado}</p>
                     <p>${ventaTxt}</p>
+                    <p>${meseroTxt}</p>
                     <p>${unionTxt}</p>
                     <button class="detalles" data-venta="${m.venta_id || ''}" data-mesa="${m.id}" data-nombre="${m.nombre}" data-estado="${m.estado}">Detalles</button>
                     <button class="dividir" data-id="${m.id}">Dividir</button>

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -7,20 +7,21 @@ async function cargarHistorial() {
             tbody.innerHTML = '';
             ventasData = {};
             data.resultado.forEach(v => {
-                ventasData[v.id] = v;
+                const id = v.venta_id || v.id; // compatibilidad con vista
+                ventasData[id] = v;
                 const row = document.createElement('tr');
                 const accion = v.estatus !== 'cancelada'
-                    ? `<button class="cancelar" data-id="${v.id}">Cancelar</button>`
+                    ? `<button class="cancelar" data-id="${id}">Cancelar</button>`
                     : '';
                 const destino = v.tipo_entrega === 'mesa' ? v.mesa : v.repartidor;
                 row.innerHTML = `
-                    <td>${v.id}</td>
+                    <td>${id}</td>
                     <td>${v.fecha}</td>
                     <td>${v.total}</td>
                     <td>${v.tipo_entrega}</td>
                     <td>${destino || ''}</td>
                     <td>${v.estatus}</td>
-                    <td><button class="detalles" data-id="${v.id}">Ver detalles</button></td>
+                    <td><button class="detalles" data-id="${id}">Ver detalles</button></td>
                     <td>${accion}</td>
                 `;
                 tbody.appendChild(row);


### PR DESCRIPTION
## Summary
- correctly map venta IDs from `vw_ventas_detalladas`
- include waiter id when listing tables
- show waiter id on tables dashboard

## Testing
- `php -l api/mesas/listar_mesas.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68618e21bdf4832bb91e08c6ccdb41d3