### PR TITLE
Implement stock checks and editable sales

### DIFF
--- a/api/ventas/detalle_venta.php
+++ b/api/ventas/detalle_venta.php
@@ -40,7 +40,7 @@ $datosVenta = $info->get_result()->fetch_assoc();
 $info->close();
 
 $stmt = $conn->prepare(
-    'SELECT vd.producto_id, p.nombre, vd.cantidad, vd.precio_unitario, ' .
+    'SELECT vd.id, vd.producto_id, p.nombre, vd.cantidad, vd.precio_unitario, ' .
     '(vd.cantidad * vd.precio_unitario) AS subtotal ' .
     'FROM venta_detalles vd ' .
     'JOIN productos p ON vd.producto_id = p.id ' .


### PR DESCRIPTION
## Summary
- check product quantities against inventory before saving sales
- return detail ids for editing
- allow editing sales from the detail modal

## Testing
- `node --check vistas/ventas/ventas.js`


------
https://chatgpt.com/codex/tasks/task_e_68629d65e904832bb529f1558b89290b