### PR TITLE
Fix insumo flag after trigger

### DIFF
--- a/api/cocina/cambiar_estado_producto.php
+++ b/api/cocina/cambiar_estado_producto.php
@@ -56,14 +56,46 @@ if (!$upd->execute()) {
     $upd->close();
     error('Error al actualizar: ' . $upd->error);
 }
+
 $upd->close();
 
+// Tras cambiar a "listo" el trigger descuenta insumos. Ahora marcamos que
+// ya se descargaron si aún no estaba registrado.
 if ($nuevo_estado === 'listo') {
+    $check = $conn->prepare('SELECT insumos_descargados FROM venta_detalles WHERE id = ?');
+    if (!$check) {
+        error('Error al verificar insumos: ' . $conn->error);
+    }
+    $check->bind_param('i', $detalle_id);
+    $check->execute();
+    $res = $check->get_result();
+    if (!$res || $res->num_rows === 0) {
+        $check->close();
+        error('Detalle no encontrado');
+    }
+    $row = $res->fetch_assoc();
+    $check->close();
+
+    if ((int)$row['insumos_descargados'] === 0) {
+        $mk = $conn->prepare('UPDATE venta_detalles SET insumos_descargados = 1 WHERE id = ?');
+        if (!$mk) {
+            error('Error al preparar actualización de insumos: ' . $conn->error);
+        }
+        $mk->bind_param('i', $detalle_id);
+        if (!$mk->execute()) {
+            $mk->close();
+            error('Error al marcar insumos: ' . $mk->error);
+        }
+        $mk->close();
+    } else {
+        error('Los insumos ya se habían descargado');
+    }
+
     $log = $conn->prepare('INSERT INTO logs_accion (usuario_id, modulo, accion, referencia_id) VALUES (?, ?, ?, ?)');
     if ($log) {
         $usuario_id = $input['usuario_id'] ?? null;
-        $mod = 'cocina';
-        $accion = 'Producto marcado como listo';
+        $mod        = 'cocina';
+        $accion     = 'Producto marcado como listo';
         $log->bind_param('issi', $usuario_id, $mod, $accion, $detalle_id);
         $log->execute();
         $log->close();


### PR DESCRIPTION
## Summary
- update product state then mark `insumos_descargados` only from PHP
- guard against repeated updates

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b6185274832b8df2e4cef6012465