### PR TITLE
Mejora carga y actualización de imágenes de recetas

### DIFF
--- a/api/inventario/subir_imagen_producto.php
+++ b/api/inventario/subir_imagen_producto.php
@@ -1,0 +1,53 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+require_once __DIR__ . '/../../utils/imagen.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$producto_id = isset($_POST['producto_id']) ? (int)$_POST['producto_id'] : 0;
+if ($producto_id <= 0 || empty($_FILES['imagen']['name'])) {
+    error('Datos incompletos');
+}
+
+// obtener imagen actual
+$stmt = $conn->prepare('SELECT imagen FROM productos WHERE id = ?');
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('i', $producto_id);
+$stmt->execute();
+$res = $stmt->get_result();
+if (!$res || $res->num_rows === 0) {
+    $stmt->close();
+    error('Producto no encontrado');
+}
+$actual = $res->fetch_assoc()['imagen'];
+$stmt->close();
+
+$dir = __DIR__ . '/../../uploads/productos/';
+$alias = procesarImagenProducto($_FILES['imagen'], $dir);
+if (!$alias) {
+    error('Error al procesar imagen');
+}
+
+if ($actual && file_exists($dir . $actual)) {
+    @unlink($dir . $actual);
+}
+
+$up = $conn->prepare('UPDATE productos SET imagen = ? WHERE id = ?');
+if (!$up) {
+    error('Error al guardar imagen: ' . $conn->error);
+}
+$up->bind_param('si', $alias, $producto_id);
+if (!$up->execute()) {
+    $up->close();
+    error('Error al actualizar producto: ' . $up->error);
+}
+$up->close();
+
+$path = 'uploads/productos/' . $alias;
+success(['ruta' => $path]);
+

--- a/utils/imagen.php
+++ b/utils/imagen.php
@@ -169,5 +169,74 @@ function procesarImagenInsumo(array $file, string $dir): ?string
 
 }
 
+function procesarImagenProducto(array $file, string $dir): ?string
+{
+    if (!isset($file['tmp_name']) || $file['error'] !== UPLOAD_ERR_OK) {
+        return null;
+    }
+
+    if (!is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+
+    $info = getimagesize($file['tmp_name']);
+    if (!$info) {
+        return null;
+    }
+
+    $mime = $info['mime'];
+    switch ($mime) {
+        case 'image/jpeg':
+        case 'image/pjpeg':
+            $src = imagecreatefromjpeg($file['tmp_name']);
+            break;
+        case 'image/png':
+            $src = imagecreatefrompng($file['tmp_name']);
+            break;
+        default:
+            return null;
+    }
+
+    if (!$src) {
+        return null;
+    }
+
+    $width = imagesx($src);
+    $height = imagesy($src);
+    $size = 768;
+
+    $dst = imagecreatetruecolor($size, $size);
+    $white = imagecolorallocate($dst, 255, 255, 255);
+    imagefill($dst, 0, 0, $white);
+
+    $ratio = min($size / $width, $size / $height);
+    $new_w = (int)($width * $ratio);
+    $new_h = (int)($height * $ratio);
+    $dst_x = (int)(($size - $new_w) / 2);
+    $dst_y = (int)(($size - $new_h) / 2);
+
+    imagecopyresampled($dst, $src, $dst_x, $dst_y, 0, 0, $new_w, $new_h, $width, $height);
+
+    $nombre = uniqid('prod_');
+
+    $archivoJpg = rtrim($dir, '/') . '/' . $nombre . '.jpg';
+    if (@imagejpeg($dst, $archivoJpg, 85)) {
+        imagedestroy($src);
+        imagedestroy($dst);
+        return $nombre . '.jpg';
+    }
+
+    $archivoPng = rtrim($dir, '/') . '/' . $nombre . '.png';
+    if (@imagepng($dst, $archivoPng)) {
+        imagedestroy($src);
+        imagedestroy($dst);
+        return $nombre . '.png';
+    }
+
+    imagedestroy($src);
+    imagedestroy($dst);
+    return null;
+}
+
 
 ?>

--- a/vistas/recetas/recetas.js
+++ b/vistas/recetas/recetas.js
@@ -1,5 +1,6 @@
 let catalogoInsumos = [];
 let catalogoProductos = [];
+const imagenDefault = '../../utils/img/default.jpg';
 
 function mostrarImagenProducto(id) {
     const img = document.getElementById('imgProducto');
@@ -17,11 +18,10 @@ function mostrarImagenProducto(id) {
     nom.textContent = prod.nombre;
     if (prod.imagen) {
         img.src = `../../uploads/productos/${prod.imagen}`;
-        img.style.display = 'block';
     } else {
-        img.style.display = 'none';
-        img.src = '';
+        img.src = imagenDefault;
     }
+    img.style.display = 'block';
     frm.style.display = 'block';
 }
 
@@ -271,7 +271,7 @@ async function subirImagenProducto() {
     fd.append('producto_id', producto_id);
     fd.append('imagen', file);
     try {
-        const resp = await fetch('../../api/inventario/actualizar_imagen.php', {
+        const resp = await fetch('../../api/inventario/subir_imagen_producto.php', {
             method: 'POST',
             body: fd
         });
@@ -279,7 +279,7 @@ async function subirImagenProducto() {
         if (data.success) {
             alert('Imagen actualizada');
             const prod = catalogoProductos.find(p => p.id == producto_id);
-            if (prod) prod.imagen = data.resultado.imagen;
+            if (prod) prod.imagen = data.resultado.ruta.split('/').pop();
             mostrarImagenProducto(producto_id);
         } else {
             alert(data.mensaje);


### PR DESCRIPTION
## Summary
- show product name and image when selecting a dish
- use default image when product doesn't have one
- allow uploading a new product image
- resize and convert product image on the backend

## Testing
- `php -l utils/imagen.php`
- `php -l api/inventario/subir_imagen_producto.php`


------
https://chatgpt.com/codex/tasks/task_e_6877c5e47818832b8cbd9ae174a67f7e