### PR TITLE
Add reportes module and update corte APIs

### DIFF
--- a/api/corte_caja/listar_cortes.php
+++ b/api/corte_caja/listar_cortes.php
@@ -36,7 +36,7 @@ if ($fin) {
 }
 $where = $conditions ? 'WHERE ' . implode(' AND ', $conditions) : '';
 
-$query = "SELECT v.corte_id AS id, v.fecha_inicio, v.fecha_fin, v.total, v.cajero AS usuario
+$query = "SELECT v.corte_id AS id, v.fecha_inicio, v.fecha_fin, v.total, v.cajero AS usuario, cc.observaciones
           FROM vw_corte_resumen v
           JOIN corte_caja cc ON cc.id = v.corte_id
           $where
@@ -61,7 +61,8 @@ while ($row = $res->fetch_assoc()) {
         'fecha_inicio' => $row['fecha_inicio'],
         'fecha_fin' => $row['fecha_fin'],
         'total' => $row['total'] !== null ? (float)$row['total'] : null,
-        'usuario' => $row['usuario']
+        'usuario' => $row['usuario'],
+        'observaciones' => $row['observaciones'] ?? ''
     ];
 }
 $stmt->close();

--- a/api/corte_caja/listar_ventas_por_corte.php
+++ b/api/corte_caja/listar_ventas_por_corte.php
@@ -7,7 +7,7 @@ if (!$corte_id) {
     error('corte_id requerido');
 }
 
-$query = $conn->prepare('SELECT v.id, v.fecha, SUM(t.total) AS total, u.nombre AS usuario, SUM(t.propina) AS propina
+$query = $conn->prepare('SELECT v.id, v.fecha, v.tipo_entrega, SUM(t.total) AS total, u.nombre AS usuario, SUM(t.propina) AS propina
                          FROM ventas v
                          LEFT JOIN tickets t ON t.venta_id = v.id
                          JOIN usuarios u ON v.usuario_id = u.id
@@ -23,11 +23,12 @@ $res = $query->get_result();
 $ventas = [];
 while ($row = $res->fetch_assoc()) {
     $ventas[] = [
-        'id'       => (int)$row['id'],
-        'fecha'    => $row['fecha'],
-        'total'    => (float)($row['total'] ?? 0),
-        'usuario'  => $row['usuario'],
-        'propina'  => (float)($row['propina'] ?? 0)
+        'id'          => (int)$row['id'],
+        'fecha'       => $row['fecha'],
+        'tipo_entrega'=> $row['tipo_entrega'],
+        'total'       => (float)($row['total'] ?? 0),
+        'usuario'     => $row['usuario'],
+        'propina'     => (float)($row['propina'] ?? 0)
     ];
 }
 $query->close();

--- a/utils/corte_reportes.sql
+++ b/utils/corte_reportes.sql
@@ -1,0 +1,8 @@
+-- Agrega campo de observaciones al corte
+ALTER TABLE corte_caja
+ADD COLUMN observaciones TEXT;
+
+-- Relaciona ventas con cortes
+ALTER TABLE ventas
+ADD COLUMN corte_id INT DEFAULT NULL,
+ADD CONSTRAINT fk_venta_corte FOREIGN KEY (corte_id) REFERENCES corte_caja(id);

--- a/vistas/reportes/reportes.html
+++ b/vistas/reportes/reportes.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Reportes de Cortes</title>
+</head>
+<body>
+    <h1>Reportes de Cortes</h1>
+    <button id="btnResumen">Resumen de corte actual</button>
+    <div id="modal" style="display:none;"></div>
+
+    <h2>Historial de Cortes</h2>
+    <table id="tablaCortes" border="1">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Usuario</th>
+                <th>Fecha inicio</th>
+                <th>Fecha cierre</th>
+                <th>Total</th>
+                <th>Observaciones</th>
+                <th>Detalle</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
+    <script src="reportes.js"></script>
+</body>
+</html>

--- a/vistas/reportes/reportes.js
+++ b/vistas/reportes/reportes.js
@@ -1,0 +1,101 @@
+const usuarioId = 1; // En producción usar id de sesión
+
+async function cargarHistorial() {
+    const tbody = document.querySelector('#tablaCortes tbody');
+    tbody.innerHTML = '<tr><td colspan="7">Cargando...</td></tr>';
+    try {
+        const resp = await fetch('../../api/corte_caja/listar_cortes.php');
+        const data = await resp.json();
+        if (data.success) {
+            tbody.innerHTML = '';
+            data.resultado.forEach(c => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${c.id}</td>
+                    <td>${c.usuario}</td>
+                    <td>${c.fecha_inicio}</td>
+                    <td>${c.fecha_fin || ''}</td>
+                    <td>${c.total !== null ? c.total : ''}</td>
+                    <td>${c.observaciones || ''}</td>
+                    <td><button class="detalle" data-id="${c.id}">Ver detalle</button></td>
+                `;
+                tbody.appendChild(tr);
+            });
+            tbody.querySelectorAll('button.detalle').forEach(btn => {
+                btn.addEventListener('click', () => verDetalle(btn.dataset.id));
+            });
+        } else {
+            tbody.innerHTML = '<tr><td colspan="7">Error al cargar</td></tr>';
+        }
+    } catch (err) {
+        console.error(err);
+        tbody.innerHTML = '<tr><td colspan="7">Error</td></tr>';
+    }
+}
+
+async function verDetalle(corteId) {
+    const modal = document.getElementById('modal');
+    modal.innerHTML = 'Cargando...';
+    modal.style.display = 'block';
+    try {
+        const resp = await fetch('../../api/corte_caja/listar_ventas_por_corte.php?corte_id=' + corteId);
+        const data = await resp.json();
+        if (data.success) {
+            let html = `<h3>Ventas del corte ${corteId}</h3>`;
+            html += '<table border="1"><thead><tr><th>ID</th><th>Fecha</th><th>Total</th><th>Propina</th><th>Tipo</th></tr></thead><tbody>';
+            data.resultado.forEach(v => {
+                html += `<tr><td>${v.id}</td><td>${v.fecha}</td><td>${v.total}</td><td>${v.propina}</td><td>${v.tipo_entrega}</td></tr>`;
+            });
+            html += '</tbody></table><button id="cerrarModal">Cerrar</button>';
+            modal.innerHTML = html;
+            document.getElementById('cerrarModal').addEventListener('click', () => {
+                modal.style.display = 'none';
+            });
+        } else {
+            modal.innerHTML = data.mensaje;
+        }
+    } catch (err) {
+        console.error(err);
+        modal.innerHTML = 'Error al obtener detalle';
+    }
+}
+
+async function resumenActual() {
+    const modal = document.getElementById('modal');
+    modal.innerHTML = 'Cargando...';
+    modal.style.display = 'block';
+    try {
+        const resp = await fetch('../../api/corte_caja/resumen_corte_actual.php?usuario_id=' + usuarioId);
+        const data = await resp.json();
+        if (!data.success || !data.resultado.abierto) {
+            modal.style.display = 'none';
+            alert('No hay corte abierto');
+            return;
+        }
+        const r = data.resultado;
+        let html = `<h3>Resumen del corte ${r.corte_id}</h3>`;
+        html += `<p>Ventas totales: $${r.total}</p>`;
+        html += `<p>Número de ventas: ${r.num_ventas}</p>`;
+        html += `<p>Total en propinas: $${r.propinas}</p>`;
+        if (r.metodos_pago && r.metodos_pago.length) {
+            html += '<h4>Métodos de pago</h4><ul>';
+            r.metodos_pago.forEach(m => {
+                html += `<li>${m.metodo}: $${m.total}</li>`;
+            });
+            html += '</ul>';
+        }
+        html += '<button id="cerrarModal">Cerrar</button>';
+        modal.innerHTML = html;
+        document.getElementById('cerrarModal').addEventListener('click', () => {
+            modal.style.display = 'none';
+        });
+    } catch (err) {
+        console.error(err);
+        modal.innerHTML = 'Error al obtener resumen';
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    cargarHistorial();
+    document.getElementById('btnResumen').addEventListener('click', resumenActual);
+});


### PR DESCRIPTION
## Summary
- extend API to return `observaciones` on cortes
- include `tipo_entrega` in ventas-by-corte endpoint
- enrich corte summary with payment method totals
- add SQL migrations for corte reporting
- create new `vistas/reportes` screen

## Testing
- `php -l api/corte_caja/listar_cortes.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b668aff8832ba01642cfd37f9d4a