### PR TITLE
Procesa imágenes de insumos

### DIFF
--- a/api/insumos/actualizar_insumo.php
+++ b/api/insumos/actualizar_insumo.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
+require_once __DIR__ . '/../../utils/imagen.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     error('Método no permitido');
@@ -34,13 +35,9 @@ $sel->close();
 $aliasImagen = $actual;
 if (!empty($_FILES['imagen']['name'])) {
     $dir = __DIR__ . '/../../uploads/';
-    if (!is_dir($dir)) {
-        mkdir($dir, 0777, true);
-    }
-    $ext = pathinfo($_FILES['imagen']['name'], PATHINFO_EXTENSION);
-    $aliasImagen = uniqid('ins_') . ($ext ? ".{$ext}" : '');
-    if (!move_uploaded_file($_FILES['imagen']['tmp_name'], $dir . $aliasImagen)) {
-        error('Error al subir imagen');
+    $aliasImagen = procesarImagenInsumo($_FILES['imagen'], $dir);
+    if (!$aliasImagen) {
+        error('Error al procesar imagen');
     }
     if ($actual && file_exists($dir . $actual)) {
         @unlink($dir . $actual);

--- a/api/insumos/agregar_insumo.php
+++ b/api/insumos/agregar_insumo.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
+require_once __DIR__ . '/../../utils/imagen.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     error('Método no permitido');
@@ -18,13 +19,9 @@ if ($nombre === '' || $unidad === '' || $tipo === '') {
 $aliasImagen = '';
 if (!empty($_FILES['imagen']['name'])) {
     $dir = __DIR__ . '/../../uploads/';
-    if (!is_dir($dir)) {
-        mkdir($dir, 0777, true);
-    }
-    $ext = pathinfo($_FILES['imagen']['name'], PATHINFO_EXTENSION);
-    $aliasImagen = uniqid('ins_') . ($ext ? ".{$ext}" : '');
-    if (!move_uploaded_file($_FILES['imagen']['tmp_name'], $dir . $aliasImagen)) {
-        error('Error al subir imagen');
+    $aliasImagen = procesarImagenInsumo($_FILES['imagen'], $dir);
+    if (!$aliasImagen) {
+        error('Error al procesar imagen');
     }
 }
 

--- a/utils/imagen.php
+++ b/utils/imagen.php
@@ -1,0 +1,58 @@
+<?php
+function procesarImagenInsumo(array $file, string $dir): ?string
+{
+    if (!isset($file['tmp_name']) || $file['error'] !== UPLOAD_ERR_OK) {
+        return null;
+    }
+    if (!is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+    $info = getimagesize($file['tmp_name']);
+    if (!$info) {
+        return null;
+    }
+    $mime = $info['mime'];
+    switch ($mime) {
+        case 'image/jpeg':
+        case 'image/pjpeg':
+            $src = imagecreatefromjpeg($file['tmp_name']);
+            break;
+        case 'image/png':
+            $src = imagecreatefrompng($file['tmp_name']);
+            break;
+        default:
+            return null;
+    }
+    if (!$src) {
+        return null;
+    }
+    $width = imagesx($src);
+    $height = imagesy($src);
+    $size = 768;
+    $dst = imagecreatetruecolor($size, $size);
+    $white = imagecolorallocate($dst, 255, 255, 255);
+    imagefill($dst, 0, 0, $white);
+    $ratio = min($size / $width, $size / $height);
+    $new_w = (int)($width * $ratio);
+    $new_h = (int)($height * $ratio);
+    $dst_x = (int)(($size - $new_w) / 2);
+    $dst_y = (int)(($size - $new_h) / 2);
+    imagecopyresampled($dst, $src, $dst_x, $dst_y, 0, 0, $new_w, $new_h, $width, $height);
+    $nombre = uniqid('ins_');
+    $archivoJpg = rtrim($dir, '/') . '/' . $nombre . '.jpg';
+    if (@imagejpeg($dst, $archivoJpg, 85)) {
+        imagedestroy($src);
+        imagedestroy($dst);
+        return $nombre . '.jpg';
+    }
+    $archivoPng = rtrim($dir, '/') . '/' . $nombre . '.png';
+    if (@imagepng($dst, $archivoPng)) {
+        imagedestroy($src);
+        imagedestroy($dst);
+        return $nombre . '.png';
+    }
+    imagedestroy($src);
+    imagedestroy($dst);
+    return null;
+}
+?>


### PR DESCRIPTION
## Summary
- add helper `procesarImagenInsumo` to resize any uploaded image to 768x768px
- use the helper when creating and updating supplies

## Testing
- `php -l utils/imagen.php`
- `php -l api/insumos/agregar_insumo.php`
- `php -l api/insumos/actualizar_insumo.php`


------
https://chatgpt.com/codex/tasks/task_e_6875605e068c832bae2bfa042dd1ca4c