### PR TITLE
Fix inventory update from PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ Para mejorar la integridad y rendimiento del sistema, se delegaron varias operac
 
 ###  STORED PROCEDURES
 
-- `sp_descuento_insumos_por_detalle(detalle_id)`  
-  Aplica receta y descuenta insumos asociados.
+- ~~`sp_descuento_insumos_por_detalle(detalle_id)`~~
+  La lógica de descuento de insumos se implementó directamente en PHP para
+  mayor transparencia.
 
-- `sp_cerrar_corte(usuario_id)`  
+- `sp_cerrar_corte(usuario_id)`
   Calcula el total de ventas cerradas desde el último corte de caja y actualiza `corte_caja`.
 
 ###  VISTAS


### PR DESCRIPTION
## Summary
- remove dependency on `sp_descuento_insumos_por_detalle`
- deduct ingredients directly from PHP when starting products
- when delivering from tables view, also update product and ingredient stock
- document that the SP is now obsolete

## Testing
- `php -l api/cocina/cambiar_estado_producto.php` *(fails: command not found)*
- `php -l api/mesas/marcar_entregado.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b2c4f3d8832ba5a6102c55b711d1