### PR TITLE
Fix subaccount products and delivery sale validation

### DIFF
--- a/api/ventas/detalle_venta.php
+++ b/api/ventas/detalle_venta.php
@@ -40,7 +40,7 @@ $datosVenta = $info->get_result()->fetch_assoc();
 $info->close();
 
 $stmt = $conn->prepare(
-    'SELECT p.nombre, vd.cantidad, vd.precio_unitario, ' .
+    'SELECT vd.producto_id, p.nombre, vd.cantidad, vd.precio_unitario, ' .
     '(vd.cantidad * vd.precio_unitario) AS subtotal ' .
     'FROM venta_detalles vd ' .
     'JOIN productos p ON vd.producto_id = p.id ' .

--- a/vistas/ventas/ticket.html
+++ b/vistas/ventas/ticket.html
@@ -197,17 +197,24 @@
             const info = JSON.parse(localStorage.getItem('ticketData'));
             const payload = { venta_id: info.venta_id, usuario_id: info.usuario_id || 1, subcuentas: [] };
             for (let i = 1; i <= numSub; i++) {
-                const prods = productos.filter(p => p.subcuenta === i)
-                    .map(p => ({
-                        producto_id: p.producto_id,
-                        cantidad: p.cantidad,
-                        precio_unitario: p.precio_unitario
-                    }))
-                    ;
+                const prods = productos
+                    .filter(p => p.subcuenta === i)
+                    .map(p => {
+                        if (!p.producto_id) {
+                            alert('Producto sin ID en subcuenta ' + i);
+                            throw new Error('Producto sin id');
+                        }
+                        return {
+                            producto_id: Number(p.producto_id),
+                            cantidad: p.cantidad,
+                            precio_unitario: p.precio_unitario
+                        };
+                    });
                 if (prods.length === 0) continue;
                 const prop = parseFloat(document.getElementById('propina' + i).value || 0);
                 payload.subcuentas.push({ productos: prods, propina: prop });
             }
+            console.log(JSON.stringify(payload));
             fetch('../../api/tickets/guardar_ticket.php', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -194,18 +194,24 @@ async function registrarVenta() {
     });
 
     if (tipo === 'mesa') {
-        if (isNaN(mesa_id) || !mesa_id || !isNaN(repartidor_id) && repartidor_id) {
+        if (isNaN(mesa_id) || !mesa_id) {
             alert('Selecciona una mesa válida');
             return;
         }
     } else {
-        if (isNaN(repartidor_id) || !repartidor_id || !isNaN(mesa_id) && mesa_id) {
+        if (isNaN(repartidor_id) || !repartidor_id) {
             alert('Selecciona un repartidor válido');
             return;
         }
     }
 
-    const payload = { tipo, mesa_id, repartidor_id, usuario_id, productos };
+    const payload = {
+        tipo,
+        mesa_id: tipo === 'mesa' ? mesa_id : null,
+        repartidor_id: tipo === 'domicilio' ? repartidor_id : null,
+        usuario_id,
+        productos
+    };
 
     try {
         const resp = await fetch('../../api/ventas/crear_venta.php', {


### PR DESCRIPTION
## Summary
- include `producto_id` when requesting sale details
- validate presence of `producto_id` before saving subaccounts
- log payload used for ticket requests
- fix delivery sale validations and only send relevant IDs

## Testing
- `php -l api/ventas/detalle_venta.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861ee103508832ba1f40b29a6ae3957