### PR TITLE
Implement cash opening and payment features

### DIFF
--- a/api/corte_caja/iniciar_corte.php
+++ b/api/corte_caja/iniciar_corte.php
@@ -8,8 +8,12 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 
 $input = json_decode(file_get_contents('php://input'), true);
 $usuario_id = $input['usuario_id'] ?? null;
+$fondo_inicial = isset($input['fondo_inicial']) ? (float)$input['fondo_inicial'] : null;
 if (!$usuario_id) {
     error('usuario_id requerido');
+}
+if ($fondo_inicial === null) {
+    error('fondo_inicial requerido');
 }
 
 $stmt = $conn->prepare('SELECT id FROM corte_caja WHERE usuario_id = ? AND fecha_fin IS NULL');
@@ -25,11 +29,11 @@ if ($stmt->num_rows > 0) {
 }
 $stmt->close();
 
-$stmt = $conn->prepare('INSERT INTO corte_caja (usuario_id, fecha_inicio) VALUES (?, NOW())');
+$stmt = $conn->prepare('INSERT INTO corte_caja (usuario_id, fecha_inicio, fondo_inicial) VALUES (?, NOW(), ?)');
 if (!$stmt) {
     error('Error al preparar inserción: ' . $conn->error);
 }
-$stmt->bind_param('i', $usuario_id);
+$stmt->bind_param('id', $usuario_id, $fondo_inicial);
 if (!$stmt->execute()) {
     $stmt->close();
     error('Error al crear corte: ' . $stmt->error);

--- a/utils/bd.sql
+++ b/utils/bd.sql
@@ -172,6 +172,8 @@ CREATE TABLE IF NOT EXISTS tickets (
     folio INT NOT NULL,
     total DECIMAL(10,2) NOT NULL,
     propina DECIMAL(10,2) DEFAULT 0,
+    monto_recibido DECIMAL(10,2) DEFAULT 0,
+    tipo_pago ENUM('efectivo','boucher','cheque') DEFAULT 'efectivo',
     fecha DATETIME DEFAULT CURRENT_TIMESTAMP,
     usuario_id INT,
     FOREIGN KEY (venta_id) REFERENCES ventas(id),

--- a/utils/desglose_corte.sql
+++ b/utils/desglose_corte.sql
@@ -1,0 +1,10 @@
+ALTER TABLE corte_caja ADD COLUMN fondo_inicial DECIMAL(10,2) DEFAULT 0;
+
+CREATE TABLE desglose_corte (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  corte_id INT NOT NULL,
+  denominacion DECIMAL(10,2) NOT NULL,
+  cantidad INT NOT NULL,
+  tipo_pago ENUM('efectivo','boucher','cheque') DEFAULT 'efectivo',
+  FOREIGN KEY (corte_id) REFERENCES corte_caja(id)
+);

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -95,11 +95,16 @@ fetch('../../api/corte_caja/verificar_corte_abierto.php', {
 }
 
 async function abrirCaja() {
+    const monto = prompt('Indica fondo de caja:');
+    if (monto === null || monto === '') {
+        alert('Debes indicar un monto');
+        return;
+    }
     try {
         const resp = await fetch('../../api/corte_caja/iniciar_corte.php', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ usuario_id: usuarioId })
+            body: JSON.stringify({ usuario_id: usuarioId, fondo_inicial: parseFloat(monto) })
         });
         const data = await resp.json();
         if (data.success) {


### PR DESCRIPTION
## Summary
- add columns to store payment info in tickets
- accept fondo inicial when opening cash register
- add numeric keypad and payment fields on ticket page
- send payment data to backend when saving tickets
- provide SQL script for new cash breakdown table

## Testing
- `php` syntax checks *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686612b62038832bb8db5756a4341275