### PR TITLE
Implement fondo and cash count

### DIFF
--- a/api/corte_caja/consultar_fondo.php
+++ b/api/corte_caja/consultar_fondo.php
@@ -1,0 +1,22 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$usuario_id = isset($_GET['usuario_id']) ? (int)$_GET['usuario_id'] : 0;
+if (!$usuario_id) {
+    error('usuario_id requerido');
+}
+
+$stmt = $conn->prepare('SELECT monto FROM fondo WHERE usuario_id = ?');
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('i', $usuario_id);
+$stmt->execute();
+$res = $stmt->get_result();
+if ($row = $res->fetch_assoc()) {
+    success(['existe' => true, 'monto' => (float)$row['monto']]);
+} else {
+    success(['existe' => false]);
+}
+?>

--- a/api/corte_caja/guardar_desglose.php
+++ b/api/corte_caja/guardar_desglose.php
@@ -1,0 +1,81 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$corte_id = $input['corte_id'] ?? null;
+$desglose = $input['desglose'] ?? [];
+$boucher = isset($input['boucher']) ? (float)$input['boucher'] : 0;
+$cheque  = isset($input['cheque']) ? (float)$input['cheque'] : 0;
+if (!$corte_id || !is_array($desglose)) {
+    error('Datos incompletos');
+}
+
+$stmt = $conn->prepare('SELECT total FROM corte_caja WHERE id = ?');
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('i', $corte_id);
+$stmt->execute();
+$res = $stmt->get_result();
+$info = $res->fetch_assoc();
+$stmt->close();
+if (!$info) {
+    error('Corte no encontrado');
+}
+$corte_total = (float)$info['total'];
+
+$total_calc = $boucher + $cheque;
+foreach ($desglose as $denom => $cant) {
+    $total_calc += ((float)$denom) * ((int)$cant);
+}
+if (abs($total_calc - $corte_total) > 5) {
+    error('El total del desglose no coincide con el corte');
+}
+
+$conn->begin_transaction();
+$ins = $conn->prepare('INSERT INTO desglose_corte (corte_id, denominacion, cantidad, tipo_pago) VALUES (?, ?, ?, ?)');
+if (!$ins) {
+    $conn->rollback();
+    error('Error al preparar inserción: ' . $conn->error);
+}
+foreach ($desglose as $denom => $cant) {
+    $tipo = 'efectivo';
+    $d = (float)$denom;
+    $c = (int)$cant;
+    if ($c <= 0) continue;
+    $ins->bind_param('idis', $corte_id, $d, $c, $tipo);
+    if (!$ins->execute()) {
+        $conn->rollback();
+        error('Error al guardar desglose: ' . $ins->error);
+    }
+}
+if ($boucher > 0) {
+    $tipo = 'boucher';
+    $d = $boucher;
+    $c = 1;
+    $ins->bind_param('idis', $corte_id, $d, $c, $tipo);
+    if (!$ins->execute()) {
+        $conn->rollback();
+        error('Error al guardar boucher');
+    }
+}
+if ($cheque > 0) {
+    $tipo = 'cheque';
+    $d = $cheque;
+    $c = 1;
+    $ins->bind_param('idis', $corte_id, $d, $c, $tipo);
+    if (!$ins->execute()) {
+        $conn->rollback();
+        error('Error al guardar cheque');
+    }
+}
+$ins->close();
+$conn->commit();
+
+success(['total' => $total_calc]);
+?>

--- a/api/corte_caja/guardar_fondo.php
+++ b/api/corte_caja/guardar_fondo.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$usuario_id = $input['usuario_id'] ?? null;
+$monto = isset($input['monto']) ? (float)$input['monto'] : null;
+if (!$usuario_id || $monto === null) {
+    error('Datos incompletos');
+}
+
+$stmt = $conn->prepare('INSERT INTO fondo (usuario_id, monto) VALUES (?, ?) ON DUPLICATE KEY UPDATE monto = VALUES(monto)');
+if (!$stmt) {
+    error('Error al preparar inserción: ' . $conn->error);
+}
+$stmt->bind_param('id', $usuario_id, $monto);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al guardar fondo: ' . $stmt->error);
+}
+$stmt->close();
+
+success(['monto' => $monto]);
+?>

--- a/api/usuarios/listar_usuarios.php
+++ b/api/usuarios/listar_usuarios.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$result = $conn->query("SELECT id, nombre FROM usuarios WHERE activo = 1 ORDER BY nombre");
+if (!$result) {
+    error('Error al obtener usuarios: ' . $conn->error);
+}
+$usuarios = [];
+while ($row = $result->fetch_assoc()) {
+    $usuarios[] = $row;
+}
+success($usuarios);
+?>

--- a/utils/desglose_corte.sql
+++ b/utils/desglose_corte.sql
@@ -8,3 +8,9 @@ CREATE TABLE desglose_corte (
   tipo_pago ENUM('efectivo','boucher','cheque') DEFAULT 'efectivo',
   FOREIGN KEY (corte_id) REFERENCES corte_caja(id)
 );
+
+CREATE TABLE fondo (
+  usuario_id INT PRIMARY KEY,
+  monto DECIMAL(10,2) NOT NULL,
+  FOREIGN KEY (usuario_id) REFERENCES usuarios(id)
+);

--- a/vistas/reportes/reportes.js
+++ b/vistas/reportes/reportes.js
@@ -1,10 +1,33 @@
 const usuarioId = 1; // En producción usar id de sesión
 
+async function cargarUsuarios() {
+    const sel = document.getElementById('filtroUsuario');
+    if (!sel) return;
+    const r = await fetch('../../api/usuarios/listar_usuarios.php');
+    const d = await r.json();
+    sel.innerHTML = '<option value="">--Todos--</option>';
+    if (d.success) {
+        d.resultado.forEach(u => {
+            const opt = document.createElement('option');
+            opt.value = u.id;
+            opt.textContent = u.nombre;
+            sel.appendChild(opt);
+        });
+    }
+}
+
 async function cargarHistorial() {
     const tbody = document.querySelector('#tablaCortes tbody');
-    tbody.innerHTML = '<tr><td colspan="7">Cargando...</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="11">Cargando...</td></tr>';
     try {
-        const resp = await fetch('../../api/corte_caja/listar_cortes.php');
+        const params = new URLSearchParams();
+        const u = document.getElementById('filtroUsuario').value;
+        const i = document.getElementById('filtroInicio').value;
+        const f = document.getElementById('filtroFin').value;
+        if (u) params.append('usuario_id', u);
+        if (i) params.append('inicio', i);
+        if (f) params.append('fin', f);
+        const resp = await fetch('../../api/corte_caja/listar_cortes.php?' + params.toString());
         const data = await resp.json();
         if (data.success) {
             tbody.innerHTML = '';
@@ -16,6 +39,10 @@ async function cargarHistorial() {
                     <td>${c.fecha_inicio}</td>
                     <td>${c.fecha_fin || ''}</td>
                     <td>${c.total !== null ? c.total : ''}</td>
+                    <td>${c.efectivo || ''}</td>
+                    <td>${c.boucher || ''}</td>
+                    <td>${c.cheque || ''}</td>
+                    <td>${c.fondo_inicial || ''}</td>
                     <td>${c.observaciones || ''}</td>
                     <td><button class="detalle" data-id="${c.id}">Ver detalle</button></td>
                 `;
@@ -96,6 +123,11 @@ async function resumenActual() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+    cargarUsuarios();
     cargarHistorial();
     document.getElementById('btnResumen').addEventListener('click', resumenActual);
+    const btn = document.getElementById('aplicarFiltros');
+    if (btn) btn.addEventListener('click', cargarHistorial);
+    const imp = document.getElementById('btnImprimir');
+    if (imp) imp.addEventListener('click', () => window.print());
 });

--- a/vistas/reportes/reportes.php
+++ b/vistas/reportes/reportes.php
@@ -8,6 +8,13 @@ $title = 'Reportes';
 ob_start();
 ?>
 <h1>Reportes de Cortes</h1>
+<div>
+    Usuario: <select id="filtroUsuario"></select>
+    Inicio: <input type="date" id="filtroInicio">
+    Fin: <input type="date" id="filtroFin">
+    <button id="aplicarFiltros">Buscar</button>
+    <button id="btnImprimir">Imprimir</button>
+</div>
 <button id="btnResumen">Resumen de corte actual</button>
 <div id="modal" style="display:none;"></div>
 <h2>Historial de Cortes</h2>
@@ -19,6 +26,10 @@ ob_start();
             <th>Fecha inicio</th>
             <th>Fecha cierre</th>
             <th>Total</th>
+            <th>Efectivo</th>
+            <th>Tarjeta</th>
+            <th>Cheque</th>
+            <th>Fondo</th>
             <th>Observaciones</th>
             <th>Detalle</th>
         </tr>

--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -90,6 +90,7 @@ ob_start();
     </table>
 
     <div id="modal-detalles" style="display:none;"></div>
+    <div id="modalDesglose" style="display:none;"></div>
 
     <script>
         // ID de usuario proveniente de la sesión para operaciones en JS


### PR DESCRIPTION
## Summary
- support fondo de caja table
- manage fondo via new endpoints
- insert fondo when opening caja
- add cash breakdown modal to close caja
- enhance corte reports with filters and payment totals

## Testing
- `php -l api/corte_caja/guardar_fondo.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661abd3b9c832bb78d3cd18294ad18