### PR TITLE
Add evidence display in delivery details

### DIFF
--- a/api/ventas/detalle_venta.php
+++ b/api/ventas/detalle_venta.php
@@ -19,7 +19,8 @@ $venta_id = (int)$input['venta_id'];
 
 // Obtener datos generales de la venta
 $info = $conn->prepare(
-    'SELECT v.tipo_entrega, m.nombre AS mesa, r.nombre AS repartidor, u.nombre AS mesero
+    'SELECT v.tipo_entrega, m.nombre AS mesa, r.nombre AS repartidor, u.nombre AS mesero,
+            v.seudonimo_entrega, v.foto_entrega
      FROM ventas v
      LEFT JOIN mesas m ON v.mesa_id = m.id
      LEFT JOIN repartidores r ON v.repartidor_id = r.id
@@ -66,10 +67,12 @@ while ($row = $res->fetch_assoc()) {
 $stmt->close();
 
 echo json_encode([
-    'success'      => true,
-    'tipo_entrega' => $datosVenta['tipo_entrega'] ?? '',
-    'mesa'         => $datosVenta['mesa'] ?? '',
-    'repartidor'   => $datosVenta['repartidor'] ?? '',
-    'mesero'       => $datosVenta['mesero'] ?? '',
-    'productos'    => $productos
+    'success'          => true,
+    'tipo_entrega'     => $datosVenta['tipo_entrega'] ?? '',
+    'mesa'             => $datosVenta['mesa'] ?? '',
+    'repartidor'       => $datosVenta['repartidor'] ?? '',
+    'mesero'           => $datosVenta['mesero'] ?? '',
+    'seudonimo_entrega'=> $datosVenta['seudonimo_entrega'] ?? '',
+    'foto_entrega'     => $datosVenta['foto_entrega'] ?? '',
+    'productos'        => $productos
 ]);

--- a/vistas/repartidores/repartos.js
+++ b/vistas/repartidores/repartos.js
@@ -132,7 +132,11 @@ function mostrarDetalle(info) {
         const sub = p.cantidad * p.precio_unitario;
         html += `<li>${p.nombre} - ${p.cantidad} x ${p.precio_unitario} = ${sub}</li>`;
     });
-    html += `</ul><p>Total: ${info.total}</p><button id="cerrarDetalle">Cerrar</button>`;
+    html += '</ul>';
+    if (info.foto_entrega) {
+        html += `<p>Evidencia:<br><img src="../../uploads/evidencias/${info.foto_entrega}" width="300"></p>`;
+    }
+    html += `<p>Total: ${info.total}</p><button id="cerrarDetalle">Cerrar</button>`;
     contenedor.innerHTML = html;
     contenedor.style.display = 'block';
     document.getElementById('cerrarDetalle').addEventListener('click', () => {

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -366,6 +366,9 @@ async function verDetalles(id) {
                         `<td>${btn}</td></tr>`;
             });
             html += `</tbody></table>`;
+            if (info.foto_entrega) {
+                html += `<p>Evidencia:<br><img src="../../uploads/evidencias/${info.foto_entrega}" width="300"></p>`;
+            }
             html += `<h4>Agregar producto</h4>`;
             html += `<select id="detalle_producto"></select>`;
             html += `<input type="number" id="detalle_cantidad" value="1" min="1">`;


### PR DESCRIPTION
## Summary
- expose `foto_entrega` and `seudonimo_entrega` in `detalle_venta.php`
- show evidence image in repartos details modal
- show evidence image in ventas details modal

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865810b8348832bb462a9d914858553