### PR TITLE
Use session user id in ventas view

### DIFF
--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -45,7 +45,7 @@ async function cargarHistorial() {
     }
 }
 
-const usuarioId = 1; // ID del cajero, reemplazar por sesión en producción
+const usuarioId = window.usuarioId || 1; // ID del cajero proveniente de la sesión
 let corteIdActual = null;
 let catalogo = [];
 let productos = [];

--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -91,6 +91,10 @@ ob_start();
 
     <div id="modal-detalles" style="display:none;"></div>
 
+    <script>
+        // ID de usuario proveniente de la sesión para operaciones en JS
+        window.usuarioId = <?php echo json_encode($_SESSION['usuario_id']); ?>;
+    </script>
     <script src="ventas.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose `usuario_id` from PHP session to `ventas.js`
- read session user ID in `ventas.js`

## Testing
- `php -l vistas/ventas/ventas.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ed0b5ca8832bb1bb7180684ef843