### PR TITLE
Implement cash breakdown entry after closing cash register

### DIFF
--- a/vistas/corte_caja/corte.php
+++ b/vistas/corte_caja/corte.php
@@ -12,6 +12,7 @@ ob_start();
     <button id="btnIniciar">Iniciar Corte</button>
 </div>
 <div id="resumenModal" style="display:none;"></div>
+<div id="modalDesglose" style="display:none;"></div>
 <h2>Historial de Cortes</h2>
 <table id="tablaCortes" border="1">
     <thead>


### PR DESCRIPTION
## Summary
- open modal after successfully closing a cut
- include container for cash breakdown in the view
- allow entering denomination, quantity and payment type
- add endpoint logic to accept new `detalle` structure and insert rows

## Testing
- `php -l api/corte_caja/guardar_desglose.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867454d3c08832ba15e1fddd66ab9fc