### PR TITLE
Implement caja check and cajero-based sale

### DIFF
--- a/api/ventas/crear_venta_mesa.php
+++ b/api/ventas/crear_venta_mesa.php
@@ -1,0 +1,104 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+if (!isset($_SESSION['usuario_id'])) {
+    error('Sesión no iniciada');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    error('JSON inválido');
+}
+
+$mesa_id   = isset($input['mesa_id']) ? (int)$input['mesa_id'] : null;
+$productos = isset($input['productos']) && is_array($input['productos']) ? $input['productos'] : null;
+
+if (!$mesa_id || !$productos) {
+    error('Datos incompletos');
+}
+
+$cajero_id = (int)$_SESSION['usuario_id'];
+
+// Verificar corte abierto para el cajero
+$qc = $conn->prepare('SELECT id FROM corte_caja WHERE usuario_id = ? AND fecha_fin IS NULL ORDER BY fecha_inicio DESC LIMIT 1');
+if (!$qc) {
+    error('Error al preparar consulta de corte: ' . $conn->error);
+}
+$qc->bind_param('i', $cajero_id);
+$qc->execute();
+$resCorte = $qc->get_result();
+if ($resCorte->num_rows === 0) {
+    $qc->close();
+    error('Debe abrir caja antes de iniciar una venta.');
+}
+$corteRow = $resCorte->fetch_assoc();
+$corte_id = (int)$corteRow['id'];
+$qc->close();
+
+// Verificar si ya hay venta activa para la mesa
+$check = $conn->prepare("SELECT id FROM ventas WHERE mesa_id = ? AND estatus = 'activa' LIMIT 1");
+if (!$check) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$check->bind_param('i', $mesa_id);
+$check->execute();
+$resCheck = $check->get_result();
+if ($resCheck->num_rows > 0) {
+    $check->close();
+    error('La mesa ya tiene una venta activa');
+}
+$check->close();
+
+$total = 0;
+foreach ($productos as $p) {
+    if (!isset($p['producto_id'], $p['cantidad'], $p['precio_unitario'])) {
+        error('Formato de producto incorrecto');
+    }
+    $total += $p['cantidad'] * $p['precio_unitario'];
+}
+
+$stmt = $conn->prepare('INSERT INTO ventas (mesa_id, tipo_entrega, total, corte_id, cajero_id) VALUES (?, ?, ?, ?, ?)');
+if (!$stmt) {
+    error('Error al preparar venta: ' . $conn->error);
+}
+$tipo = 'mesa';
+$stmt->bind_param('isdii', $mesa_id, $tipo, $total, $corte_id, $cajero_id);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al crear venta: ' . $stmt->error);
+}
+$venta_id = $stmt->insert_id;
+$stmt->close();
+
+$detalle = $conn->prepare('INSERT INTO venta_detalles (venta_id, producto_id, cantidad, precio_unitario) VALUES (?, ?, ?, ?)');
+if (!$detalle) {
+    error('Error al preparar detalle: ' . $conn->error);
+}
+foreach ($productos as $p) {
+    $producto_id = (int)$p['producto_id'];
+    $cantidad = (int)$p['cantidad'];
+    $precio = (float)$p['precio_unitario'];
+    $detalle->bind_param('iiid', $venta_id, $producto_id, $cantidad, $precio);
+    if (!$detalle->execute()) {
+        $detalle->close();
+        error('Error al insertar detalle: ' . $detalle->error);
+    }
+}
+$detalle->close();
+
+$log = $conn->prepare('INSERT INTO logs_accion (usuario_id, modulo, accion, referencia_id) VALUES (?, ?, ?, ?)');
+if ($log) {
+    $mod = 'ventas';
+    $accion = 'Alta de venta';
+    $log->bind_param('issi', $cajero_id, $mod, $accion, $venta_id);
+    $log->execute();
+    $log->close();
+}
+
+success(['venta_id' => $venta_id]);

--- a/utils/bd.sql
+++ b/utils/bd.sql
@@ -61,6 +61,7 @@ CREATE TABLE IF NOT EXISTS ventas (
     repartidor_id INT DEFAULT NULL,
     tipo_entrega ENUM('mesa','domicilio') DEFAULT 'mesa',
     usuario_id INT,
+    cajero_id INT DEFAULT NULL,
     total DECIMAL(10,2) DEFAULT 0.00,
     corte_id INT DEFAULT NULL,
     estatus ENUM('activa','cerrada','cancelada') DEFAULT 'activa',
@@ -68,6 +69,7 @@ CREATE TABLE IF NOT EXISTS ventas (
     FOREIGN KEY (mesa_id) REFERENCES mesas(id),
     FOREIGN KEY (repartidor_id) REFERENCES repartidores(id),
     FOREIGN KEY (usuario_id) REFERENCES usuarios(id),
+    FOREIGN KEY (cajero_id) REFERENCES usuarios(id),
     FOREIGN KEY (corte_id) REFERENCES corte_caja(id)
 );
 
@@ -473,6 +475,8 @@ ADD COLUMN observaciones TEXT;
 
 ALTER TABLE ventas ADD COLUMN corte_id INT DEFAULT NULL;
 ALTER TABLE ventas ADD CONSTRAINT fk_corte FOREIGN KEY (corte_id) REFERENCES corte_caja(id);
+ALTER TABLE ventas ADD COLUMN cajero_id INT DEFAULT NULL;
+ALTER TABLE ventas ADD CONSTRAINT fk_cajero FOREIGN KEY (cajero_id) REFERENCES usuarios(id);
 -- Agrega campo de observaciones al corte en reportes
 ALTER TABLE corte_caja
 ADD COLUMN observaciones TEXT;


### PR DESCRIPTION
## Summary
- add `cajero_id` column definition to `ventas` table and update migration script
- create endpoint `crear_venta_mesa.php` that inserts sales using the logged in user as cajero
- check for open cash register and existing active sale before creating
- verify caja status from `mesas.js` before opening/creating a sale and use new API

## Testing
- `php` linting not available


------
https://chatgpt.com/codex/tasks/task_e_6866c0b86458832b9608bdb5df3b21e2