### PR TITLE
Add image handling to insumos

### DIFF
--- a/api/insumos/agregar_insumo.php
+++ b/api/insumos/agregar_insumo.php
@@ -6,25 +6,33 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     error('Método no permitido');
 }
 
-$input = json_decode(file_get_contents('php://input'), true);
-if (!$input) {
-    error('JSON inválido');
-}
-
-$nombre      = isset($input['nombre']) ? trim($input['nombre']) : '';
-$unidad      = isset($input['unidad']) ? trim($input['unidad']) : '';
-$existencia  = isset($input['existencia']) ? (float)$input['existencia'] : 0;
-$tipo        = isset($input['tipo_control']) ? trim($input['tipo_control']) : '';
+$nombre      = isset($_POST['nombre']) ? trim($_POST['nombre']) : '';
+$unidad      = isset($_POST['unidad']) ? trim($_POST['unidad']) : '';
+$existencia  = isset($_POST['existencia']) ? (float)$_POST['existencia'] : 0;
+$tipo        = isset($_POST['tipo_control']) ? trim($_POST['tipo_control']) : '';
 
 if ($nombre === '' || $unidad === '' || $tipo === '') {
     error('Datos incompletos');
 }
 
-$stmt = $conn->prepare('INSERT INTO insumos (nombre, unidad, existencia, tipo_control) VALUES (?, ?, ?, ?)');
+$aliasImagen = '';
+if (!empty($_FILES['imagen']['name'])) {
+    $dir = __DIR__ . '/../../uploads/';
+    if (!is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+    $ext = pathinfo($_FILES['imagen']['name'], PATHINFO_EXTENSION);
+    $aliasImagen = uniqid('ins_') . ($ext ? ".{$ext}" : '');
+    if (!move_uploaded_file($_FILES['imagen']['tmp_name'], $dir . $aliasImagen)) {
+        error('Error al subir imagen');
+    }
+}
+
+$stmt = $conn->prepare('INSERT INTO insumos (nombre, unidad, existencia, tipo_control, imagen) VALUES (?, ?, ?, ?, ?)');
 if (!$stmt) {
     error('Error al preparar inserción: ' . $conn->error);
 }
-$stmt->bind_param('ssds', $nombre, $unidad, $existencia, $tipo);
+$stmt->bind_param('ssdss', $nombre, $unidad, $existencia, $tipo, $aliasImagen);
 if (!$stmt->execute()) {
     $stmt->close();
     error('Error al agregar insumo: ' . $stmt->error);

--- a/api/insumos/listar_insumos.php
+++ b/api/insumos/listar_insumos.php
@@ -2,7 +2,7 @@
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
-$query = "SELECT id, nombre, unidad, existencia, tipo_control FROM insumos ORDER BY nombre";
+$query = "SELECT id, nombre, unidad, existencia, tipo_control, imagen FROM insumos ORDER BY nombre";
 $result = $conn->query($query);
 
 if (!$result) {

--- a/utils/bd.sql
+++ b/utils/bd.sql
@@ -89,17 +89,18 @@ CREATE TABLE `insumos` (
   `nombre` varchar(100) DEFAULT NULL,
   `unidad` varchar(20) DEFAULT NULL,
   `existencia` decimal(10,2) DEFAULT NULL,
-  `tipo_control` enum('por_receta','unidad_completa','uso_general','no_controlado','desempaquetado') DEFAULT 'por_receta'
+  `tipo_control` enum('por_receta','unidad_completa','uso_general','no_controlado','desempaquetado') DEFAULT 'por_receta',
+  `imagen` varchar(255) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 
 
-INSERT INTO `insumos` (`id`, `nombre`, `unidad`, `existencia`, `tipo_control`) VALUES
-(1, 'Arroz para sushi', 'gramos', 8800.00, 'por_receta'),
-(2, 'Alga Nori', 'piezas', 192.00, 'por_receta'),
-(3, 'Salmón fresco', 'gramos', 4600.00, 'por_receta'),
-(4, 'Refresco en lata', 'piezas', 19.00, 'unidad_completa'),
-(5, 'Salsa Soya', 'ml', 5000.00, 'uso_general');
+INSERT INTO `insumos` (`id`, `nombre`, `unidad`, `existencia`, `tipo_control`, `imagen`) VALUES
+(1, 'Arroz para sushi', 'gramos', 8800.00, 'por_receta', ''),
+(2, 'Alga Nori', 'piezas', 192.00, 'por_receta', ''),
+(3, 'Salmón fresco', 'gramos', 4600.00, 'por_receta', ''),
+(4, 'Refresco en lata', 'piezas', 19.00, 'unidad_completa', ''),
+(5, 'Salsa Soya', 'ml', 5000.00, 'uso_general', '');
 
 
 DELIMITER $$

--- a/vistas/insumos/insumos.php
+++ b/vistas/insumos/insumos.php
@@ -89,32 +89,30 @@ ob_start();
                     <h2>Recuerda validar los datos antes de guardar altas</h2>
                      <button type="button" id="btnNuevoInsumo">Nuevo insumo</button>
                 </div>
-                <div class="row">
-
-                <!-- aqui deben ir insumos -->
-                    <div class="col-md-3">
-                        <div class="blog-item">
-                            <div class="blog-img">
-                                <img src="../../utils/img/blog-1.jpg" alt="Blog">
-                            </div>
-                            <div class="blog-content">
-                                <h2 class="blog-title">Lorem ipsum dolor sit amet</h2>
-                                <div class="blog-meta">
-                                    <p><i class="far fa-user"></i>Admin</p>
-                                    <p><i class="far fa-list-alt"></i>Food</p>
-                                    <p><i class="far fa-calendar-alt"></i>01-Jan-2045</p>
-                                    <p><i class="far fa-comments"></i>10</p>
-                                </div>
-                                <div class="blog-text">
-                                    <p>
-                                        Lorem ipsum dolor sit amet elit. Neca pretim miura bitur facili ornare velit non vulpte liqum metus tortor. Lorem ipsum dolor sit amet elit. Neca pretim miura bitur facili ornare velit non vulpte
-                                    </p>
-                                    <a class="btn custom-btn" href="">Read More</a>
-                                </div>
-                            </div>
-                        </div>
+                <div class="row" id="catalogoInsumos"></div>
+                
+                <form id="formInsumo" style="display:none;margin-top:20px;">
+                    <input type="hidden" id="insumoId">
+                    <div>
+                        <label>Nombre:</label>
+                        <input type="text" id="nombre">
+                        <label>Unidad:</label>
+                        <input type="text" id="unidad">
+                        <label>Existencia:</label>
+                        <input type="number" step="0.01" id="existencia" value="0">
+                        <label>Tipo:</label>
+                        <select id="tipo_control">
+                            <option value="por_receta">por_receta</option>
+                            <option value="unidad_completa">unidad_completa</option>
+                            <option value="uso_general">uso_general</option>
+                            <option value="no_controlado">no_controlado</option>
+                            <option value="desempaquetado">desempaquetado</option>
+                        </select>
+                        <input type="file" id="imagen">
+                        <button type="submit">Guardar</button>
+                        <button type="button" id="cancelarInsumo">Cancelar</button>
                     </div>
-               <!-- aqui termina donde van insumos -->
+                </form>
 
                 </div>
                 <div class="row">


### PR DESCRIPTION
## Summary
- extend DB script adding imagen column in insumos
- support uploading image on add and update API endpoints
- return imagen on list endpoint
- display insumos as cards with image and CRUD actions
- provide form with file input to create or edit
- adjust JS to use FormData and update cards

## Testing
- `php` not available, no automated tests run

------
https://chatgpt.com/codex/tasks/task_e_686b19b9d734832baf3866b6bcca8626