### PR TITLE
Add details modal in deliveries and update price logic

### DIFF
--- a/vistas/repartidores/repartos.html
+++ b/vistas/repartidores/repartos.html
@@ -31,10 +31,13 @@
                 <th>Total</th>
                 <th>Repartidor</th>
                 <th>Productos</th>
+                <th>Ver detalles</th>
             </tr>
         </thead>
         <tbody></tbody>
     </table>
+
+    <div id="modal-detalles" style="display:none;"></div>
 
     <script src="repartos.js"></script>
 </body>

--- a/vistas/repartidores/repartos.js
+++ b/vistas/repartidores/repartos.js
@@ -32,6 +32,12 @@ async function cargarEntregas() {
                     row.appendChild(accionTd);
                     pendientesBody.appendChild(row);
                 } else {
+                    const btn = document.createElement('button');
+                    btn.textContent = 'Ver detalle';
+                    btn.addEventListener('click', () => mostrarDetalle(v));
+                    const detTd = document.createElement('td');
+                    detTd.appendChild(btn);
+                    row.appendChild(detTd);
                     entregadasBody.appendChild(row);
                 }
             });
@@ -61,6 +67,21 @@ async function marcarEntregada(id) {
         console.error(err);
         alert('Error al actualizar');
     }
+}
+
+function mostrarDetalle(info) {
+    const contenedor = document.getElementById('modal-detalles');
+    let html = '<h3>Productos entregados</h3><ul>';
+    info.productos.forEach(p => {
+        const sub = p.cantidad * p.precio_unitario;
+        html += `<li>${p.nombre} - ${p.cantidad} x ${p.precio_unitario} = ${sub}</li>`;
+    });
+    html += `</ul><p>Total: ${info.total}</p><button id="cerrarDetalle">Cerrar</button>`;
+    contenedor.innerHTML = html;
+    contenedor.style.display = 'block';
+    document.getElementById('cerrarDetalle').addEventListener('click', () => {
+        contenedor.style.display = 'none';
+    });
 }
 
 document.addEventListener('DOMContentLoaded', cargarEntregas);

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -134,14 +134,16 @@ function actualizarPrecio(select) {
     const cantidadInput = row.querySelector('.cantidad');
     const productoId = select.value;
     const producto = productos.find(p => parseInt(p.id) === parseInt(productoId));
-    console.log(productoId, producto);
     if (producto) {
-        precioInput.value = parseFloat(producto.precio).toFixed(2);
+        const cant = parseInt(cantidadInput.value) || 1;
+        precioInput.dataset.unitario = producto.precio;
+        precioInput.value = (cant * parseFloat(producto.precio)).toFixed(2);
         if (!cantidadInput.value || parseInt(cantidadInput.value) === 0) {
             cantidadInput.value = 1;
         }
     } else {
         precioInput.value = '';
+        delete precioInput.dataset.unitario;
     }
 }
 
@@ -163,7 +165,10 @@ function agregarFilaProducto() {
     const tbody = document.querySelector('#productos tbody');
     const base = tbody.querySelector('tr');
     const nueva = base.cloneNode(true);
-    nueva.querySelectorAll('input').forEach(inp => inp.value = '');
+    nueva.querySelectorAll('input').forEach(inp => {
+        inp.value = '';
+        if (inp.classList.contains('precio')) delete inp.dataset.unitario;
+    });
     tbody.appendChild(nueva);
     const select = nueva.querySelector('.producto');
     select.innerHTML = '<option value="">--Selecciona--</option>';
@@ -191,7 +196,8 @@ async function registrarVenta() {
         const producto_id = parseInt(fila.querySelector('.producto').value);
         const cantidad = parseInt(fila.querySelector('.cantidad').value);
         if (!isNaN(producto_id) && !isNaN(cantidad)) {
-            const precio_unitario = parseFloat(fila.querySelector('.precio').value);
+            const precioInput = fila.querySelector('.precio');
+            const precio_unitario = parseFloat(precioInput.dataset.unitario || 0);
             if (precio_unitario > 0) {
                 productos.push({ producto_id, cantidad, precio_unitario });
             }


### PR DESCRIPTION
## Summary
- show product details for delivered orders
- compute row price based on quantity in sales page

## Testing
- `node --check vistas/ventas/ventas.js`
- `node --check vistas/repartidores/repartos.js`


------
https://chatgpt.com/codex/tasks/task_e_68629671d578832bb0a2527d7b4e1ca6