### PR TITLE
Actualizar descarga de insumos

### DIFF
--- a/api/cocina/cambiar_estado_producto.php
+++ b/api/cocina/cambiar_estado_producto.php
@@ -62,34 +62,10 @@ $upd->close();
 // Tras cambiar a "listo" el trigger descuenta insumos. Ahora marcamos que
 // ya se descargaron si aún no estaba registrado.
 if ($nuevo_estado === 'listo') {
-    $check = $conn->prepare('SELECT insumos_descargados FROM venta_detalles WHERE id = ?');
-    if (!$check) {
-        error('Error al verificar insumos: ' . $conn->error);
-    }
-    $check->bind_param('i', $detalle_id);
-    $check->execute();
-    $res = $check->get_result();
-    if (!$res || $res->num_rows === 0) {
-        $check->close();
-        error('Detalle no encontrado');
-    }
-    $row = $res->fetch_assoc();
-    $check->close();
-
-    if ((int)$row['insumos_descargados'] === 0) {
-        $mk = $conn->prepare('UPDATE venta_detalles SET insumos_descargados = 1 WHERE id = ?');
-        if (!$mk) {
-            error('Error al preparar actualización de insumos: ' . $conn->error);
-        }
-        $mk->bind_param('i', $detalle_id);
-        if (!$mk->execute()) {
-            $mk->close();
-            error('Error al marcar insumos: ' . $mk->error);
-        }
-        $mk->close();
-    } else {
-        error('Los insumos ya se habían descargado');
-    }
+    $stmt = $conn->prepare("UPDATE venta_detalles SET insumos_descargados = 1 WHERE id = ? AND insumos_descargados = 0");
+    $stmt->bind_param("i", $detalle_id);
+    $stmt->execute();
+    $stmt->close();
 
     $log = $conn->prepare('INSERT INTO logs_accion (usuario_id, modulo, accion, referencia_id) VALUES (?, ?, ?, ?)');
     if ($log) {


### PR DESCRIPTION
## Summary
- registra descarga de insumos en PHP cuando un producto pasa a `listo`

## Testing
- `php -l api/cocina/cambiar_estado_producto.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ba2eded0832bbae0377e3c840aa5