### PR TITLE
Implement improvements to insumos, tickets and reparto

### DIFF
--- a/api/insumos/actualizar_insumo.php
+++ b/api/insumos/actualizar_insumo.php
@@ -11,20 +11,21 @@ if (!$input || !isset($input['id'])) {
     error('Datos inválidos');
 }
 
-$id     = (int)$input['id'];
-$nombre = isset($input['nombre']) ? trim($input['nombre']) : '';
-$unidad = isset($input['unidad']) ? trim($input['unidad']) : '';
-$tipo   = isset($input['tipo_control']) ? trim($input['tipo_control']) : '';
+$id        = (int)$input['id'];
+$nombre    = isset($input['nombre']) ? trim($input['nombre']) : '';
+$unidad    = isset($input['unidad']) ? trim($input['unidad']) : '';
+$existencia = isset($input['existencia']) ? (float)$input['existencia'] : 0;
+$tipo      = isset($input['tipo_control']) ? trim($input['tipo_control']) : '';
 
 if ($nombre === '' || $unidad === '' || $tipo === '') {
     error('Datos incompletos');
 }
 
-$stmt = $conn->prepare('UPDATE insumos SET nombre = ?, unidad = ?, tipo_control = ? WHERE id = ?');
+$stmt = $conn->prepare('UPDATE insumos SET nombre = ?, unidad = ?, existencia = ?, tipo_control = ? WHERE id = ?');
 if (!$stmt) {
     error('Error al preparar actualización: ' . $conn->error);
 }
-$stmt->bind_param('sssi', $nombre, $unidad, $tipo, $id);
+$stmt->bind_param('ssdsi', $nombre, $unidad, $existencia, $tipo, $id);
 if (!$stmt->execute()) {
     $stmt->close();
     error('Error al actualizar insumo: ' . $stmt->error);

--- a/api/insumos/agregar_insumo.php
+++ b/api/insumos/agregar_insumo.php
@@ -11,19 +11,20 @@ if (!$input) {
     error('JSON inválido');
 }
 
-$nombre = isset($input['nombre']) ? trim($input['nombre']) : '';
-$unidad = isset($input['unidad']) ? trim($input['unidad']) : '';
-$tipo   = isset($input['tipo_control']) ? trim($input['tipo_control']) : '';
+$nombre      = isset($input['nombre']) ? trim($input['nombre']) : '';
+$unidad      = isset($input['unidad']) ? trim($input['unidad']) : '';
+$existencia  = isset($input['existencia']) ? (float)$input['existencia'] : 0;
+$tipo        = isset($input['tipo_control']) ? trim($input['tipo_control']) : '';
 
 if ($nombre === '' || $unidad === '' || $tipo === '') {
     error('Datos incompletos');
 }
 
-$stmt = $conn->prepare('INSERT INTO insumos (nombre, unidad, existencia, tipo_control) VALUES (?, ?, 0, ?)');
+$stmt = $conn->prepare('INSERT INTO insumos (nombre, unidad, existencia, tipo_control) VALUES (?, ?, ?, ?)');
 if (!$stmt) {
     error('Error al preparar inserción: ' . $conn->error);
 }
-$stmt->bind_param('sss', $nombre, $unidad, $tipo);
+$stmt->bind_param('ssds', $nombre, $unidad, $existencia, $tipo);
 if (!$stmt->execute()) {
     $stmt->close();
     error('Error al agregar insumo: ' . $stmt->error);

--- a/api/mesas/liberar_mesa_de_venta.php
+++ b/api/mesas/liberar_mesa_de_venta.php
@@ -1,0 +1,45 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$venta_id = $input['venta_id'] ?? null;
+if (!$venta_id) {
+    error('Datos inválidos');
+}
+$venta_id = (int)$venta_id;
+
+$stmt = $conn->prepare('SELECT mesa_id FROM ventas WHERE id = ?');
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('i', $venta_id);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al obtener venta: ' . $stmt->error);
+}
+$res = $stmt->get_result();
+$row = $res->fetch_assoc();
+$stmt->close();
+if (!$row || !$row['mesa_id']) {
+    success(true); // nothing to liberar
+}
+$mesa_id = (int)$row['mesa_id'];
+
+$upd = $conn->prepare("UPDATE mesas SET estado = 'libre' WHERE id = ?");
+if (!$upd) {
+    error('Error al preparar actualización: ' . $conn->error);
+}
+$upd->bind_param('i', $mesa_id);
+if (!$upd->execute()) {
+    $upd->close();
+    error('Error al liberar mesa: ' . $upd->error);
+}
+$upd->close();
+
+success(true);
+?>

--- a/api/repartidores/listar_entregas.php
+++ b/api/repartidores/listar_entregas.php
@@ -17,7 +17,7 @@ if (isset($_GET['repartidor_id'])) {
 
 if ($repartidor_id) {
     $stmt = $conn->prepare(
-        "SELECT id, fecha, total, estatus, entregado FROM ventas WHERE repartidor_id = ? AND estatus IN ('activa','cerrada') ORDER BY fecha DESC"
+        "SELECT v.id, v.fecha, v.total, v.estatus, v.entregado, r.nombre AS repartidor FROM ventas v JOIN repartidores r ON v.repartidor_id = r.id WHERE v.repartidor_id = ? AND v.estatus IN ('activa','cerrada') ORDER BY v.fecha DESC"
     );
     if (!$stmt) {
         error('Error al preparar consulta: ' . $conn->error);
@@ -25,7 +25,7 @@ if ($repartidor_id) {
     $stmt->bind_param('i', $repartidor_id);
 } else {
     $stmt = $conn->prepare(
-        "SELECT id, fecha, total, estatus, entregado FROM ventas WHERE tipo_entrega = 'domicilio' AND estatus IN ('activa','cerrada') ORDER BY fecha DESC"
+        "SELECT v.id, v.fecha, v.total, v.estatus, v.entregado, r.nombre AS repartidor FROM ventas v JOIN repartidores r ON v.repartidor_id = r.id WHERE v.tipo_entrega = 'domicilio' AND v.estatus IN ('activa','cerrada') ORDER BY v.fecha DESC"
     );
     if (!$stmt) {
         error('Error al preparar consulta: ' . $conn->error);
@@ -44,6 +44,7 @@ while ($row = $res->fetch_assoc()) {
         'total'     => (float)$row['total'],
         'estatus'   => $row['estatus'],
         'entregado' => (int)$row['entregado'],
+        'repartidor'=> $row['repartidor'] ?? '',
         'productos' => []
     ];
 }

--- a/api/repartidores/marcar_entregado.php
+++ b/api/repartidores/marcar_entregado.php
@@ -18,6 +18,23 @@ if (!$venta_id) {
     error('Datos inválidos');
 }
 
+// verificar que todos los productos estén listos
+$check = $conn->prepare("SELECT COUNT(*) AS faltan FROM venta_detalles WHERE venta_id = ? AND estatus_preparacion <> 'listo'");
+if (!$check) {
+    error('Error al preparar verificación: ' . $conn->error);
+}
+$check->bind_param('i', $venta_id);
+if (!$check->execute()) {
+    $check->close();
+    error('Error al ejecutar verificación: ' . $check->error);
+}
+$res = $check->get_result();
+$row = $res->fetch_assoc();
+$check->close();
+if ($row && (int)$row['faltan'] > 0) {
+    error('Aún hay productos sin preparar');
+}
+
 $stmt = $conn->prepare("UPDATE ventas SET estatus = 'cerrada', entregado = 1 WHERE id = ?");
 if (!$stmt) {
     error('Error al preparar actualización: ' . $conn->error);

--- a/api/tickets/guardar_ticket.php
+++ b/api/tickets/guardar_ticket.php
@@ -14,33 +14,8 @@ if (!$input || !isset($input['venta_id'], $input['usuario_id'], $input['subcuent
 $venta_id   = (int)$input['venta_id'];
 $usuario_id = (int)$input['usuario_id'];
 $subcuentas = $input['subcuentas'];
-$serie_id   = isset($input['serie_id']) ? (int)$input['serie_id'] : null;
 
 $conn->begin_transaction();
-
-$folioStmt = $serie_id
-    ? $conn->prepare('SELECT id, folio_actual FROM catalogo_folios WHERE id = ? FOR UPDATE')
-    : $conn->prepare('SELECT id, folio_actual FROM catalogo_folios LIMIT 1 FOR UPDATE');
-if (!$folioStmt) {
-    $conn->rollback();
-    error('Error al preparar folio: ' . $conn->error);
-}
-if ($serie_id) {
-    $folioStmt->bind_param('i', $serie_id);
-}
-if (!$folioStmt->execute()) {
-    $conn->rollback();
-    error('Error al obtener folio: ' . $folioStmt->error);
-}
-$resFolio = $folioStmt->get_result();
-$row = $resFolio->fetch_assoc();
-$folioStmt->close();
-if (!$row) {
-    $conn->rollback();
-    error('Serie de folios no encontrada');
-}
-$catalogo_id = (int)$row['id'];
-$folio_actual = (int)$row['folio_actual'];
 
 $insTicket  = $conn->prepare('INSERT INTO tickets (venta_id, folio, total, propina, usuario_id) VALUES (?, ?, ?, ?, ?)');
 $insDetalle = $conn->prepare('INSERT INTO ticket_detalles (ticket_id, producto_id, cantidad, precio_unitario) VALUES (?, ?, ?, ?)');
@@ -55,6 +30,31 @@ foreach ($subcuentas as $sub) {
         $conn->rollback();
         error('Subcuenta inválida');
     }
+    $serie = isset($sub['serie_id']) ? (int)$sub['serie_id'] : null;
+    $folioStmt = $serie
+        ? $conn->prepare('SELECT id, folio_actual FROM catalogo_folios WHERE id = ? FOR UPDATE')
+        : $conn->prepare('SELECT id, folio_actual FROM catalogo_folios LIMIT 1 FOR UPDATE');
+    if (!$folioStmt) {
+        $conn->rollback();
+        error('Error al preparar folio: ' . $conn->error);
+    }
+    if ($serie) {
+        $folioStmt->bind_param('i', $serie);
+    }
+    if (!$folioStmt->execute()) {
+        $conn->rollback();
+        error('Error al obtener folio: ' . $folioStmt->error);
+    }
+    $resFolio = $folioStmt->get_result();
+    $row = $resFolio->fetch_assoc();
+    $folioStmt->close();
+    if (!$row) {
+        $conn->rollback();
+        error('Serie de folios no encontrada');
+    }
+    $catalogo_id = (int)$row['id'];
+    $folio_actual = (int)$row['folio_actual'] + 1;
+
     $propina = isset($sub['propina']) ? (float)$sub['propina'] : 0;
     $total = 0;
     foreach ($sub['productos'] as $p) {
@@ -67,13 +67,14 @@ foreach ($subcuentas as $sub) {
         $total += $cantidad * $precio;
     }
     $total += $propina;
-    $folio_actual++;
+
     $insTicket->bind_param('iiddi', $venta_id, $folio_actual, $total, $propina, $usuario_id);
     if (!$insTicket->execute()) {
         $conn->rollback();
         error('Error al guardar ticket: ' . $insTicket->error);
     }
     $ticket_id = $insTicket->insert_id;
+
     foreach ($sub['productos'] as $p) {
         $producto_id     = (int)$p['producto_id'];
         $cantidad        = (int)$p['cantidad'];
@@ -84,23 +85,25 @@ foreach ($subcuentas as $sub) {
             error('Error al guardar detalle: ' . $insDetalle->error);
         }
     }
+
+    $updFolio = $conn->prepare('UPDATE catalogo_folios SET folio_actual = ? WHERE id = ?');
+    if (!$updFolio) {
+        $conn->rollback();
+        error('Error al preparar actualización de folio: ' . $conn->error);
+    }
+    $updFolio->bind_param('ii', $folio_actual, $catalogo_id);
+    if (!$updFolio->execute()) {
+        $conn->rollback();
+        error('Error al actualizar folio: ' . $updFolio->error);
+    }
+    $updFolio->close();
+
     $ticketsResp[] = [
         'ticket_id' => $ticket_id,
         'folio'     => $folio_actual,
         'total'     => $total,
         'propina'   => $propina
     ];
-}
-
-$updFolio = $conn->prepare('UPDATE catalogo_folios SET folio_actual = ? WHERE id = ?');
-if (!$updFolio) {
-    $conn->rollback();
-    error('Error al preparar actualización de folio: ' . $conn->error);
-}
-$updFolio->bind_param('ii', $folio_actual, $catalogo_id);
-if (!$updFolio->execute()) {
-    $conn->rollback();
-    error('Error al actualizar folio: ' . $updFolio->error);
 }
 
 $cerrar = $conn->prepare("UPDATE ventas SET estatus = 'cerrada' WHERE id = ?");

--- a/vistas/insumos/insumos.js
+++ b/vistas/insumos/insumos.js
@@ -157,13 +157,14 @@ async function nuevoInsumo() {
     if (!nombre) return;
     const unidad = prompt('Unidad:');
     if (!unidad) return;
+    const existencia = parseFloat(prompt('Existencia inicial:', '0')) || 0;
     const tipo = prompt('Tipo de control (por_receta, unidad_completa, uso_general, no_controlado, desempaquetado):', 'por_receta');
     if (!tipo) return;
     try {
         const resp = await fetch('../../api/insumos/agregar_insumo.php', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ nombre, unidad, tipo_control: tipo })
+            body: JSON.stringify({ nombre, unidad, existencia, tipo_control: tipo })
         });
         const data = await resp.json();
         if (data.success) {
@@ -185,13 +186,14 @@ async function editarInsumo(id) {
     if (!nombre) return;
     const unidad = prompt('Unidad:', ins.unidad);
     if (!unidad) return;
+    const existencia = parseFloat(prompt('Existencia:', ins.existencia)) || 0;
     const tipo = prompt('Tipo de control:', ins.tipo_control);
     if (!tipo) return;
     try {
         const resp = await fetch('../../api/insumos/actualizar_insumo.php', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ id: parseInt(id), nombre, unidad, tipo_control: tipo })
+            body: JSON.stringify({ id: parseInt(id), nombre, unidad, existencia, tipo_control: tipo })
         });
         const data = await resp.json();
         if (data.success) {

--- a/vistas/repartidores/repartos.html
+++ b/vistas/repartidores/repartos.html
@@ -14,6 +14,7 @@
                 <th>ID</th>
                 <th>Fecha</th>
                 <th>Total</th>
+                <th>Repartidor</th>
                 <th>Productos</th>
                 <th>Acciones</th>
             </tr>
@@ -28,6 +29,7 @@
                 <th>ID</th>
                 <th>Fecha</th>
                 <th>Total</th>
+                <th>Repartidor</th>
                 <th>Productos</th>
             </tr>
         </thead>

--- a/vistas/repartidores/repartos.js
+++ b/vistas/repartidores/repartos.js
@@ -20,6 +20,7 @@ async function cargarEntregas() {
                     <td>${v.id}</td>
                     <td>${v.fecha}</td>
                     <td>${v.total}</td>
+                    <td>${v.repartidor}</td>
                     <td>${productos}</td>
                 `;
                 if (v.estatus === 'activa' && !v.entregado) {

--- a/vistas/ventas/ticket.html
+++ b/vistas/ventas/ticket.html
@@ -53,8 +53,6 @@
             </thead>
             <tbody></tbody>
         </table>
-        <label for="serie_id">Serie:</label>
-        <select id="serie_id"></select>
         <button id="agregarSub">Agregar subcuenta</button>
         <button id="guardarSub">Guardar Tickets</button>
         <div id="subcuentas"></div>
@@ -105,25 +103,20 @@
             if (imprimir) {
                 document.getElementById('imprimir').style.display = 'block';
                 llenarTicket(datos);
+                liberarMesa(datos.venta_id);
             } else {
                 cargarSeries();
                 inicializarDividir(datos);
             }
         });
 
+        let series = [];
         async function cargarSeries() {
             try {
                 const resp = await fetch('../../api/tickets/listar_series.php');
                 const data = await resp.json();
                 if (data.success) {
-                    const sel = document.getElementById('serie_id');
-                    sel.innerHTML = '';
-                    data.resultado.forEach(s => {
-                        const opt = document.createElement('option');
-                        opt.value = s.id;
-                        opt.textContent = s.descripcion;
-                        sel.appendChild(opt);
-                    });
+                    series = data.resultado;
                 } else {
                     alert(data.mensaje);
                 }
@@ -201,9 +194,17 @@
                     html += `<tr><td>${p.nombre}</td><td>${p.cantidad} x ${p.precio_unitario}</td></tr>`;
                 });
                 html += '</tbody></table>';
-                html += `Propina: <input type="number" step="0.01" id="propina${i}" value="0"><div id="tot${i}"></div>`;
+                html += `Serie: <select id="serie${i}" class="serie"></select>`;
+                html += ` Propina: <input type="number" step="0.01" id="propina${i}" value="0"><div id="tot${i}"></div>`;
                 div.innerHTML = html;
                 cont.appendChild(div);
+                const sel = div.querySelector('select.serie');
+                series.forEach(s => {
+                    const opt = document.createElement('option');
+                    opt.value = s.id;
+                    opt.textContent = s.descripcion;
+                    sel.appendChild(opt);
+                });
             }
             mostrarTotal();
         }
@@ -220,7 +221,7 @@
 
         function guardarSubcuentas() {
             const info = JSON.parse(localStorage.getItem('ticketData'));
-            const payload = { venta_id: info.venta_id, usuario_id: info.usuario_id || 1, serie_id: parseInt(document.getElementById('serie_id').value), subcuentas: [] };
+            const payload = { venta_id: info.venta_id, usuario_id: info.usuario_id || 1, subcuentas: [] };
             for (let i = 1; i <= numSub; i++) {
                 const prods = productos
                     .filter(p => p.subcuenta === i)
@@ -237,7 +238,9 @@
                     });
                 if (prods.length === 0) continue;
                 const prop = parseFloat(document.getElementById('propina' + i).value || 0);
-                payload.subcuentas.push({ productos: prods, propina: prop });
+                const serieSel = document.getElementById('serie' + i);
+                const serie = serieSel ? parseInt(serieSel.value) : null;
+                payload.subcuentas.push({ productos: prods, propina: prop, serie_id: serie });
             }
             console.log(JSON.stringify(payload));
             fetch('../../api/tickets/guardar_ticket.php', {
@@ -279,6 +282,19 @@
                 });
                 div.appendChild(btn);
             });
+        }
+
+        async function liberarMesa(ventaId) {
+            if (!ventaId) return;
+            try {
+                await fetch('../../api/mesas/liberar_mesa_de_venta.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ venta_id: parseInt(ventaId) })
+                });
+            } catch (e) {
+                console.error('Error al liberar mesa');
+            }
         }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- allow setting existence when adding or editing an insumo
- let each sub ticket choose its own series and free the table after printing
- include deliverer name in reparto lists and validate kitchen status before marking delivered
- provide endpoint to release table by venta

## Testing
- `php -l api/insumos/agregar_insumo.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6861f58b36b0832b93c71110845c6f14