### PR TITLE
Add observacion field to ventas

### DIFF
--- a/api/repartidores/listar_entregas.php
+++ b/api/repartidores/listar_entregas.php
@@ -17,7 +17,7 @@ if (isset($_GET['repartidor_id'])) {
 
 if ($repartidor_id) {
     $stmt = $conn->prepare(
-        "SELECT v.id, v.fecha, v.total, v.estatus, v.entregado, v.estado_entrega, v.fecha_asignacion, v.fecha_inicio, v.fecha_entrega, v.seudonimo_entrega, v.foto_entrega, r.nombre AS repartidor FROM ventas v JOIN repartidores r ON v.repartidor_id = r.id WHERE v.repartidor_id = ? AND v.estatus IN ('activa','cerrada') ORDER BY v.fecha DESC"
+        "SELECT v.id, v.fecha, v.total, v.estatus, v.entregado, v.estado_entrega, v.fecha_asignacion, v.fecha_inicio, v.fecha_entrega, v.seudonimo_entrega, v.foto_entrega, v.observacion, r.nombre AS repartidor FROM ventas v JOIN repartidores r ON v.repartidor_id = r.id WHERE v.repartidor_id = ? AND v.estatus IN ('activa','cerrada') ORDER BY v.fecha DESC"
     );
     if (!$stmt) {
         error('Error al preparar consulta: ' . $conn->error);
@@ -25,7 +25,7 @@ if ($repartidor_id) {
     $stmt->bind_param('i', $repartidor_id);
 } else {
     $stmt = $conn->prepare(
-        "SELECT v.id, v.fecha, v.total, v.estatus, v.entregado, v.estado_entrega, v.fecha_asignacion, v.fecha_inicio, v.fecha_entrega, v.seudonimo_entrega, v.foto_entrega, r.nombre AS repartidor FROM ventas v JOIN repartidores r ON v.repartidor_id = r.id WHERE v.tipo_entrega = 'domicilio' AND v.estatus IN ('activa','cerrada') ORDER BY v.fecha DESC"
+        "SELECT v.id, v.fecha, v.total, v.estatus, v.entregado, v.estado_entrega, v.fecha_asignacion, v.fecha_inicio, v.fecha_entrega, v.seudonimo_entrega, v.foto_entrega, v.observacion, r.nombre AS repartidor FROM ventas v JOIN repartidores r ON v.repartidor_id = r.id WHERE v.tipo_entrega = 'domicilio' AND v.estatus IN ('activa','cerrada') ORDER BY v.fecha DESC"
     );
     if (!$stmt) {
         error('Error al preparar consulta: ' . $conn->error);
@@ -50,6 +50,7 @@ while ($row = $res->fetch_assoc()) {
         'fecha_entrega'    => $row['fecha_entrega'],
         'seudonimo_entrega'=> $row['seudonimo_entrega'],
         'foto_entrega'     => $row['foto_entrega'],
+        'observacion'      => $row['observacion'] ?? '',
         'repartidor'       => $row['repartidor'] ?? '',
         'productos' => []
     ];

--- a/api/ventas/crear_venta.php
+++ b/api/ventas/crear_venta.php
@@ -24,6 +24,7 @@ $repartidor_id = isset($input['repartidor_id']) ? (int) $input['repartidor_id'] 
 $usuario_id    = isset($input['usuario_id']) ? (int) $input['usuario_id'] : null;
 $corte_id      = isset($input['corte_id']) ? (int) $input['corte_id'] : null;
 $productos     = isset($input['productos']) && is_array($input['productos']) ? $input['productos'] : null;
+$observacion   = isset($input['observacion']) ? $input['observacion'] : null;
 
 if (!$tipo || !$usuario_id || !$productos) {
     error('Datos incompletos para crear la venta');
@@ -106,17 +107,17 @@ $nueva_venta = false;
 
 if (!isset($venta_id)) {
     if ($tipo === 'domicilio') {
-        $stmt = $conn->prepare('INSERT INTO ventas (mesa_id, repartidor_id, usuario_id, tipo_entrega, total, corte_id, cajero_id, fecha_asignacion) VALUES (?, ?, ?, ?, ?, ?, ?, NOW())');
+        $stmt = $conn->prepare('INSERT INTO ventas (mesa_id, repartidor_id, usuario_id, tipo_entrega, total, observacion, corte_id, cajero_id, fecha_asignacion) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW())');
     } else {
-        $stmt = $conn->prepare('INSERT INTO ventas (mesa_id, repartidor_id, usuario_id, tipo_entrega, total, corte_id, cajero_id) VALUES (?, ?, ?, ?, ?, ?, ?)');
+        $stmt = $conn->prepare('INSERT INTO ventas (mesa_id, repartidor_id, usuario_id, tipo_entrega, total, observacion, corte_id, cajero_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
     }
     if (!$stmt) {
         error('Error al preparar venta: ' . $conn->error);
     }
     if ($tipo === 'domicilio') {
-        $stmt->bind_param('iiisdii', $mesa_id, $repartidor_id, $usuario_id, $tipo, $total, $corte_id, $cajero_id);
+        $stmt->bind_param('iiisdsii', $mesa_id, $repartidor_id, $usuario_id, $tipo, $total, $observacion, $corte_id, $cajero_id);
     } else {
-        $stmt->bind_param('iiisdii', $mesa_id, $repartidor_id, $usuario_id, $tipo, $total, $corte_id, $cajero_id);
+        $stmt->bind_param('iiisdsii', $mesa_id, $repartidor_id, $usuario_id, $tipo, $total, $observacion, $corte_id, $cajero_id);
     }
     if (!$stmt->execute()) {
         error('Error al crear venta: ' . $stmt->error);

--- a/utils/bd.sql
+++ b/utils/bd.sql
@@ -289,7 +289,8 @@ CREATE TABLE `ventas` (
   `seudonimo_entrega` varchar(100) DEFAULT NULL,
   `foto_entrega` varchar(255) DEFAULT NULL,
   `corte_id` int(11) DEFAULT NULL,
-  `cajero_id` int(11) DEFAULT NULL
+  `cajero_id` int(11) DEFAULT NULL,
+  `observacion` text DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 

--- a/vistas/repartidores/repartos.js
+++ b/vistas/repartidores/repartos.js
@@ -34,6 +34,7 @@ async function cargarEntregas() {
                     <td>${v.total}</td>
                     <td>${v.repartidor}</td>
                     <td>${productos}</td>
+                    <td>${v.observacion || ''}</td>
                     <td>${asign}</td>
                     <td>${inicio}</td>
                     <td>${entrega}</td>
@@ -143,6 +144,9 @@ function mostrarDetalle(info) {
     });
 
     html += `</ul>`;
+    if (info.observacion) {
+        html += `<p style="margin-top:10px;"><strong>Observación:</strong> ${info.observacion}</p>`;
+    }
 
     if (info.foto_entrega) {
         html += `<div style="margin-top: 15px;">

--- a/vistas/repartidores/repartos.php
+++ b/vistas/repartidores/repartos.php
@@ -38,6 +38,7 @@ ob_start();
                     <th>Total</th>
                     <th>Repartidor</th>
                     <th>Productos</th>
+                    <th>Observación</th>
                     <th>Asignado</th>
                     <th>Inicio</th>
                     <th>Entrega</th>
@@ -66,6 +67,7 @@ ob_start();
                     <th>Total</th>
                     <th>Repartidor</th>
                     <th>Productos</th>
+                    <th>Observación</th>
                     <th>Asignado</th>
                     <th>Inicio</th>
                     <th>Entrega</th>

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -495,6 +495,7 @@ async function registrarVenta() {
     const mesa_id = parseInt(document.getElementById('mesa_id').value);
     const repartidor_id = parseInt(document.getElementById('repartidor_id').value);
     const usuario_id = parseInt(document.getElementById('usuario_id').value);
+    const observacion = document.getElementById('observacion').value.trim();
     const filas = document.querySelectorAll('#productos tbody tr');
     const productos = [];
 
@@ -535,6 +536,7 @@ async function registrarVenta() {
         mesa_id: tipo === 'mesa' ? mesa_id : null,
         repartidor_id: tipo === 'domicilio' ? repartidor_id : null,
         usuario_id,
+        observacion: (tipo === 'domicilio' || tipo === 'rapido') ? observacion : '',
         productos,
         corte_id: corteIdActual
     };
@@ -815,6 +817,10 @@ document.getElementById('tipo_entrega').addEventListener('change', function () {
   const tipo = this.value;
   document.getElementById('campoMesa').style.display = tipo === 'mesa' ? 'block' : 'none';
   document.getElementById('campoRepartidor').style.display = tipo === 'domicilio' ? 'block' : 'none';
+  document.getElementById('campoObservacion').style.display = (tipo === 'domicilio' || tipo === 'rapido') ? 'block' : 'none';
+  if (tipo === 'mesa') {
+    document.getElementById('observacion').value = '';
+  }
   verificarActivacionProductos();
 });
 
@@ -835,6 +841,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const tipo = document.getElementById('tipo_entrega').value;
         document.getElementById('campoMesa').style.display = tipo === 'mesa' ? 'block' : 'none';
         document.getElementById('campoRepartidor').style.display = tipo === 'domicilio' ? 'block' : 'none';
+        document.getElementById('campoObservacion').style.display = (tipo === 'domicilio' || tipo === 'rapido') ? 'block' : 'none';
+        if (tipo === 'mesa') {
+            document.getElementById('observacion').value = '';
+        }
     });
 
     // Delegación de eventos con jQuery para botones dinámicos

--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -40,6 +40,11 @@ ob_start();
           </select>
         </div>
 
+        <div id="campoObservacion" class="form-group" style="display:none;">
+          <label for="observacion" class="text-white">Observación:</label>
+          <textarea id="observacion" name="observacion" class="form-control"></textarea>
+        </div>
+
         <div id="campoMesa" class="form-group">
           <label for="mesa_id" class="text-white">Mesa:</label>
           <select id="mesa_id" name="mesa_id" class="form-control">


### PR DESCRIPTION
## Summary
- add `observacion` column in sales schema
- support observacion in venta creation
- show observacion textbox in ventas form
- send and display observacion for deliveries
- display observation details in repartos tables and modal

## Testing
- `php -l api/ventas/crear_venta.php`
- `php -l api/repartidores/listar_entregas.php`

------
https://chatgpt.com/codex/tasks/task_e_687861a76b30832b961d3d2a5a3634f5