### PR TITLE
Remove cocina tables and use card view

### DIFF
--- a/vistas/cocina/cocina.js
+++ b/vistas/cocina/cocina.js
@@ -33,49 +33,36 @@ async function cargarPendientes() {
         const resp = await fetch('../../api/cocina/listar_pendientes.php');
         const data = await resp.json();
         if (data.success) {
-            const tbody = document.querySelector('#tabla-pendientes tbody');
             const contCards = document.getElementById('pendientes-cards');
-            tbody.innerHTML = '';
             contCards.innerHTML = '';
             let grupo = '';
             data.resultado.forEach(p => {
                 if (p.destino !== grupo) {
-                    const trg = document.createElement('tr');
-                    trg.innerHTML = `<td colspan="5"><strong>${p.destino}</strong></td>`;
-                    tbody.appendChild(trg);
+                    const header = document.createElement('h5');
+                    header.textContent = p.destino;
+                    contCards.appendChild(header);
                     grupo = p.destino;
                 }
-                const tr = document.createElement('tr');
                 const t = tiempoTranscurrido(p.hora);
                 const obs = p.observaciones ? ` <span title="${p.observaciones}">🛈</span>` : '';
-                tr.innerHTML = `
-                    <td>${p.producto}${obs}</td>
-                    <td>${p.cantidad}</td>
-                    <td>${t.texto}</td>
-                    <td>${p.estado}</td>
-                    <td>${botonPorEstado(p.estado, p.detalle_id, p.tipo)}</td>`;
-                tr.style.backgroundColor = colorPorTiempo(t.minutos);
-                tbody.appendChild(tr);
-
                 const card = document.createElement('div');
-                card.className = 'col-lg-7 col-md-12';
+                card.className = 'menu-item';
                 card.innerHTML = `
-                    <div class="menu-item">
-                        <div class="menu-img">
-                            <img src="../../utils/img/menu-burger.jpg" alt="Image">
-                        </div>
-                        <div class="menu-text">
-                            <h3>
-                                <span>${p.destino}</span>
-                                <strong style="background-color:${colorPorTiempo(t.minutos)}">${p.estado}</strong>
-                            </h3>
-                            <p>${p.producto} Total de: ${p.cantidad} unidades - ${t.texto}</p>
-                        </div>
+                    <div class="menu-img">
+                        <img src="../../utils/img/menu-burger.jpg" alt="Image">
+                    </div>
+                    <div class="menu-text">
+                        <h3>
+                            <span>${p.producto}${obs}</span>
+                            <strong style="background-color:${colorPorTiempo(t.minutos)}">${p.estado}</strong>
+                        </h3>
+                        <p>${p.cantidad} unidades - ${t.texto}</p>
+                        ${botonPorEstado(p.estado, p.detalle_id, p.tipo)}
                     </div>`;
                 contCards.appendChild(card);
-            });
-            tbody.querySelectorAll('button.cambiar').forEach(btn => {
-                btn.addEventListener('click', () => cambiarEstado(btn.dataset.id, btn.dataset.sig));
+                card.querySelectorAll('button.cambiar').forEach(btn => {
+                    btn.addEventListener('click', () => cambiarEstado(btn.dataset.id, btn.dataset.sig));
+                });
             });
         } else {
             alert(data.mensaje);
@@ -91,37 +78,29 @@ async function cargarEntregados() {
         const resp = await fetch('../../api/cocina/listar_entregados.php');
         const data = await resp.json();
         if (data.success) {
-            const tbody = document.querySelector('#tabla-entregados tbody');
             const contCards = document.getElementById('entregados-cards');
-            tbody.innerHTML = '';
             contCards.innerHTML = '';
             let grupo = '';
             data.resultado.forEach(p => {
                 if (p.destino !== grupo) {
-                    const trg = document.createElement('tr');
-                    trg.innerHTML = `<td colspan="4"><strong>${p.destino}</strong></td>`;
-                    tbody.appendChild(trg);
+                    const header = document.createElement('h5');
+                    header.textContent = p.destino;
+                    contCards.appendChild(header);
                     grupo = p.destino;
                 }
-                const tr = document.createElement('tr');
-                tr.innerHTML = `<td>${p.producto}</td><td>${p.cantidad}</td><td>${p.hora}</td>`;
-                tbody.appendChild(tr);
-
                 const t = tiempoTranscurrido(p.hora);
                 const card = document.createElement('div');
-                card.className = 'col-lg-7 col-md-12';
+                card.className = 'menu-item';
                 card.innerHTML = `
-                    <div class="menu-item">
-                        <div class="menu-img">
-                            <img src="../../utils/img/menu-burger.jpg" alt="Image">
-                        </div>
-                        <div class="menu-text">
-                            <h3>
-                                <span>${p.destino}</span>
-                                <strong style="background-color:${colorPorTiempo(t.minutos)}">${p.estado}</strong>
-                            </h3>
-                            <p>${p.cantidad} unidades - ${t.texto}</p>
-                        </div>
+                    <div class="menu-img">
+                        <img src="../../utils/img/menu-burger.jpg" alt="Image">
+                    </div>
+                    <div class="menu-text">
+                        <h3>
+                            <span>${p.producto}</span>
+                            <strong style="background-color:${colorPorTiempo(t.minutos)}">${p.estado}</strong>
+                        </h3>
+                        <p>${p.cantidad} unidades - ${t.texto}</p>
                     </div>`;
                 contCards.appendChild(card);
             });
@@ -153,16 +132,10 @@ async function cambiarEstado(detalleId, nuevo) {
 
 document.addEventListener('DOMContentLoaded', () => {
     cargarPendientes();
-    document.getElementById('btn-pendientes').addEventListener('click', () => {
-        document.getElementById('seccion-pendientes').style.display = 'block';
-        document.getElementById('seccion-entregados').style.display = 'none';
-        cargarPendientes();
+    document.querySelector('a[href="#Pendientes"]').addEventListener('click', () => {
+        setTimeout(cargarPendientes, 10);
     });
-document.querySelector('a[href="#Entregados"]').addEventListener('click', (e) => {
-    setTimeout(() => {
-        document.getElementById('seccion-pendientes').style.display = 'none';
-        document.getElementById('seccion-entregados').style.display = 'block';
-        cargarEntregados();
-    }, 10); // pequeño delay por comportamiento del tab
-});
+    document.querySelector('a[href="#Entregados"]').addEventListener('click', () => {
+        setTimeout(cargarEntregados, 10);
+    });
 });

--- a/vistas/cocina/cocina.php
+++ b/vistas/cocina/cocina.php
@@ -27,39 +27,7 @@ ob_start();
         
         
 
-<!-- pendientes -->
- <button id="btn-pendientes">Pendientes</button>
-<button id="btn-entregados">Entregados hoy</button>
-<div id="seccion-pendientes">
-    <table id="tabla-pendientes" border="1">
-        <thead>
-            <tr>
-                <th>Producto</th>
-                <th>Cantidad</th>
-                <th>Tiempo</th>
-                <th>Estado</th>
-                <th>Acciones</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
-</div>       
-<!-- Pendientes -->
 
-<!-- entregados -->
-<div id="seccion-entregados" style="display:none;">
-    <table id="tabla-entregados" border="1">
-        <thead>
-            <tr>
-                <th>Producto</th>
-                <th>Cantidad</th>
-                <th>Hora</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
-</div>
-<!-- entregados -->
 
         <!-- Menu Start -->
         <div class="menu">


### PR DESCRIPTION
## Summary
- drop old tables from `cocina.php`
- render orders in card containers using `cocina.js`
- hook tab clicks to reload data

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686d6c922c98832b9a39f93dd1082013