### PR TITLE
Fix delivery display and add ticket series selection

### DIFF
--- a/api/cocina/listar_pendientes.php
+++ b/api/cocina/listar_pendientes.php
@@ -2,13 +2,24 @@
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
-$query = "SELECT m.nombre AS mesa, p.nombre AS producto, d.cantidad, d.created_at AS hora, d.estatus_preparacion, d.id AS detalle_id
+$query = "SELECT
+            v.tipo_entrega,
+            CASE
+                WHEN v.tipo_entrega = 'mesa' THEN m.nombre
+                ELSE CONCAT('Domicilio - ', r.nombre)
+            END AS destino,
+            p.nombre AS producto,
+            d.cantidad,
+            d.created_at AS hora,
+            d.estatus_preparacion,
+            d.id AS detalle_id
           FROM venta_detalles d
           JOIN ventas v ON v.id = d.venta_id
-          JOIN mesas m ON m.id = v.mesa_id
+          LEFT JOIN mesas m ON m.id = v.mesa_id
+          LEFT JOIN repartidores r ON r.id = v.repartidor_id
           JOIN productos p ON p.id = d.producto_id
           WHERE d.estatus_preparacion IN ('pendiente','en preparación')
-          ORDER BY m.nombre, d.created_at";
+          ORDER BY d.created_at";
 $result = $conn->query($query);
 if (!$result) {
     error('Error al obtener productos: ' . $conn->error);
@@ -16,7 +27,8 @@ if (!$result) {
 $pendientes = [];
 while ($row = $result->fetch_assoc()) {
     $pendientes[] = [
-        'mesa'       => $row['mesa'],
+        'destino'    => $row['destino'],
+        'tipo'       => $row['tipo_entrega'],
         'producto'   => $row['producto'],
         'cantidad'   => (int) $row['cantidad'],
         'hora'       => $row['hora'],

--- a/api/repartidores/listar_entregas.php
+++ b/api/repartidores/listar_entregas.php
@@ -15,17 +15,22 @@ if (isset($_GET['repartidor_id'])) {
     }
 }
 
-if (!$repartidor_id) {
-    error('repartidor_id requerido');
+if ($repartidor_id) {
+    $stmt = $conn->prepare(
+        "SELECT id, fecha, total, estatus, entregado FROM ventas WHERE repartidor_id = ? AND estatus IN ('activa','cerrada') ORDER BY fecha DESC"
+    );
+    if (!$stmt) {
+        error('Error al preparar consulta: ' . $conn->error);
+    }
+    $stmt->bind_param('i', $repartidor_id);
+} else {
+    $stmt = $conn->prepare(
+        "SELECT id, fecha, total, estatus, entregado FROM ventas WHERE tipo_entrega = 'domicilio' AND estatus IN ('activa','cerrada') ORDER BY fecha DESC"
+    );
+    if (!$stmt) {
+        error('Error al preparar consulta: ' . $conn->error);
+    }
 }
-
-$stmt = $conn->prepare(
-    "SELECT id, fecha, total, estatus, entregado FROM ventas WHERE repartidor_id = ? AND estatus IN ('activa','cerrada') ORDER BY fecha DESC"
-);
-if (!$stmt) {
-    error('Error al preparar consulta: ' . $conn->error);
-}
-$stmt->bind_param('i', $repartidor_id);
 if (!$stmt->execute()) {
     $stmt->close();
     error('Error al ejecutar consulta: ' . $stmt->error);

--- a/api/tickets/listar_series.php
+++ b/api/tickets/listar_series.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$result = $conn->query("SELECT id, descripcion FROM catalogo_folios ORDER BY descripcion");
+if (!$result) {
+    error('Error al obtener series: ' . $conn->error);
+}
+$series = [];
+while ($row = $result->fetch_assoc()) {
+    $series[] = [
+        'id' => (int)$row['id'],
+        'descripcion' => $row['descripcion']
+    ];
+}
+
+success($series);
+?>

--- a/vistas/cocina/cocina.html
+++ b/vistas/cocina/cocina.html
@@ -10,7 +10,7 @@
     <table id="tabla-pendientes" border="1">
         <thead>
             <tr>
-                <th>Mesa</th>
+                <th>Destino</th>
                 <th>Producto</th>
                 <th>Cantidad</th>
                 <th>Hora</th>

--- a/vistas/cocina/cocina.js
+++ b/vistas/cocina/cocina.js
@@ -10,7 +10,7 @@ async function cargarPendientes() {
                 const inicioVisible = p.estatus === 'pendiente';
                 const listoVisible = p.estatus === 'en preparación';
                 tr.innerHTML = `
-                    <td>${p.mesa}</td>
+                    <td>${p.destino}</td>
                     <td>${p.producto}</td>
                     <td>${p.cantidad}</td>
                     <td>${p.hora}</td>

--- a/vistas/repartidores/repartos.js
+++ b/vistas/repartidores/repartos.js
@@ -2,9 +2,11 @@ const params = new URLSearchParams(location.search);
 const repartidorId = params.get('id');
 
 async function cargarEntregas() {
-    if (!repartidorId) return;
     try {
-        const resp = await fetch(`../../api/repartidores/listar_entregas.php?repartidor_id=${repartidorId}`);
+        const url = repartidorId
+            ? `../../api/repartidores/listar_entregas.php?repartidor_id=${repartidorId}`
+            : '../../api/repartidores/listar_entregas.php';
+        const resp = await fetch(url);
         const data = await resp.json();
         if (data.success) {
             const pendientesBody = document.querySelector('#tabla-pendientes tbody');

--- a/vistas/ventas/ticket.html
+++ b/vistas/ventas/ticket.html
@@ -53,6 +53,8 @@
             </thead>
             <tbody></tbody>
         </table>
+        <label for="serie_id">Serie:</label>
+        <select id="serie_id"></select>
         <button id="agregarSub">Agregar subcuenta</button>
         <button id="guardarSub">Guardar Tickets</button>
         <div id="subcuentas"></div>
@@ -104,9 +106,32 @@
                 document.getElementById('imprimir').style.display = 'block';
                 llenarTicket(datos);
             } else {
+                cargarSeries();
                 inicializarDividir(datos);
             }
         });
+
+        async function cargarSeries() {
+            try {
+                const resp = await fetch('../../api/tickets/listar_series.php');
+                const data = await resp.json();
+                if (data.success) {
+                    const sel = document.getElementById('serie_id');
+                    sel.innerHTML = '';
+                    data.resultado.forEach(s => {
+                        const opt = document.createElement('option');
+                        opt.value = s.id;
+                        opt.textContent = s.descripcion;
+                        sel.appendChild(opt);
+                    });
+                } else {
+                    alert(data.mensaje);
+                }
+            } catch (err) {
+                console.error(err);
+                alert('Error al cargar series');
+            }
+        }
 
         let productos = [];
         let numSub = 1;
@@ -195,7 +220,7 @@
 
         function guardarSubcuentas() {
             const info = JSON.parse(localStorage.getItem('ticketData'));
-            const payload = { venta_id: info.venta_id, usuario_id: info.usuario_id || 1, subcuentas: [] };
+            const payload = { venta_id: info.venta_id, usuario_id: info.usuario_id || 1, serie_id: parseInt(document.getElementById('serie_id').value), subcuentas: [] };
             for (let i = 1; i <= numSub; i++) {
                 const prods = productos
                     .filter(p => p.subcuenta === i)


### PR DESCRIPTION
## Summary
- show delivery orders in kitchen view
- allow listing deliveries without specifying repartidor
- enable selecting ticket series when generating tickets

## Testing
- `php -l api/cocina/listar_pendientes.php` *(fails: php not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6861f25f4018832ba91cf9b7d666eaa8