### PR TITLE
Clarify removal of inventory procedure

### DIFF
--- a/api/cocina/cambiar_estado_producto.php
+++ b/api/cocina/cambiar_estado_producto.php
@@ -3,6 +3,11 @@ require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 require_once __DIR__ . '/../../utils/inventario.php';
 
+// Antes se invocaba al procedimiento almacenado
+// `sp_descuento_insumos_por_detalle` para rebajar inventario.
+// Esa función fue eliminada y el descuento se hace aquí
+// mediante `descontarInsumos()`.
+
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     error('Método no permitido');


### PR DESCRIPTION
## Summary
- clarify that `cambiar_estado_producto.php` no longer calls a stored procedure

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c94e93a8832b88906fa74169c681