### PR TITLE
Implementar cards para pedidos entregados

### DIFF
--- a/vistas/cocina/cocina.js
+++ b/vistas/cocina/cocina.js
@@ -92,7 +92,9 @@ async function cargarEntregados() {
         const data = await resp.json();
         if (data.success) {
             const tbody = document.querySelector('#tabla-entregados tbody');
+            const contCards = document.getElementById('entregados-cards');
             tbody.innerHTML = '';
+            contCards.innerHTML = '';
             let grupo = '';
             data.resultado.forEach(p => {
                 if (p.destino !== grupo) {
@@ -104,6 +106,24 @@ async function cargarEntregados() {
                 const tr = document.createElement('tr');
                 tr.innerHTML = `<td>${p.producto}</td><td>${p.cantidad}</td><td>${p.hora}</td>`;
                 tbody.appendChild(tr);
+
+                const t = tiempoTranscurrido(p.hora);
+                const card = document.createElement('div');
+                card.className = 'col-lg-7 col-md-12';
+                card.innerHTML = `
+                    <div class="menu-item">
+                        <div class="menu-img">
+                            <img src="../../utils/img/menu-burger.jpg" alt="Image">
+                        </div>
+                        <div class="menu-text">
+                            <h3>
+                                <span>${p.destino}</span>
+                                <strong style="background-color:${colorPorTiempo(t.minutos)}">${p.estado}</strong>
+                            </h3>
+                            <p>${p.cantidad} unidades - ${t.texto}</p>
+                        </div>
+                    </div>`;
+                contCards.appendChild(card);
             });
         }
     } catch (err) {

--- a/vistas/cocina/cocina.php
+++ b/vistas/cocina/cocina.php
@@ -90,20 +90,8 @@ ob_start();
                         </div>
                         <div id="Entregados" class="container tab-pane fade">
                             <div class="row">
-                                <div class="col-lg-7 col-md-12">
-
-                                <!-- entregados aqui-->
-                                    <div class="menu-item">
-                                        <div class="menu-img">
-                                            <img src="../../utils/img/menu-snack.jpg" alt="Image">
-                                        </div>
-                                        <div class="menu-text">
-                                            <h3><span>Corn Tikki - Spicy fried Aloo</span> <strong>$15.00</strong></h3>
-                                            <p>Lorem ipsum dolor sit amet elit. Phasel nec preti facil</p>
-                                        </div>
-                                    </div>
-
-                                </div>
+                                <!-- entregados aqui -->
+                                <div id="entregados-cards" class="col-lg-7 col-md-12"></div>
                                 <div class="col-lg-5 d-none d-lg-block">
                                     <img src="../../utils/img/menu-snack-img.jpg" alt="Image">
                                 </div>


### PR DESCRIPTION
## Summary
- agregar contenedor `entregados-cards` en la vista
- mostrar tarjetas de pedidos entregados usando los datos de la API

## Testing
- `php -l vistas/cocina/cocina.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c2c598e44832b9660e3fb5d285b02