### PR TITLE
Cambiar flujo de impresión de tickets

### DIFF
--- a/vistas/ventas/ticket.html
+++ b/vistas/ventas/ticket.html
@@ -253,7 +253,7 @@
                     if (d.success) {
                         ticketsGuardados = d.resultado.tickets || [];
                         alert('Tickets guardados');
-                        mostrarBotonesImprimir(payload);
+                        mostrarBotonesImprimir(payload, true);
                     } else {
                         alert(d.mensaje);
                     }
@@ -261,26 +261,32 @@
                 .catch(() => alert('Error al guardar'));
         }
 
-        function mostrarBotonesImprimir(payload) {
+        function mostrarBotonesImprimir(payload, auto) {
+            const params = new URLSearchParams(window.location.search);
+            const mesaId = params.get('mesa');
             ticketsGuardados.forEach((t, i) => {
-                const div = document.getElementById('sub' + (i + 1));
-                if (!div) return;
-                const btn = document.createElement('button');
-                btn.textContent = 'Imprimir Ticket';
-                btn.addEventListener('click', () => {
-                    const prods = productos.filter(p => p.subcuenta === i + 1);
-                    const data = {
-                        venta_id: payload.venta_id,
-                        folio: t.folio,
-                        fecha: new Date().toLocaleString(),
-                        productos: prods,
-                        propina: t.propina,
-                        total: t.total
-                    };
+                const prods = productos.filter(p => p.subcuenta === i + 1);
+                const data = {
+                    venta_id: payload.venta_id,
+                    folio: t.folio,
+                    fecha: new Date().toLocaleString(),
+                    productos: prods,
+                    propina: t.propina,
+                    total: t.total
+                };
+                const url = mesaId ? `ticket.html?print=1&mesa=${mesaId}` : 'ticket.html?print=1';
+                const imprimir = () => {
                     localStorage.setItem('ticketData', JSON.stringify(data));
-                    window.open('ticket.html?print=1', '_blank');
-                });
-                div.appendChild(btn);
+                    window.open(url, '_blank');
+                };
+                const div = document.getElementById('sub' + (i + 1));
+                if (div) {
+                    const btn = document.createElement('button');
+                    btn.textContent = 'Imprimir Ticket';
+                    btn.addEventListener('click', imprimir);
+                    div.appendChild(btn);
+                }
+                if (auto) imprimir();
             });
         }
 
@@ -296,6 +302,12 @@
                 console.error('Error al liberar mesa');
             }
         }
+
+        window.ticketPrinted = function (mesaId) {
+            if (window.opener && window.opener.ticketPrinted) {
+                window.opener.ticketPrinted(mesaId);
+            }
+        };
 
         window.addEventListener('beforeunload', () => {
             const params = new URLSearchParams(window.location.search);

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -301,8 +301,8 @@ async function verDetalles(id) {
                     total
                 };
                 localStorage.setItem('ticketData', JSON.stringify(payload));
-                const mesaId = venta.mesa_id ? `&mesa=${venta.mesa_id}` : '';
-                window.open(`ticket.html?print=1${mesaId}&venta=${id}`, '_blank');
+                const mesaParam = venta.mesa_id ? `&mesa=${venta.mesa_id}` : '';
+                window.open(`ticket.html?venta=${id}${mesaParam}`, '_blank');
             });
         } else {
             alert(data.mensaje);
@@ -348,7 +348,7 @@ async function imprimirSolicitud(mesaId, ventaId) {
                 total
             };
             localStorage.setItem('ticketData', JSON.stringify(payload));
-            const w = window.open(`ticket.html?print=1&mesa=${mesaId}&venta=${ventaId}`, '_blank');
+            const w = window.open(`ticket.html?venta=${ventaId}&mesa=${mesaId}`, '_blank');
             if (w) w.focus();
         } else {
             alert(data.mensaje);


### PR DESCRIPTION
## Summary
- actualizar funciones de impresión para abrir la vista `ticket.html` sin imprimir de inmediato
- imprimir los tickets automáticamente después de presionar **Guardar Tickets** y propagar evento al opener

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629b92b6cc832bb261d2e72d99303c