### PR TITLE
Handle dynamic sales buttons with jQuery

### DIFF
--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -133,7 +133,9 @@ ob_start();
 </div>
 
 <!-- Modales -->
-<div id="modal-detalles" class="custom-modal" style="display:none;"></div>
+<div id="modalDetalle" class="custom-modal" style="display:none;">
+  <div id="detalleContenido"></div>
+</div>
 <div id="modalDesglose" class="custom-modal" style="display:none;"></div>
 
 


### PR DESCRIPTION
## Summary
- add modal container ids for ventas
- adjust ventas table buttons to use `.btn-detalle` and `.btn-cancelar`
- display detail info in `#detalleContenido` inside `#modalDetalle`
- delegate click handlers with jQuery to support dynamic rows

## Testing
- `php -l vistas/ventas/ventas.php`

------
https://chatgpt.com/codex/tasks/task_e_68716afa7b08832b8e382baf5b92403c