### PR TITLE
Restrict sale quantities and fix deletion condition

### DIFF
--- a/api/mesas/eliminar_producto_venta.php
+++ b/api/mesas/eliminar_producto_venta.php
@@ -29,7 +29,7 @@ if (!$detalle) {
     error('Detalle no encontrado');
 }
 
-if (in_array($detalle['estatus_preparacion'], ['en preparación', 'entregado'])) {
+if ($detalle['estatus_preparacion'] === 'entregado') {
     error('No se puede eliminar el producto');
 }
 

--- a/api/ventas/detalle_venta.php
+++ b/api/ventas/detalle_venta.php
@@ -41,7 +41,7 @@ $info->close();
 
 $stmt = $conn->prepare(
     'SELECT vd.id, vd.producto_id, p.nombre, vd.cantidad, vd.precio_unitario, ' .
-    '(vd.cantidad * vd.precio_unitario) AS subtotal ' .
+    '(vd.cantidad * vd.precio_unitario) AS subtotal, vd.estatus_preparacion ' .
     'FROM venta_detalles vd ' .
     'JOIN productos p ON vd.producto_id = p.id ' .
     'WHERE vd.venta_id = ?'


### PR DESCRIPTION
## Summary
- prevent deletion of delivered items only
- expose preparation status in `detalle_venta.php`
- add inventory checks to sales screen
- disable "Eliminar" button for delivered items in details

## Testing
- `php` not available, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_6862a3763554832b8dce7117eb00a6c7