### PR TITLE
Implement ticket request flow

### DIFF
--- a/vistas/mesas/mesas.js
+++ b/vistas/mesas/mesas.js
@@ -39,6 +39,7 @@ async function cargarMesas() {
                     <button class="detalles" data-venta="${m.venta_id || ''}" data-mesa="${m.id}" data-nombre="${m.nombre}" data-estado="${m.estado}" data-mesero="${m.mesero_id || ''}">Detalles</button>
                     <button class="dividir" data-id="${m.id}">Dividir</button>
                     <button class="cambiar" data-id="${m.id}">Cambiar estado</button>
+                    <button class="ticket" data-mesa="${m.id}" data-nombre="${m.nombre}" data-venta="${m.venta_id || ''}">Solicitar ticket</button>
                 `;
                 tablero.appendChild(card);
             });
@@ -59,6 +60,9 @@ async function cargarMesas() {
                         btn.dataset.mesero
                     )
                 );
+            });
+            tablero.querySelectorAll('button.ticket').forEach(btn => {
+                btn.addEventListener('click', () => solicitarTicket(btn.dataset.mesa, btn.dataset.nombre, btn.dataset.venta));
             });
         } else {
             alert(data.mensaje);
@@ -92,6 +96,19 @@ async function cambiarEstado(id, estado) {
     } catch (err) {
         console.error(err);
         alert('Error al cambiar estado');
+    }
+}
+
+function solicitarTicket(mesaId, nombre, ventaId) {
+    if (!ventaId) {
+        alert('La mesa no tiene venta activa');
+        return;
+    }
+    let reqs = JSON.parse(localStorage.getItem('ticketRequests') || '[]');
+    if (!reqs.find(r => parseInt(r.mesa_id) === parseInt(mesaId))) {
+        reqs.push({ mesa_id: parseInt(mesaId), nombre, venta_id: parseInt(ventaId) });
+        localStorage.setItem('ticketRequests', JSON.stringify(reqs));
+        alert('Ticket solicitado');
     }
 }
 

--- a/vistas/ventas/ticket.html
+++ b/vistas/ventas/ticket.html
@@ -296,6 +296,14 @@
                 console.error('Error al liberar mesa');
             }
         }
+
+        window.addEventListener('beforeunload', () => {
+            const params = new URLSearchParams(window.location.search);
+            const mesaId = params.get('mesa');
+            if (window.opener && window.opener.ticketPrinted && mesaId) {
+                window.opener.ticketPrinted(parseInt(mesaId));
+            }
+        });
     </script>
 </body>
 

--- a/vistas/ventas/ventas.html
+++ b/vistas/ventas/ventas.html
@@ -67,6 +67,17 @@
         <tbody></tbody>
     </table>
 
+    <h2>Solicitudes de Ticket</h2>
+    <table id="solicitudes" border="1">
+        <thead>
+            <tr>
+                <th>Mesa</th>
+                <th>Imprimir</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
     <div id="modal-detalles" style="display:none;"></div>
 
     <script src="ventas.js"></script>


### PR DESCRIPTION
## Summary
- label deliveries as "Entregado"/"No entregado" in sales history
- show ticket requests in *Ventas*
- allow ticket requests from *Mesas*
- notify sales view when ticket window closes

## Testing
- `php -l api/ventas/listar_ventas.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629390f4cc832bb9fadf16a914056d