### PR TITLE
Add low stock list and fix ticket series loading

### DIFF
--- a/api/insumos/listar_bajo_stock.php
+++ b/api/insumos/listar_bajo_stock.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$limite = 50;
+$stmt = $conn->prepare('SELECT id, nombre, unidad, existencia FROM insumos WHERE existencia < ? ORDER BY existencia ASC');
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('d', $limite);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al ejecutar consulta: ' . $stmt->error);
+}
+$res = $stmt->get_result();
+$insumos = [];
+while ($row = $res->fetch_assoc()) {
+    $insumos[] = $row;
+}
+$stmt->close();
+
+success($insumos);
+?>

--- a/vistas/insumos/insumos.html
+++ b/vistas/insumos/insumos.html
@@ -55,6 +55,19 @@
         <button type="button" id="registrarEntrada">Registrar entrada</button>
     </form>
 
+    <h2>Insumos con bajo stock</h2>
+    <table id="bajoStock" border="1">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Nombre</th>
+                <th>Unidad</th>
+                <th>Existencia</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
     <h2>Historial de Entradas por Proveedor</h2>
     <table id="historial" border="1">
         <thead>

--- a/vistas/insumos/insumos.js
+++ b/vistas/insumos/insumos.js
@@ -150,6 +150,33 @@ function mostrarCatalogo() {
     });
 }
 
+async function cargarBajoStock() {
+    try {
+        const resp = await fetch('../../api/insumos/listar_bajo_stock.php');
+        const data = await resp.json();
+        if (data.success) {
+            mostrarBajoStock(data.resultado);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar insumos de bajo stock');
+    }
+}
+
+function mostrarBajoStock(lista) {
+    const tbody = document.querySelector('#bajoStock tbody');
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    lista.forEach(i => {
+        const tr = document.createElement('tr');
+        if (parseFloat(i.existencia) < 20) {
+            tr.style.backgroundColor = '#f8d7da';
+        }
+        tr.innerHTML = `<td>${i.id}</td><td>${i.nombre}</td><td>${i.unidad}</td><td>${i.existencia}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
 async function nuevoProveedor() {
     const nombre = prompt('Nombre del proveedor:');
     if (!nombre) return;
@@ -324,6 +351,7 @@ async function cargarHistorial() {
 document.addEventListener('DOMContentLoaded', () => {
     cargarProveedores();
     cargarInsumos();
+    cargarBajoStock();
     cargarHistorial();
     document.getElementById('agregarFila').addEventListener('click', agregarFila);
     document.getElementById('registrarEntrada').addEventListener('click', registrarEntrada);

--- a/vistas/ventas/ticket.html
+++ b/vistas/ventas/ticket.html
@@ -94,7 +94,7 @@
             document.getElementById('totalVenta').textContent = 'Total: $' + data.total;
         }
 
-        document.addEventListener('DOMContentLoaded', () => {
+        document.addEventListener('DOMContentLoaded', async () => {
             const params = new URLSearchParams(window.location.search);
             const imprimir = params.get('print') === '1';
             const almacenado = localStorage.getItem('ticketData');
@@ -105,7 +105,7 @@
                 llenarTicket(datos);
                 liberarMesa(datos.venta_id);
             } else {
-                cargarSeries();
+                await cargarSeries();
                 inicializarDividir(datos);
             }
         });
@@ -129,6 +129,7 @@
         let productos = [];
         let numSub = 1;
         let ticketsGuardados = [];
+        const seleccionSeries = {};
 
         function inicializarDividir(data) {
             document.getElementById('dividir').style.display = 'block';
@@ -204,6 +205,12 @@
                     opt.value = s.id;
                     opt.textContent = s.descripcion;
                     sel.appendChild(opt);
+                });
+                if (seleccionSeries[i]) {
+                    sel.value = seleccionSeries[i];
+                }
+                sel.addEventListener('change', () => {
+                    seleccionSeries[i] = parseInt(sel.value);
                 });
             }
             mostrarTotal();


### PR DESCRIPTION
## Summary
- show low stock items in `insumos.html`
- load low stock list from new PHP endpoint
- ensure ticket page waits for series list
- preserve series selection while editing tickets

## Testing
- `php -l api/insumos/listar_bajo_stock.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68640c0a05a8832bb2e47d57ff2467e3