### PR TITLE
Implementar registro de entradas de insumos

### DIFF
--- a/api/insumos/crear_entrada.php
+++ b/api/insumos/crear_entrada.php
@@ -12,28 +12,59 @@ if (!$input) {
 }
 
 $proveedor_id = isset($input['proveedor_id']) ? (int)$input['proveedor_id'] : 0;
-$productos = isset($input['productos']) && is_array($input['productos']) ? $input['productos'] : null;
+$usuario_id   = isset($input['usuario_id']) ? (int)$input['usuario_id'] : 0;
+$productos    = isset($input['productos']) && is_array($input['productos']) ? $input['productos'] : null;
 
-if (!$proveedor_id || !$productos) {
+if (!$proveedor_id || !$usuario_id || !$productos) {
     error('Datos incompletos');
 }
 
 $total = 0;
+$ids = [];
+$check = $conn->prepare('SELECT id FROM insumos WHERE id = ?');
+if (!$check) {
+    error('Error al preparar verificación: ' . $conn->error);
+}
 foreach ($productos as $p) {
     if (!isset($p['insumo_id'], $p['cantidad'], $p['precio_unitario'])) {
+        $check->close();
         error('Formato de producto incorrecto');
     }
-    $total += $p['cantidad'] * $p['precio_unitario'];
+    $insumo_id = (int)$p['insumo_id'];
+    $cantidad  = (float)$p['cantidad'];
+    $precio    = (float)$p['precio_unitario'];
+
+    if ($cantidad <= 0 || $precio <= 0) {
+        $check->close();
+        error('Cantidad y precio deben ser mayores a cero');
+    }
+    if (in_array($insumo_id, $ids)) {
+        $check->close();
+        error('No repitas insumo en la misma entrada');
+    }
+    $check->bind_param('i', $insumo_id);
+    if (!$check->execute()) {
+        $check->close();
+        error('Error al verificar insumo: ' . $check->error);
+    }
+    $res = $check->get_result();
+    if ($res->num_rows === 0) {
+        $check->close();
+        error('Insumo no encontrado: ' . $insumo_id);
+    }
+    $ids[] = $insumo_id;
+    $total += $cantidad * $precio;
 }
+$check->close();
 
 $conn->begin_transaction();
 
-$stmtEntrada = $conn->prepare('INSERT INTO entradas_insumo (proveedor_id, total) VALUES (?, ?)');
+$stmtEntrada = $conn->prepare('INSERT INTO entradas_insumo (proveedor_id, usuario_id, total) VALUES (?, ?, ?)');
 if (!$stmtEntrada) {
     $conn->rollback();
     error('Error al preparar entrada: ' . $conn->error);
 }
-$stmtEntrada->bind_param('id', $proveedor_id, $total);
+$stmtEntrada->bind_param('iid', $proveedor_id, $usuario_id, $total);
 if (!$stmtEntrada->execute()) {
     $stmtEntrada->close();
     $conn->rollback();
@@ -42,7 +73,7 @@ if (!$stmtEntrada->execute()) {
 $entrada_id = $stmtEntrada->insert_id;
 $stmtEntrada->close();
 
-$det = $conn->prepare('INSERT INTO entradas_detalle (entrada_id, producto_id, cantidad, precio_unitario) VALUES (?, ?, ?, ?)');
+$det = $conn->prepare('INSERT INTO entradas_detalle (entrada_id, insumo_id, cantidad, precio_unitario) VALUES (?, ?, ?, ?)');
 $upd = $conn->prepare('UPDATE insumos SET existencia = existencia + ? WHERE id = ?');
 $tipoStmt = $conn->prepare('SELECT tipo_control FROM insumos WHERE id = ?');
 if (!$det || !$upd || !$tipoStmt) {

--- a/vistas/insumos/insumos.html
+++ b/vistas/insumos/insumos.html
@@ -31,6 +31,7 @@
                 </tr>
             </tbody>
         </table>
+        <p><strong>Total: $<span id="total">0.00</span></strong></p>
         <button type="button" id="agregarFila">Agregar producto</button>
         <button type="button" id="registrarEntrada">Registrar entrada</button>
     </form>

--- a/vistas/insumos/insumos.js
+++ b/vistas/insumos/insumos.js
@@ -1,4 +1,5 @@
 let catalogo = [];
+const usuarioId = 1; // En entorno real se obtendría de la sesión
 
 async function cargarProveedores() {
     try {
@@ -93,11 +94,26 @@ function mostrarTipoEnFila(select) {
     }
 }
 
+function calcularTotal() {
+    let total = 0;
+    document.querySelectorAll('#tablaProductos tbody tr').forEach(f => {
+        const cantidad = parseFloat(f.querySelector('.cantidad').value) || 0;
+        const precio = parseFloat(f.querySelector('.precio').value) || 0;
+        total += cantidad * precio;
+    });
+    const totalEl = document.getElementById('total');
+    if (totalEl) {
+        totalEl.textContent = total.toFixed(2);
+    }
+}
+
 function agregarFila() {
     const tbody = document.querySelector('#tablaProductos tbody');
     const base = tbody.querySelector('tr');
     const nueva = base.cloneNode(true);
     nueva.querySelectorAll('input').forEach(i => i.value = '');
+    nueva.querySelector('.cantidad').addEventListener('input', calcularTotal);
+    nueva.querySelector('.precio').addEventListener('input', calcularTotal);
     tbody.appendChild(nueva);
     actualizarSelectsProducto();
 }
@@ -246,7 +262,7 @@ async function registrarEntrada() {
             productos.push(obj);
         }
     });
-    const payload = { proveedor_id, productos };
+    const payload = { proveedor_id, usuario_id: usuarioId, productos };
     try {
         const resp = await fetch('../../api/insumos/crear_entrada.php', {
             method: 'POST',
@@ -257,6 +273,11 @@ async function registrarEntrada() {
         if (data.success) {
             alert('Entrada registrada');
             cargarHistorial();
+            document.querySelectorAll('#tablaProductos tbody tr').forEach((f, i) => {
+                if (i > 0) f.remove();
+                f.querySelectorAll('input').forEach(inp => inp.value = '');
+            });
+            calcularTotal();
         } else {
             alert(data.mensaje);
         }
@@ -303,4 +324,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (btnNuevoInsumo) {
         btnNuevoInsumo.addEventListener('click', nuevoInsumo);
     }
+    document.querySelectorAll('.cantidad').forEach(i => i.addEventListener('input', calcularTotal));
+    document.querySelectorAll('.precio').forEach(i => i.addEventListener('input', calcularTotal));
+    calcularTotal();
 });


### PR DESCRIPTION
## Resumen
- mostrar total de la compra en `insumos.html`
- calcular automáticamente el total en `insumos.js`
- incluir `usuario_id` y limpiar formulario tras registrar la entrada
- validar datos en `api/insumos/crear_entrada.php`

## Testing
- `php` no está disponible en el entorno, por lo que no se pudieron ejecutar validaciones de sintaxis

------
https://chatgpt.com/codex/tasks/task_e_6863e5dc28fc832b870aee5cacdb7b88