### PR TITLE
Fix kitchen inventory updates and product pricing

### DIFF
--- a/vistas/mesas/mesas.js
+++ b/vistas/mesas/mesas.js
@@ -366,8 +366,8 @@ async function agregarProductoVenta(ventaId, mesaId, estado) {
     const select = document.getElementById('nuevo_producto');
     const cantidad = parseInt(document.getElementById('nuevo_cantidad').value);
     const productoId = parseInt(select.value);
-    const prod = productos.find(p => p.id === productoId);
-    const precio = prod ? parseFloat(prod.precio) : 0;
+    const selected = select.selectedOptions[0];
+    const precio = selected ? parseFloat(selected.dataset.precio || '0') : 0;
 
     if (isNaN(productoId) || isNaN(cantidad) || cantidad <= 0) {
         alert('Producto o cantidad inválida');


### PR DESCRIPTION
## Summary
- move ingredient discount to start of preparation and adjust logs
- reduce product stock when marking item as ready
- use option's price when adding items from the tables view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862a9459458832ba9389ddb4a593826