### PR TITLE
Integrar caja en ventas

### DIFF
--- a/vistas/ventas/ventas.html
+++ b/vistas/ventas/ventas.html
@@ -6,6 +6,7 @@
 </head>
 <body>
     <h1>Registro de Venta</h1>
+    <div id="controlCaja"></div>
     <form id="formVenta">
         <label for="tipo_entrega">Tipo de venta:</label>
         <select id="tipo_entrega" name="tipo_entrega">


### PR DESCRIPTION
## Summary
- integrate caja verification and actions in `ventas` view
- include `corte_id` when creating a sale

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865d9ef4ee0832bb211e1466e7bbfb4