### PR TITLE
Fix QR generation and provide URLs

### DIFF
--- a/vistas/bodega/generar_qr.php
+++ b/vistas/bodega/generar_qr.php
@@ -81,8 +81,8 @@ document.getElementById('btnGenerar').addEventListener('click', async function(e
         const data = await resp.json();
         if(data.success){
             const url = data.resultado.url;
-            const pdf = '../../' + data.resultado.ruta_pdf;
-            const img = '../../' + data.resultado.ruta_qr;
+            const pdf = '../../' + data.resultado.pdf_url;
+            const img = '../../' + data.resultado.qr_url;
             document.getElementById('resultado').innerHTML =
                 '<p class="text-white">Escanea el código para recibir:</p>'+
                 '<img src="'+img+'" alt="QR" width="200" height="200">'+


### PR DESCRIPTION
## Summary
- create URL_BASE_QR constant for QR URLs
- store generated QR images in a public folder
- include QR image in generated PDF
- return `pdf_url` and `qr_url` in the API
- adjust frontend to consume new API response

## Testing
- `php -l api/bodega/generar_qr.php`
- `php -l vistas/bodega/generar_qr.php`

------
https://chatgpt.com/codex/tasks/task_e_6879579c116c832ba7bfb3edd78bcae4