### PR TITLE
Fix delivery button visibility

### DIFF
--- a/vistas/cocina/cocina.js
+++ b/vistas/cocina/cocina.js
@@ -12,14 +12,17 @@ function colorPorTiempo(min) {
     return '#f8d7da';
 }
 
-function botonPorEstado(estado, id) {
+function botonPorEstado(estado, id, tipo) {
     switch (estado) {
         case 'pendiente':
             return `<button class="cambiar" data-id="${id}" data-sig="en_preparacion">Iniciar</button>`;
         case 'en_preparacion':
             return `<button class="cambiar" data-id="${id}" data-sig="listo">Listo</button>`;
         case 'listo':
-            return `<button class="cambiar" data-id="${id}" data-sig="entregado">Entregar</button>`;
+            if (tipo === 'domicilio') {
+                return `<button class="cambiar" data-id="${id}" data-sig="entregado">Entregar</button>`;
+            }
+            return '';
         default:
             return '';
     }
@@ -48,7 +51,7 @@ async function cargarPendientes() {
                     <td>${p.cantidad}</td>
                     <td>${t.texto}</td>
                     <td>${p.estado}</td>
-                    <td>${botonPorEstado(p.estado, p.detalle_id)}</td>`;
+                    <td>${botonPorEstado(p.estado, p.detalle_id, p.tipo)}</td>`;
                 tr.style.backgroundColor = colorPorTiempo(t.minutos);
                 tbody.appendChild(tr);
             });


### PR DESCRIPTION
## Summary
- only show the "Entregar" action in kitchen view when the order is for delivery

## Testing
- `php -l vistas/cocina/cocina.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696e6afb74832babce4d9116e54061