### PR TITLE
Add catalogo areas to mesas

### DIFF
--- a/api/mesas/listar_mesas.php
+++ b/api/mesas/listar_mesas.php
@@ -4,13 +4,15 @@ require_once __DIR__ . '/../../utils/response.php';
 
 // Obtener mesas y, en su caso, la venta activa asociada
 $query = "SELECT m.id, m.nombre, m.estado, m.capacidad, m.mesa_principal_id,
-                m.area, m.estado_reserva, m.nombre_reserva, m.fecha_reserva,
+                m.area_id, COALESCE(ca.nombre, m.area) AS area_nombre,
+                m.estado_reserva, m.nombre_reserva, m.fecha_reserva,
                 m.tiempo_ocupacion_inicio, m.usuario_id AS mesa_usuario_id,
                 v.id AS venta_id, v.usuario_id AS mesero_id, u.nombre AS mesero_nombre
           FROM mesas m
+          LEFT JOIN catalogo_areas ca ON m.area_id = ca.id
           LEFT JOIN ventas v ON v.mesa_id = m.id AND v.estatus = 'activa'
           LEFT JOIN usuarios u ON v.usuario_id = u.id
-          ORDER BY m.area, m.id";
+          ORDER BY area_nombre, m.id";
 $result = $conn->query($query);
 
 if (!$result) {
@@ -26,7 +28,8 @@ while ($row = $result->fetch_assoc()) {
         'estado'            => $row['estado'],
         'capacidad'         => (int)$row['capacidad'],
         'mesa_principal_id' => $row['mesa_principal_id'] ? (int)$row['mesa_principal_id'] : null,
-        'area'              => $row['area'],
+        'area_id'           => $row['area_id'] !== null ? (int)$row['area_id'] : null,
+        'area'              => $row['area_nombre'],
         'estado_reserva'    => $row['estado_reserva'],
         'nombre_reserva'    => $row['nombre_reserva'],
         'fecha_reserva'     => $row['fecha_reserva'],

--- a/utils/bd.sql
+++ b/utils/bd.sql
@@ -14,6 +14,12 @@ CREATE TABLE IF NOT EXISTS usuarios (
     activo TINYINT(1) DEFAULT 1
 );
 
+-- Catálogo de áreas para las mesas
+CREATE TABLE IF NOT EXISTS catalogo_areas (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre VARCHAR(50) NOT NULL
+);
+
 -- Tabla de mesas del restaurante
 CREATE TABLE IF NOT EXISTS mesas (
     id INT AUTO_INCREMENT PRIMARY KEY,
@@ -198,11 +204,21 @@ INSERT INTO repartidores (nombre, telefono) VALUES
 ('Pedro Repartidor', '555-000-1111'),
 ('Ana Repartidora', '555-999-2222');
 
+-- ÁREAS DE MESAS
+INSERT INTO catalogo_areas (nombre) VALUES
+('Ala izquierda'),
+('Ala derecha'),
+('Terraza');
+
+ALTER TABLE mesas
+ADD COLUMN area_id INT DEFAULT NULL,
+ADD CONSTRAINT fk_mesa_area FOREIGN KEY (area_id) REFERENCES catalogo_areas(id);
+
 -- MESAS
-INSERT INTO mesas (nombre, estado, capacidad, area) VALUES
-('Mesa 1', 'libre', 4, 'General'),
-('Mesa 2', 'ocupada', 4, 'General'),
-('Mesa 3', 'reservada', 6, 'Terraza');
+INSERT INTO mesas (nombre, estado, capacidad, area, area_id) VALUES
+('Mesa 1', 'libre', 4, 'Ala izquierda', 1),
+('Mesa 2', 'ocupada', 4, 'Ala derecha', 2),
+('Mesa 3', 'reservada', 6, 'Terraza', 3);
 
 -- PRODUCTOS
 INSERT INTO productos (nombre, precio, descripcion, existencia) VALUES

--- a/vistas/mesas/mesas.js
+++ b/vistas/mesas/mesas.js
@@ -15,21 +15,22 @@ async function cargarMesas() {
 
             const areas = {};
             data.resultado.forEach(m => {
-                const area = m.area || 'Sin área';
-                if (!areas[area]) areas[area] = [];
-                areas[area].push(m);
+                const nombre = m.area || 'Sin área';
+                const key = m.area_id !== null ? String(m.area_id) : nombre;
+                if (!areas[key]) areas[key] = { nombre, mesas: [] };
+                areas[key].mesas.push(m);
             });
 
-            Object.keys(areas).forEach(areaNombre => {
+            Object.values(areas).forEach(areaInfo => {
                 const seccion = document.createElement('section');
                 const h2 = document.createElement('h2');
-                h2.textContent = areaNombre;
+                h2.textContent = areaInfo.nombre;
                 seccion.appendChild(h2);
                 const cont = document.createElement('div');
                 seccion.appendChild(cont);
                 tablero.appendChild(seccion);
 
-                areas[areaNombre].forEach(m => {
+                areaInfo.mesas.forEach(m => {
                     const card = document.createElement('div');
                     card.className = 'mesa';
 


### PR DESCRIPTION
## Summary
- create `catalogo_areas` table and seed data
- link mesas with new `area_id` column
- update `listar_mesas.php` to join `catalogo_areas`
- group mesas by `area_id` in the frontend

## Testing
- `php -l api/mesas/listar_mesas.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865618b8f98832b80b700993e327e4b