### PR TITLE
Add table reservation tracking

### DIFF
--- a/api/mesas/listar_mesas.php
+++ b/api/mesas/listar_mesas.php
@@ -4,11 +4,13 @@ require_once __DIR__ . '/../../utils/response.php';
 
 // Obtener mesas y, en su caso, la venta activa asociada
 $query = "SELECT m.id, m.nombre, m.estado, m.capacidad, m.mesa_principal_id,
+                m.area, m.estado_reserva, m.nombre_reserva, m.fecha_reserva,
+                m.tiempo_ocupacion_inicio, m.usuario_id AS mesa_usuario_id,
                 v.id AS venta_id, v.usuario_id AS mesero_id, u.nombre AS mesero_nombre
           FROM mesas m
           LEFT JOIN ventas v ON v.mesa_id = m.id AND v.estatus = 'activa'
           LEFT JOIN usuarios u ON v.usuario_id = u.id
-          ORDER BY m.id ASC";
+          ORDER BY m.area, m.id";
 $result = $conn->query($query);
 
 if (!$result) {
@@ -24,6 +26,12 @@ while ($row = $result->fetch_assoc()) {
         'estado'            => $row['estado'],
         'capacidad'         => (int)$row['capacidad'],
         'mesa_principal_id' => $row['mesa_principal_id'] ? (int)$row['mesa_principal_id'] : null,
+        'area'              => $row['area'],
+        'estado_reserva'    => $row['estado_reserva'],
+        'nombre_reserva'    => $row['nombre_reserva'],
+        'fecha_reserva'     => $row['fecha_reserva'],
+        'tiempo_ocupacion_inicio' => $row['tiempo_ocupacion_inicio'],
+        'mesa_usuario_id'   => $row['mesa_usuario_id'] !== null ? (int)$row['mesa_usuario_id'] : null,
         'venta_activa'      => $row['venta_id'] !== null,
         'venta_id'          => $row['venta_id'] !== null ? (int)$row['venta_id'] : null,
         'mesero_id'         => $row['mesero_id'] !== null ? (int)$row['mesero_id'] : null,

--- a/api/mesas/reasignar_mesa.php
+++ b/api/mesas/reasignar_mesa.php
@@ -1,0 +1,71 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$venta_id = $input['venta_id'] ?? null;
+$nueva_mesa_id = $input['nueva_mesa_id'] ?? null;
+if (!$venta_id || !$nueva_mesa_id) {
+    error('Datos inválidos');
+}
+$venta_id = (int)$venta_id;
+$nueva_mesa_id = (int)$nueva_mesa_id;
+
+$stmt = $conn->prepare('SELECT mesa_id FROM ventas WHERE id = ?');
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('i', $venta_id);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al obtener venta: ' . $stmt->error);
+}
+$res = $stmt->get_result();
+$row = $res->fetch_assoc();
+$stmt->close();
+if (!$row) {
+    error('Venta no encontrada');
+}
+$mesa_actual = (int)$row['mesa_id'];
+
+$check = $conn->prepare('SELECT estado FROM mesas WHERE id = ?');
+if ($check) {
+    $check->bind_param('i', $nueva_mesa_id);
+    $check->execute();
+    $row2 = $check->get_result()->fetch_assoc();
+    $check->close();
+    if (!$row2 || $row2['estado'] !== 'libre') {
+        error('La mesa destino no está libre');
+    }
+}
+
+$updVenta = $conn->prepare('UPDATE ventas SET mesa_id = ? WHERE id = ?');
+if (!$updVenta) {
+    error('Error al preparar actualización: ' . $conn->error);
+}
+$updVenta->bind_param('ii', $nueva_mesa_id, $venta_id);
+if (!$updVenta->execute()) {
+    $updVenta->close();
+    error('Error al actualizar venta: ' . $updVenta->error);
+}
+$updVenta->close();
+
+$liberar = $conn->prepare("UPDATE mesas SET estado = 'libre', tiempo_ocupacion_inicio = NULL, estado_reserva = 'ninguna', nombre_reserva = NULL, fecha_reserva = NULL, usuario_id = NULL WHERE id = ?");
+if ($liberar) {
+    $liberar->bind_param('i', $mesa_actual);
+    $liberar->execute();
+    $liberar->close();
+}
+$ocupar = $conn->prepare("UPDATE mesas SET estado = 'ocupada', tiempo_ocupacion_inicio = NOW() WHERE id = ?");
+if ($ocupar) {
+    $ocupar->bind_param('i', $nueva_mesa_id);
+    $ocupar->execute();
+    $ocupar->close();
+}
+
+success(true);
+?>

--- a/utils/bd.sql
+++ b/utils/bd.sql
@@ -20,7 +20,14 @@ CREATE TABLE IF NOT EXISTS mesas (
     nombre VARCHAR(50) NOT NULL,
     estado ENUM('libre','ocupada','reservada') DEFAULT 'libre',
     capacidad INT DEFAULT 4,
-    mesa_principal_id INT DEFAULT NULL
+    mesa_principal_id INT DEFAULT NULL,
+    area VARCHAR(50),
+    tiempo_ocupacion_inicio DATETIME DEFAULT NULL,
+    estado_reserva ENUM('ninguna','reservada') DEFAULT 'ninguna',
+    nombre_reserva VARCHAR(100),
+    fecha_reserva DATETIME,
+    usuario_id INT,
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id)
 );
 
 -- Tabla de repartidores para ventas a domicilio
@@ -69,6 +76,19 @@ CREATE TABLE IF NOT EXISTS venta_detalles (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (venta_id) REFERENCES ventas(id),
     FOREIGN KEY (producto_id) REFERENCES productos(id)
+);
+
+-- Historial de uso de mesas
+CREATE TABLE log_mesas (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    mesa_id INT NOT NULL,
+    venta_id INT,
+    usuario_id INT,
+    fecha_inicio DATETIME,
+    fecha_fin DATETIME,
+    FOREIGN KEY (mesa_id) REFERENCES mesas(id),
+    FOREIGN KEY (venta_id) REFERENCES ventas(id),
+    FOREIGN KEY (usuario_id) REFERENCES usuarios(id)
 );
 
 -- Tabla de corte de caja por usuario
@@ -179,10 +199,10 @@ INSERT INTO repartidores (nombre, telefono) VALUES
 ('Ana Repartidora', '555-999-2222');
 
 -- MESAS
-INSERT INTO mesas (nombre, estado, capacidad) VALUES
-('Mesa 1', 'libre', 4),
-('Mesa 2', 'ocupada', 4),
-('Mesa 3', 'reservada', 6);
+INSERT INTO mesas (nombre, estado, capacidad, area) VALUES
+('Mesa 1', 'libre', 4, 'General'),
+('Mesa 2', 'ocupada', 4, 'General'),
+('Mesa 3', 'reservada', 6, 'Terraza');
 
 -- PRODUCTOS
 INSERT INTO productos (nombre, precio, descripcion, existencia) VALUES


### PR DESCRIPTION
## Summary
- extend `mesas` table definition and add `log_mesas`
- expose reservation info via `listar_mesas.php`
- log table usage and clean fields in `liberar_mesa_de_venta.php`
- allow extra state handling in `cambiar_estado.php`
- add API to reassign a sale to another table
- show areas, reservations and occupation time in `mesas.js`
- sample data updated in database script

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686539041a0c832b8ade5fe500baeaa8