### PR TITLE
Implement ticket division and reprint

### DIFF
--- a/api/tickets/guardar_ticket.php
+++ b/api/tickets/guardar_ticket.php
@@ -1,0 +1,105 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['venta_id'], $input['usuario_id'], $input['subcuentas']) || !is_array($input['subcuentas'])) {
+    error('Datos incompletos');
+}
+
+$venta_id   = (int)$input['venta_id'];
+$usuario_id = (int)$input['usuario_id'];
+$subcuentas = $input['subcuentas'];
+
+$conn->begin_transaction();
+
+$folioRes = $conn->query('SELECT id, folio_actual FROM catalogo_folios LIMIT 1 FOR UPDATE');
+if (!$folioRes) {
+    $conn->rollback();
+    error('Error al obtener folio: ' . $conn->error);
+}
+$row = $folioRes->fetch_assoc();
+$catalogo_id = (int)$row['id'];
+$folio_actual = (int)$row['folio_actual'];
+$folioRes->close();
+
+$insTicket  = $conn->prepare('INSERT INTO tickets (venta_id, folio, total, propina, usuario_id) VALUES (?, ?, ?, ?, ?)');
+$insDetalle = $conn->prepare('INSERT INTO ticket_detalles (ticket_id, producto_id, cantidad, precio_unitario) VALUES (?, ?, ?, ?)');
+if (!$insTicket || !$insDetalle) {
+    $conn->rollback();
+    error('Error al preparar inserción: ' . $conn->error);
+}
+
+$ticketsResp = [];
+foreach ($subcuentas as $sub) {
+    if (!isset($sub['productos']) || !is_array($sub['productos'])) {
+        $conn->rollback();
+        error('Subcuenta inválida');
+    }
+    $propina = isset($sub['propina']) ? (float)$sub['propina'] : 0;
+    $total = 0;
+    foreach ($sub['productos'] as $p) {
+        if (!isset($p['producto_id'], $p['cantidad'], $p['precio_unitario'])) {
+            $conn->rollback();
+            error('Producto inválido en subcuenta');
+        }
+        $cantidad = (int)$p['cantidad'];
+        $precio   = (float)$p['precio_unitario'];
+        $total += $cantidad * $precio;
+    }
+    $total += $propina;
+    $folio_actual++;
+    $insTicket->bind_param('iiddi', $venta_id, $folio_actual, $total, $propina, $usuario_id);
+    if (!$insTicket->execute()) {
+        $conn->rollback();
+        error('Error al guardar ticket: ' . $insTicket->error);
+    }
+    $ticket_id = $insTicket->insert_id;
+    foreach ($sub['productos'] as $p) {
+        $producto_id     = (int)$p['producto_id'];
+        $cantidad        = (int)$p['cantidad'];
+        $precio_unitario = (float)$p['precio_unitario'];
+        $insDetalle->bind_param('iiid', $ticket_id, $producto_id, $cantidad, $precio_unitario);
+        if (!$insDetalle->execute()) {
+            $conn->rollback();
+            error('Error al guardar detalle: ' . $insDetalle->error);
+        }
+    }
+    $ticketsResp[] = [
+        'ticket_id' => $ticket_id,
+        'folio'     => $folio_actual,
+        'total'     => $total,
+        'propina'   => $propina
+    ];
+}
+
+$updFolio = $conn->prepare('UPDATE catalogo_folios SET folio_actual = ? WHERE id = ?');
+if (!$updFolio) {
+    $conn->rollback();
+    error('Error al preparar actualización de folio: ' . $conn->error);
+}
+$updFolio->bind_param('ii', $folio_actual, $catalogo_id);
+if (!$updFolio->execute()) {
+    $conn->rollback();
+    error('Error al actualizar folio: ' . $updFolio->error);
+}
+
+$cerrar = $conn->prepare("UPDATE ventas SET estatus = 'cerrada' WHERE id = ?");
+if (!$cerrar) {
+    $conn->rollback();
+    error('Error al preparar cierre de venta: ' . $conn->error);
+}
+$cerrar->bind_param('i', $venta_id);
+if (!$cerrar->execute()) {
+    $conn->rollback();
+    error('Error al cerrar venta: ' . $cerrar->error);
+}
+
+$conn->commit();
+
+success(['tickets' => $ticketsResp]);
+?>

--- a/api/tickets/reimprimir_ticket.php
+++ b/api/tickets/reimprimir_ticket.php
@@ -1,0 +1,70 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || (!isset($input['folio']) && !isset($input['venta_id']))) {
+    error('Se requiere folio o venta_id');
+}
+
+if (isset($input['folio'])) {
+    $cond = 't.folio = ?';
+    $param = (int)$input['folio'];
+} else {
+    $cond = 't.venta_id = ?';
+    $param = (int)$input['venta_id'];
+}
+
+$stmt = $conn->prepare("SELECT t.id, t.folio, t.total, t.propina, t.fecha, t.venta_id
+                        FROM tickets t WHERE $cond");
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('i', $param);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al ejecutar consulta: ' . $stmt->error);
+}
+$res = $stmt->get_result();
+$tickets = [];
+while ($t = $res->fetch_assoc()) {
+    $det = $conn->prepare("SELECT p.nombre, d.cantidad, d.precio_unitario,
+                                 (d.cantidad * d.precio_unitario) AS subtotal
+                           FROM ticket_detalles d
+                           JOIN productos p ON d.producto_id = p.id
+                           WHERE d.ticket_id = ?");
+    if (!$det) {
+        $stmt->close();
+        error('Error al preparar detalle: ' . $conn->error);
+    }
+    $det->bind_param('i', $t['id']);
+    if (!$det->execute()) {
+        $det->close();
+        $stmt->close();
+        error('Error al obtener detalle: ' . $det->error);
+    }
+    $dres = $det->get_result();
+    $prods = [];
+    while ($p = $dres->fetch_assoc()) {
+        $prods[] = $p;
+    }
+    $det->close();
+
+    $tickets[] = [
+        'ticket_id' => (int)$t['id'],
+        'folio'     => (int)$t['folio'],
+        'fecha'     => $t['fecha'],
+        'venta_id'  => (int)$t['venta_id'],
+        'propina'   => (float)$t['propina'],
+        'total'     => (float)$t['total'],
+        'productos' => $prods
+    ];
+}
+$stmt->close();
+
+success(['tickets' => $tickets]);
+?>

--- a/api/ventas/listar_ventas.php
+++ b/api/ventas/listar_ventas.php
@@ -2,7 +2,7 @@
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
-$query = "SELECT vw.*, v.tipo_entrega
+$query = "SELECT vw.*, v.tipo_entrega, v.usuario_id
           FROM vw_ventas_detalladas vw
           JOIN ventas v ON v.id = vw.venta_id
           ORDER BY vw.fecha DESC"; // Lógica reemplazada por base de datos: ver bd.sql (Vista)

--- a/vistas/ventas/ticket.html
+++ b/vistas/ventas/ticket.html
@@ -33,20 +33,38 @@
     </style>
 </head>
 <body>
-    <h2 id="nombreRestaurante">Mi Restaurante</h2>
-    <div id="fechaHora"></div>
-    <div>Número de venta: <span id="ventaId"></span></div>
-    <table id="productos">
-        <tbody></tbody>
-    </table>
-    <div id="totalVenta"></div>
-    <p>Gracias por su compra</p>
-    <button id="btnImprimir" onclick="window.print()">Imprimir</button>
+    <div id="dividir" style="display:none;">
+        <h2>Dividir venta</h2>
+        <table id="tablaProductos" border="1">
+            <thead>
+                <tr><th>Producto</th><th>Cant</th><th>Precio</th><th>Subcuenta</th></tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+        <button id="agregarSub">Agregar subcuenta</button>
+        <button id="guardarSub">Guardar Tickets</button>
+        <div id="subcuentas"></div>
+    </div>
+
+    <div id="imprimir" style="display:none;">
+        <h2 id="nombreRestaurante">Mi Restaurante</h2>
+        <div id="fechaHora"></div>
+        <div>Folio: <span id="folio"></span></div>
+        <div>Venta: <span id="ventaId"></span></div>
+        <table id="productos">
+            <tbody></tbody>
+        </table>
+        <div id="propina"></div>
+        <div id="totalVenta"></div>
+        <p>Gracias por su compra</p>
+        <button id="btnImprimir" onclick="window.print()">Imprimir</button>
+    </div>
 
     <script>
         function llenarTicket(data) {
             document.getElementById('ventaId').textContent = data.venta_id;
             document.getElementById('fechaHora').textContent = data.fecha;
+            document.getElementById('folio').textContent = data.folio || '';
             if (data.restaurante) {
                 document.getElementById('nombreRestaurante').textContent = data.restaurante;
             }
@@ -58,16 +76,160 @@
                 tr.innerHTML = `<td>${p.nombre}</td><td>${p.cantidad} x ${p.precio_unitario} = ${subtotal}</td>`;
                 tbody.appendChild(tr);
             });
+            if (typeof data.propina !== 'undefined') {
+                document.getElementById('propina').textContent = 'Propina: $' + data.propina.toFixed(2);
+            }
             document.getElementById('totalVenta').textContent = 'Total: $' + data.total;
         }
 
         document.addEventListener('DOMContentLoaded', () => {
+            const params = new URLSearchParams(window.location.search);
+            const imprimir = params.get('print') === '1';
             const almacenado = localStorage.getItem('ticketData');
-            if (almacenado) {
-                const datos = JSON.parse(almacenado);
+            if (!almacenado) return;
+            const datos = JSON.parse(almacenado);
+            if (imprimir) {
+                document.getElementById('imprimir').style.display = 'block';
                 llenarTicket(datos);
+            } else {
+                inicializarDividir(datos);
             }
         });
+
+        let productos = [];
+        let numSub = 1;
+        let ticketsGuardados = [];
+
+        function inicializarDividir(data) {
+            document.getElementById('dividir').style.display = 'block';
+            productos = data.productos.map(p => Object.assign({ subcuenta: 1 }, p));
+            renderProductos();
+            renderSubcuentas();
+            document.getElementById('agregarSub').addEventListener('click', () => {
+                numSub++;
+                actualizarSelects();
+                renderSubcuentas();
+            });
+            document.getElementById('guardarSub').addEventListener('click', guardarSubcuentas);
+        }
+
+        function renderProductos() {
+            const tbody = document.querySelector('#tablaProductos tbody');
+            tbody.innerHTML = '';
+            productos.forEach(p => {
+                const tr = document.createElement('tr');
+                const sel = document.createElement('select');
+                for (let i = 1; i <= numSub; i++) {
+                    const opt = document.createElement('option');
+                    opt.value = i;
+                    opt.textContent = i;
+                    sel.appendChild(opt);
+                }
+                sel.value = p.subcuenta;
+                sel.addEventListener('change', () => {
+                    p.subcuenta = parseInt(sel.value);
+                    renderSubcuentas();
+                });
+                tr.innerHTML = `<td>${p.nombre}</td><td>${p.cantidad}</td><td>${p.precio_unitario}</td>`;
+                const td = document.createElement('td');
+                td.appendChild(sel);
+                tr.appendChild(td);
+                tbody.appendChild(tr);
+            });
+        }
+
+        function actualizarSelects() {
+            document.querySelectorAll('#tablaProductos select').forEach(sel => {
+                const val = sel.value;
+                sel.innerHTML = '';
+                for (let i = 1; i <= numSub; i++) {
+                    const opt = document.createElement('option');
+                    opt.value = i;
+                    opt.textContent = i;
+                    sel.appendChild(opt);
+                }
+                sel.value = val;
+            });
+        }
+
+        function renderSubcuentas() {
+            const cont = document.getElementById('subcuentas');
+            cont.innerHTML = '';
+            for (let i = 1; i <= numSub; i++) {
+                const div = document.createElement('div');
+                div.id = 'sub' + i;
+                const prods = productos.filter(p => p.subcuenta === i);
+                let html = `<h3>Subcuenta ${i}</h3><table><tbody>`;
+                prods.forEach(p => {
+                    html += `<tr><td>${p.nombre}</td><td>${p.cantidad} x ${p.precio_unitario}</td></tr>`;
+                });
+                html += '</tbody></table>';
+                html += `Propina: <input type="number" step="0.01" id="propina${i}" value="0"><div id="tot${i}"></div>`;
+                div.innerHTML = html;
+                cont.appendChild(div);
+            }
+            mostrarTotal();
+        }
+
+        function mostrarTotal() {
+            for (let i = 1; i <= numSub; i++) {
+                const prods = productos.filter(p => p.subcuenta === i);
+                let total = prods.reduce((s, p) => s + p.cantidad * p.precio_unitario, 0);
+                const prop = parseFloat(document.getElementById('propina' + i).value || 0);
+                total += prop;
+                document.getElementById('tot' + i).textContent = 'Total: ' + total.toFixed(2);
+            }
+        }
+
+        function guardarSubcuentas() {
+            const info = JSON.parse(localStorage.getItem('ticketData'));
+            const payload = { venta_id: info.venta_id, usuario_id: info.usuario_id || 1, subcuentas: [] };
+            for (let i = 1; i <= numSub; i++) {
+                const prods = productos.filter(p => p.subcuenta === i).map(p => ({ producto_id: p.producto_id, cantidad: p.cantidad, precio_unitario: p.precio_unitario }));
+                if (prods.length === 0) continue;
+                const prop = parseFloat(document.getElementById('propina' + i).value || 0);
+                payload.subcuentas.push({ productos: prods, propina: prop });
+            }
+            fetch('../../api/tickets/guardar_ticket.php', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            })
+                .then(r => r.json())
+                .then(d => {
+                    if (d.success) {
+                        ticketsGuardados = d.resultado.tickets || [];
+                        alert('Tickets guardados');
+                        mostrarBotonesImprimir(payload);
+                    } else {
+                        alert(d.mensaje);
+                    }
+                })
+                .catch(() => alert('Error al guardar'));
+        }
+
+        function mostrarBotonesImprimir(payload) {
+            ticketsGuardados.forEach((t, i) => {
+                const div = document.getElementById('sub' + (i + 1));
+                if (!div) return;
+                const btn = document.createElement('button');
+                btn.textContent = 'Imprimir Ticket';
+                btn.addEventListener('click', () => {
+                    const prods = productos.filter(p => p.subcuenta === i + 1);
+                    const data = {
+                        venta_id: payload.venta_id,
+                        folio: t.folio,
+                        fecha: new Date().toLocaleString(),
+                        productos: prods,
+                        propina: t.propina,
+                        total: t.total
+                    };
+                    localStorage.setItem('ticketData', JSON.stringify(data));
+                    window.open('ticket.html?print=1', '_blank');
+                });
+                div.appendChild(btn);
+            });
+        }
     </script>
 </body>
 </html>

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -278,6 +278,7 @@ async function verDetalles(id) {
                 const total = venta.total || info.productos.reduce((s, p) => s + parseFloat(p.subtotal), 0);
                 const payload = {
                     venta_id: parseInt(id),
+                    usuario_id: venta.usuario_id || 1,
                     fecha: venta.fecha || '',
                     productos: info.productos,
                     total


### PR DESCRIPTION
## Summary
- expose `usuario_id` in sales list
- add endpoints to store and reprint splitted tickets
- extend ticket page to handle subaccounts, store tips and print
- pass user id when opening ticket window

## Testing
- `php` not available so syntax was not checked

------
https://chatgpt.com/codex/tasks/task_e_68619a4060e4832b867eb3a7d2d91c48