### PR TITLE
Fix inventory confirmation modal

### DIFF
--- a/utils/css/style2.css
+++ b/utils/css/style2.css
@@ -1333,7 +1333,6 @@ a:focus {
   border: 2px solid #cc0000;
   padding: 20px;
   border-radius: 8px;
-  margin-top: 20px;
 }
 
 #tablaCortes {

--- a/vistas/inventario/inventario.js
+++ b/vistas/inventario/inventario.js
@@ -48,11 +48,13 @@ async function actualizarExistencia(id, valor) {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ producto_id: parseInt(id), nueva_existencia: parseInt(valor) })
         });
+        if (!resp.ok) throw new Error('Respuesta no válida');
         const data = await resp.json();
-        if (!data.success) {
-            mostrarModal('Error', data.mensaje || 'No se pudo actualizar');
+        if (data && data.success) {
+            mostrarConfirmacion('¡Cambiado exitosamente!');
+            cargarProductos();
         } else {
-            mostrarModal('Éxito', 'Existencia actualizada correctamente');
+            mostrarModal('Error', (data && data.mensaje) || 'No se pudo actualizar');
         }
     } catch (err) {
         console.error(err);
@@ -109,6 +111,12 @@ function mostrarModal(titulo, mensaje) {
     document.getElementById('cerrarModal').onclick = () => {
         modal.style.display = 'none';
     };
+}
+
+function mostrarConfirmacion(mensaje) {
+    const $modal = $('#modalConfirmacion');
+    $modal.find('.mensaje').text(mensaje);
+    $modal.modal('show');
 }
 
 

--- a/vistas/inventario/inventario.php
+++ b/vistas/inventario/inventario.php
@@ -77,6 +77,20 @@ ob_start();
   </div>
 </div>
 
+<!-- Modal Bootstrap para confirmación -->
+<div class="modal fade" id="modalConfirmacion" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content custom-modal">
+      <div class="modal-body text-center">
+        <p class="mensaje mb-0">¡Cambiado exitosamente!</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn custom-btn" data-dismiss="modal">Aceptar</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 
 <script src="inventario.js"></script>
 <?php


### PR DESCRIPTION
## Summary
- show Bootstrap confirmation modal after successful inventory update
- adjust `.custom-modal` style to remove extra margin
- add confirmation modal markup to `inventario.php`
- update JS to display new modal and reload table on success

## Testing
- `php -l api/inventario/actualizar_existencia.php`
- `php -l vistas/inventario/inventario.php`
- `php -l vistas/inventario/inventario.js`

------
https://chatgpt.com/codex/tasks/task_e_68717faf2128832ba53f4af7a1f8edea