### PR TITLE
Fix QR generation and embedding

### DIFF
--- a/api/bodega/generar_qr.php
+++ b/api/bodega/generar_qr.php
@@ -66,12 +66,22 @@ $dirTmp = __DIR__ . '/../../archivos/bodega/qr';
 if (!is_dir($dirTmp)) {
     mkdir($dirTmp, 0777, true);
 }
+$dirQrPublic = __DIR__ . '/../../archivos/qr';
+if (!is_dir($dirQrPublic)) {
+    mkdir($dirQrPublic, 0777, true);
+}
 
 $pdf_rel = 'archivos/bodega/pdfs/qr_' . $token . '.pdf';
 $pdf_path = __DIR__ . '/../../' . $pdf_rel;
 $tmp_qr = $dirTmp . '/temp_' . $token . '.png';
+$public_qr_rel = 'archivos/qr/qr_' . $token . '.png';
+$public_qr_path = __DIR__ . '/../../' . $public_qr_rel;
 
 QRcode::png($token, $tmp_qr);
+if (!file_exists($tmp_qr)) {
+    error('No se pudo generar el código QR');
+}
+copy($tmp_qr, $public_qr_path);
 
 $lineas = [];
 $lineas[] = 'Fecha: ' . date('Y-m-d H:i');
@@ -80,8 +90,10 @@ foreach ($seleccionados as $s) {
     $lineas[] = $s['nombre'] . ' - ' . $s['cantidad'] . ' ' . $s['unidad'];
 }
 
-generar_pdf_con_imagen($pdf_path, 'Salida de insumos', $lineas, $tmp_qr);
-unlink($tmp_qr);
+generar_pdf_con_imagen($pdf_path, 'Salida de insumos', $lineas, $tmp_qr, 150, 10, 40, 40);
+if (file_exists($tmp_qr)) {
+    unlink($tmp_qr);
+}
 
 $up = $conn->prepare('UPDATE qrs_insumo SET pdf_envio = ? WHERE id = ?');
 $up->bind_param('si', $pdf_rel, $idqr);
@@ -107,6 +119,6 @@ if ($log) {
 $base_url = defined('BASE_URL') ? BASE_URL : '/rest';
 $url = $base_url . '/vistas/bodega/recepcion_qr.php?token=' . $token;
 
-success(['pdf' => $pdf_rel, 'url' => $url]);
+success(['ruta_pdf' => $pdf_rel, 'ruta_qr' => $public_qr_rel, 'url' => $url]);
 ?>
 

--- a/utils/pdf_simple.php
+++ b/utils/pdf_simple.php
@@ -37,7 +37,7 @@ function generar_pdf_simple($archivo, $titulo, array $lineas) {
 }
 
 
-function generar_pdf_con_imagen($archivo, $titulo, array $lineas, $imagen) {
+function generar_pdf_con_imagen($archivo, $titulo, array $lineas, $imagen, $x = 150, $y_img = 10, $w = 40, $h = 40) {
     $y = 760;
     $contenido = "BT\n/F1 16 Tf\n50 $y Td\n(" . pdf_simple_escape($titulo) . ") Tj\nET\n";
     $y -= 30;
@@ -47,7 +47,7 @@ function generar_pdf_con_imagen($archivo, $titulo, array $lineas, $imagen) {
         $y -= 14;
     }
     if (file_exists($imagen)) {
-        $contenido .= "q\n150 0 0 150 400 400 cm\n/Im1 Do\nQ\n";
+        $contenido .= "q\n$w 0 0 $h $x $y_img cm\n/Im1 Do\nQ\n";
     }
 
     $objs = [];
@@ -62,13 +62,13 @@ function generar_pdf_con_imagen($archivo, $titulo, array $lineas, $imagen) {
     $objs[] = "<< /Length " . strlen($contenido) . " >>\nstream\n" . $contenido . "endstream";
     $objs[] = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
     if (file_exists($imagen)) {
-        list($w, $h) = getimagesize($imagen);
+        list($imgW, $imgH) = getimagesize($imagen);
         $img = imagecreatefrompng($imagen);
         ob_start();
         imagejpeg($img);
         $imgData = ob_get_clean();
         imagedestroy($img);
-        $objs[] = "<< /Type /XObject /Subtype /Image /Width $w /Height $h /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length " . strlen($imgData) . " >>\nstream\n" . $imgData . "endstream";
+        $objs[] = "<< /Type /XObject /Subtype /Image /Width $imgW /Height $imgH /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length " . strlen($imgData) . " >>\nstream\n" . $imgData . "endstream";
     }
 
     $pdf = "%PDF-1.4\n";

--- a/vistas/bodega/generar_qr.php
+++ b/vistas/bodega/generar_qr.php
@@ -81,10 +81,11 @@ document.getElementById('btnGenerar').addEventListener('click', async function(e
         const data = await resp.json();
         if(data.success){
             const url = data.resultado.url;
-            const pdf = '../../' + data.resultado.pdf;
+            const pdf = '../../' + data.resultado.ruta_pdf;
+            const img = '../../' + data.resultado.ruta_qr;
             document.getElementById('resultado').innerHTML =
                 '<p class="text-white">Escanea el código para recibir:</p>'+
-                '<img src="https://chart.googleapis.com/chart?chs=200x200&cht=qr&chl='+encodeURIComponent(url)+'" alt="QR">'+
+                '<img src="'+img+'" alt="QR" width="200" height="200">'+
                 '<p class="mt-2"><a class="btn custom-btn" href="'+pdf+'" target="_blank">Ver PDF</a></p>';
         } else {
             alert(data.mensaje || 'Error');


### PR DESCRIPTION
## Summary
- support custom position for QR in pdf generator
- generate persistent QR image when creating PDF
- return pdf and qr paths from API
- show QR from backend in QR generation view

## Testing
- `php -l utils/pdf_simple.php`
- `php -l api/bodega/generar_qr.php`
- `php -l vistas/bodega/generar_qr.php`


------
https://chatgpt.com/codex/tasks/task_e_68794f8d1eac832ba97dcc452719009a