### PR TITLE
Implement PHP-based inventory deduction

### DIFF
--- a/api/cocina/cambiar_estado_producto.php
+++ b/api/cocina/cambiar_estado_producto.php
@@ -1,32 +1,8 @@
 <?php
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
+require_once __DIR__ . '/../../utils/inventario.php';
 
-function descontarInsumos($productoId, $cantidad)
-{
-    global $conn;
-    $q = $conn->prepare('SELECT insumo_id, cantidad FROM recetas WHERE producto_id = ?');
-    if (!$q) {
-        return;
-    }
-    $q->bind_param('i', $productoId);
-    if (!$q->execute()) {
-        $q->close();
-        return;
-    }
-    $res = $q->get_result();
-    while ($row = $res->fetch_assoc()) {
-        $insumo = (int)$row['insumo_id'];
-        $cant   = (float)$row['cantidad'] * $cantidad;
-        $up = $conn->prepare('UPDATE insumos SET existencia = existencia - ? WHERE id = ?');
-        if ($up) {
-            $up->bind_param('di', $cant, $insumo);
-            $up->execute();
-            $up->close();
-        }
-    }
-    $q->close();
-}
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     error('Método no permitido');

--- a/api/mesas/marcar_entregado.php
+++ b/api/mesas/marcar_entregado.php
@@ -1,33 +1,10 @@
 <?php
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
+require_once __DIR__ . '/../../utils/inventario.php';
 
 // Toda la lógica de descuento de insumos se maneja en este archivo,
 // sin apoyarse en triggers ni procedimientos almacenados.
-
-function descontarInsumos($productoId, $cantidad)
-{
-    global $conn;
-    $q = $conn->prepare('SELECT insumo_id, cantidad FROM recetas WHERE producto_id = ?');
-    if (!$q) {
-        return;
-    }
-    $q->bind_param('i', $productoId);
-    if ($q->execute()) {
-        $res = $q->get_result();
-        while ($row = $res->fetch_assoc()) {
-            $insumo = (int)$row['insumo_id'];
-            $cant   = (float)$row['cantidad'] * $cantidad;
-            $up = $conn->prepare('UPDATE insumos SET existencia = existencia - ? WHERE id = ?');
-            if ($up) {
-                $up->bind_param('di', $cant, $insumo);
-                $up->execute();
-                $up->close();
-            }
-        }
-    }
-    $q->close();
-}
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     error('Método no permitido');

--- a/utils/inventario.php
+++ b/utils/inventario.php
@@ -1,0 +1,27 @@
+<?php
+function descontarInsumos(int $productoId, int $cantidad): void
+{
+    global $conn;
+    $q = $conn->prepare('SELECT insumo_id, cantidad FROM recetas WHERE producto_id = ?');
+    if (!$q) {
+        return;
+    }
+    $q->bind_param('i', $productoId);
+    if (!$q->execute()) {
+        $q->close();
+        return;
+    }
+    $res = $q->get_result();
+    while ($row = $res->fetch_assoc()) {
+        $insumo = (int)$row['insumo_id'];
+        $descontar = (float)$row['cantidad'] * $cantidad;
+        $up = $conn->prepare('UPDATE insumos SET existencia = existencia - ? WHERE id = ?');
+        if ($up) {
+            $up->bind_param('di', $descontar, $insumo);
+            $up->execute();
+            $up->close();
+        }
+    }
+    $q->close();
+}
+?>


### PR DESCRIPTION
## Summary
- centralize inventory discount logic in `utils/inventario.php`
- reuse new helper in `cocina/cambiar_estado_producto.php` and `mesas/marcar_entregado.php`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bce06910832ba8627a93d9283f3a