### PR TITLE
Fix deduction of recipe ingredients when marking product ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Para mejorar la integridad y rendimiento del sistema, se delegaron varias operac
 | Archivo PHP | Reemplazo sugerido |
 |-------------|--------------------|
 | `crear_venta.php` | Delega descuento de insumos al trigger |
-| `cambiar_estado_producto.php` | Ya no actualiza inventario, solo estado |
+| `cambiar_estado_producto.php` | Descuenta insumos y actualiza estado sin triggers |
 | `cerrar_corte.php` | Solo llama a `CALL sp_cerrar_corte(usuario_id)` |
 | `listar_ventas.php` | Usa vista `vw_ventas_detalladas` |
 | `listar_insumos_consumidos.php` | Usa vista `vw_consumo_insumos` |

--- a/api/mesas/marcar_entregado.php
+++ b/api/mesas/marcar_entregado.php
@@ -2,6 +2,9 @@
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
+// Toda la lógica de descuento de insumos se maneja en este archivo,
+// sin apoyarse en triggers ni procedimientos almacenados.
+
 function descontarInsumos($productoId, $cantidad)
 {
     global $conn;
@@ -69,6 +72,13 @@ $upd->close();
 if ((int)$detalle['insumos_descargados'] === 0) {
     descontarInsumos((int)$detalle['producto_id'], (int)$detalle['cantidad']);
     $mark = $conn->prepare('UPDATE venta_detalles SET insumos_descargados = 1 WHERE id = ?');
+    if ($mark) {
+        $mark->bind_param('i', $detalle_id);
+        $mark->execute();
+        $mark->close();
+    }
+} else {
+    $mark = $conn->prepare('UPDATE venta_detalles SET insumos_descargados = 1 WHERE id = ? AND insumos_descargados = 0');
     if ($mark) {
         $mark->bind_param('i', $detalle_id);
         $mark->execute();


### PR DESCRIPTION
## Summary
- update README to reflect PHP-based stock discount
- rework `cambiar_estado_producto.php` to subtract ingredients only when product is marked `listo`
- ensure `marcar_entregado.php` behaves the same

## Testing
- `php -l api/cocina/cambiar_estado_producto.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b77de444832bbafca73cd93adfb4