### PR TITLE
Implement delivery tracking and area filter

### DIFF
--- a/api/repartidores/listar_entregas.php
+++ b/api/repartidores/listar_entregas.php
@@ -17,7 +17,7 @@ if (isset($_GET['repartidor_id'])) {
 
 if ($repartidor_id) {
     $stmt = $conn->prepare(
-        "SELECT v.id, v.fecha, v.total, v.estatus, v.entregado, r.nombre AS repartidor FROM ventas v JOIN repartidores r ON v.repartidor_id = r.id WHERE v.repartidor_id = ? AND v.estatus IN ('activa','cerrada') ORDER BY v.fecha DESC"
+        "SELECT v.id, v.fecha, v.total, v.estatus, v.entregado, v.estado_entrega, v.fecha_asignacion, v.fecha_inicio, v.fecha_entrega, v.seudonimo_entrega, v.foto_entrega, r.nombre AS repartidor FROM ventas v JOIN repartidores r ON v.repartidor_id = r.id WHERE v.repartidor_id = ? AND v.estatus IN ('activa','cerrada') ORDER BY v.fecha DESC"
     );
     if (!$stmt) {
         error('Error al preparar consulta: ' . $conn->error);
@@ -25,7 +25,7 @@ if ($repartidor_id) {
     $stmt->bind_param('i', $repartidor_id);
 } else {
     $stmt = $conn->prepare(
-        "SELECT v.id, v.fecha, v.total, v.estatus, v.entregado, r.nombre AS repartidor FROM ventas v JOIN repartidores r ON v.repartidor_id = r.id WHERE v.tipo_entrega = 'domicilio' AND v.estatus IN ('activa','cerrada') ORDER BY v.fecha DESC"
+        "SELECT v.id, v.fecha, v.total, v.estatus, v.entregado, v.estado_entrega, v.fecha_asignacion, v.fecha_inicio, v.fecha_entrega, v.seudonimo_entrega, v.foto_entrega, r.nombre AS repartidor FROM ventas v JOIN repartidores r ON v.repartidor_id = r.id WHERE v.tipo_entrega = 'domicilio' AND v.estatus IN ('activa','cerrada') ORDER BY v.fecha DESC"
     );
     if (!$stmt) {
         error('Error al preparar consulta: ' . $conn->error);
@@ -39,12 +39,18 @@ $res = $stmt->get_result();
 $ventas = [];
 while ($row = $res->fetch_assoc()) {
     $ventas[$row['id']] = [
-        'id'        => (int)$row['id'],
-        'fecha'     => $row['fecha'],
-        'total'     => (float)$row['total'],
-        'estatus'   => $row['estatus'],
-        'entregado' => (int)$row['entregado'],
-        'repartidor'=> $row['repartidor'] ?? '',
+        'id'          => (int)$row['id'],
+        'fecha'       => $row['fecha'],
+        'total'       => (float)$row['total'],
+        'estatus'     => $row['estatus'],
+        'entregado'   => (int)$row['entregado'],
+        'estado_entrega'   => $row['estado_entrega'],
+        'fecha_asignacion' => $row['fecha_asignacion'],
+        'fecha_inicio'     => $row['fecha_inicio'],
+        'fecha_entrega'    => $row['fecha_entrega'],
+        'seudonimo_entrega'=> $row['seudonimo_entrega'],
+        'foto_entrega'     => $row['foto_entrega'],
+        'repartidor'       => $row['repartidor'] ?? '',
         'productos' => []
     ];
 }

--- a/api/repartidores/marcar_entregado.php
+++ b/api/repartidores/marcar_entregado.php
@@ -8,14 +8,32 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 
 $input = json_decode(file_get_contents('php://input'), true);
 $venta_id = null;
+$accion = null;
 if ($input && isset($input['venta_id'])) {
     $venta_id = (int)$input['venta_id'];
+    $accion = $input['accion'] ?? null;
 } elseif (isset($_POST['venta_id'])) {
     $venta_id = (int)$_POST['venta_id'];
+    $accion = $_POST['accion'] ?? null;
 }
 
 if (!$venta_id) {
     error('Datos inválidos');
+}
+
+if ($accion === 'en_camino') {
+    $stmt = $conn->prepare("UPDATE ventas SET estado_entrega='en_camino', fecha_inicio = NOW() WHERE id = ?");
+    if (!$stmt) {
+        error('Error al preparar actualización: ' . $conn->error);
+    }
+    $stmt->bind_param('i', $venta_id);
+    if (!$stmt->execute()) {
+        $stmt->close();
+        error('Error al actualizar venta: ' . $stmt->error);
+    }
+    $stmt->close();
+    success(true);
+    exit;
 }
 
 // verificar que todos los productos estén listos
@@ -35,11 +53,25 @@ if ($row && (int)$row['faltan'] > 0) {
     error('Aún hay productos sin preparar');
 }
 
-$stmt = $conn->prepare("UPDATE ventas SET estatus = 'cerrada', entregado = 1 WHERE id = ?");
+$seudonimo = isset($_POST['seudonimo']) ? $_POST['seudonimo'] : ($input['seudonimo'] ?? null);
+$nombreArchivo = null;
+if (!empty($_FILES['foto']['name'])) {
+    $dir = __DIR__ . '/../../uploads/evidencias/';
+    if (!is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+    $ext = pathinfo($_FILES['foto']['name'], PATHINFO_EXTENSION);
+    $nombreArchivo = uniqid('evid_') . ($ext ? ".{$ext}" : '');
+    if (!move_uploaded_file($_FILES['foto']['tmp_name'], $dir . $nombreArchivo)) {
+        error('Error al subir imagen');
+    }
+}
+
+$stmt = $conn->prepare("UPDATE ventas SET estatus = 'cerrada', entregado = 1, estado_entrega='entregado', fecha_entrega=NOW(), seudonimo_entrega=?, foto_entrega=? WHERE id = ?");
 if (!$stmt) {
     error('Error al preparar actualización: ' . $conn->error);
 }
-$stmt->bind_param('i', $venta_id);
+$stmt->bind_param('ssi', $seudonimo, $nombreArchivo, $venta_id);
 if (!$stmt->execute()) {
     $stmt->close();
     error('Error al actualizar venta: ' . $stmt->error);

--- a/api/ventas/crear_venta.php
+++ b/api/ventas/crear_venta.php
@@ -79,7 +79,11 @@ if ($tipo === 'mesa') {
 $nueva_venta = false;
 
 if (!isset($venta_id)) {
-    $stmt = $conn->prepare('INSERT INTO ventas (mesa_id, repartidor_id, usuario_id, tipo_entrega, total) VALUES (?, ?, ?, ?, ?)');
+    if ($tipo === 'domicilio') {
+        $stmt = $conn->prepare('INSERT INTO ventas (mesa_id, repartidor_id, usuario_id, tipo_entrega, total, fecha_asignacion) VALUES (?, ?, ?, ?, ?, NOW())');
+    } else {
+        $stmt = $conn->prepare('INSERT INTO ventas (mesa_id, repartidor_id, usuario_id, tipo_entrega, total) VALUES (?, ?, ?, ?, ?)');
+    }
     if (!$stmt) {
         error('Error al preparar venta: ' . $conn->error);
     }

--- a/util/entregas.sql
+++ b/util/entregas.sql
@@ -1,0 +1,6 @@
+ALTER TABLE ventas ADD COLUMN estado_entrega ENUM('pendiente', 'en_camino', 'entregado') DEFAULT 'pendiente',
+ADD COLUMN fecha_asignacion DATETIME DEFAULT NULL,
+ADD COLUMN fecha_inicio DATETIME DEFAULT NULL,
+ADD COLUMN fecha_entrega DATETIME DEFAULT NULL,
+ADD COLUMN seudonimo_entrega VARCHAR(100) DEFAULT NULL,
+ADD COLUMN foto_entrega VARCHAR(255) DEFAULT NULL;

--- a/vistas/mesas/mesas.html
+++ b/vistas/mesas/mesas.html
@@ -8,6 +8,7 @@
     <h1>Mesas</h1>
     <div>
         <button id="btn-unir">Unir mesas</button>
+        <select id="filtro-area"></select>
     </div>
     <div id="tablero"></div>
     <div id="modal-detalle" style="display:none;"></div>

--- a/vistas/mesas/mesas.js
+++ b/vistas/mesas/mesas.js
@@ -1,3 +1,5 @@
+let areaFiltro = 'todas';
+
 async function cargarMesas() {
     try {
         const resp = await fetch('../../api/mesas/listar_mesas.php');
@@ -21,7 +23,18 @@ async function cargarMesas() {
                 areas[key].mesas.push(m);
             });
 
-            Object.values(areas).forEach(areaInfo => {
+            const selectArea = document.getElementById('filtro-area');
+            selectArea.innerHTML = '<option value="todas">Todas las áreas</option>';
+            Object.entries(areas).forEach(([key, a]) => {
+                const opt = document.createElement('option');
+                opt.value = key;
+                opt.textContent = a.nombre;
+                if (key === areaFiltro) opt.selected = true;
+                selectArea.appendChild(opt);
+            });
+
+            Object.entries(areas).forEach(([key, areaInfo]) => {
+                if (areaFiltro !== 'todas' && areaFiltro !== key) return;
                 const seccion = document.createElement('section');
                 const h2 = document.createElement('h2');
                 h2.textContent = areaInfo.nombre;
@@ -188,6 +201,10 @@ document.addEventListener('DOMContentLoaded', () => {
     cargarCatalogo();
     cargarMeseros();
     cargarMesas();
+    document.getElementById('filtro-area').addEventListener('change', e => {
+        areaFiltro = e.target.value;
+        cargarMesas();
+    });
 });
 
 async function dividirMesa(id) {

--- a/vistas/repartidores/repartos.html
+++ b/vistas/repartidores/repartos.html
@@ -16,6 +16,11 @@
                 <th>Total</th>
                 <th>Repartidor</th>
                 <th>Productos</th>
+                <th>Asignado</th>
+                <th>Inicio</th>
+                <th>Entrega</th>
+                <th>Total (min)</th>
+                <th>En camino (min)</th>
                 <th>Acciones</th>
             </tr>
         </thead>
@@ -31,6 +36,11 @@
                 <th>Total</th>
                 <th>Repartidor</th>
                 <th>Productos</th>
+                <th>Asignado</th>
+                <th>Inicio</th>
+                <th>Entrega</th>
+                <th>Total (min)</th>
+                <th>En camino (min)</th>
                 <th>Ver detalles</th>
             </tr>
         </thead>

--- a/vistas/repartidores/repartos.js
+++ b/vistas/repartidores/repartos.js
@@ -1,6 +1,12 @@
 const params = new URLSearchParams(location.search);
 const repartidorId = params.get('id');
 
+function diffMins(a, b) {
+    const t1 = new Date(a).getTime();
+    const t2 = new Date(b).getTime();
+    return Math.round((t2 - t1) / 60000);
+}
+
 async function cargarEntregas() {
     try {
         const url = repartidorId
@@ -16,16 +22,36 @@ async function cargarEntregas() {
             data.resultado.forEach(v => {
                 const row = document.createElement('tr');
                 const productos = v.productos.map(p => `${p.nombre} (${p.cantidad})`).join(', ');
+                const asign = v.fecha_asignacion || '';
+                const inicio = v.fecha_inicio || '';
+                const entrega = v.fecha_entrega || '';
+                const totalMin = v.fecha_asignacion && v.fecha_entrega ? diffMins(v.fecha_asignacion, v.fecha_entrega) : (v.fecha_asignacion && !v.fecha_entrega ? diffMins(v.fecha_asignacion, Date.now()) : '');
+                const caminoMin = v.fecha_inicio && v.fecha_entrega ? diffMins(v.fecha_inicio, v.fecha_entrega) : (v.fecha_inicio && !v.fecha_entrega ? diffMins(v.fecha_inicio, Date.now()) : '');
+
                 row.innerHTML = `
                     <td>${v.id}</td>
                     <td>${v.fecha}</td>
                     <td>${v.total}</td>
                     <td>${v.repartidor}</td>
                     <td>${productos}</td>
+                    <td>${asign}</td>
+                    <td>${inicio}</td>
+                    <td>${entrega}</td>
+                    <td>${totalMin}</td>
+                    <td>${caminoMin}</td>
                 `;
-                if (v.estatus === 'activa' && !v.entregado) {
+
+                if (v.estado_entrega === 'pendiente') {
                     const btn = document.createElement('button');
-                    btn.textContent = 'Marcar como entregada';
+                    btn.textContent = 'En camino';
+                    btn.addEventListener('click', () => marcarEnCamino(v.id));
+                    const accionTd = document.createElement('td');
+                    accionTd.appendChild(btn);
+                    row.appendChild(accionTd);
+                    pendientesBody.appendChild(row);
+                } else if (v.estado_entrega === 'en_camino') {
+                    const btn = document.createElement('button');
+                    btn.textContent = 'Marcar entregado';
                     btn.addEventListener('click', () => marcarEntregada(v.id));
                     const accionTd = document.createElement('td');
                     accionTd.appendChild(btn);
@@ -51,11 +77,41 @@ async function cargarEntregas() {
 }
 
 async function marcarEntregada(id) {
+    const seudonimo = prompt('Seud\u00f3nimo del cliente:') || '';
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.addEventListener('change', async () => {
+        const fd = new FormData();
+        fd.append('venta_id', id);
+        fd.append('accion', 'entregado');
+        fd.append('seudonimo', seudonimo);
+        if (input.files[0]) fd.append('foto', input.files[0]);
+        try {
+            const resp = await fetch('../../api/repartidores/marcar_entregado.php', {
+                method: 'POST',
+                body: fd
+            });
+            const data = await resp.json();
+            if (data.success) {
+                cargarEntregas();
+            } else {
+                alert(data.mensaje);
+            }
+        } catch (err) {
+            console.error(err);
+            alert('Error al actualizar');
+        }
+    });
+    input.click();
+}
+
+async function marcarEnCamino(id) {
     try {
         const resp = await fetch('../../api/repartidores/marcar_entregado.php', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ venta_id: parseInt(id) })
+            body: JSON.stringify({ venta_id: parseInt(id), accion: 'en_camino' })
         });
         const data = await resp.json();
         if (data.success) {


### PR DESCRIPTION
## Summary
- add SQL script with new delivery fields
- capture delivery assignment date in `crear_venta.php`
- expose new delivery fields in `listar_entregas.php`
- extend `marcar_entregado.php` for `en_camino` state, delivery evidence and timestamps
- show extra delivery info and actions in `repartos` UI
- add area filter dropdown to `mesas`

## Testing
- `php -l` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68656ef402e4832b809491de0b12e72f