### PR TITLE
Implement waiter assignment for tables

### DIFF
--- a/api/mesas/asignar.php
+++ b/api/mesas/asignar.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$mesa_id = $input['mesa_id'] ?? null;
+$usuario_id = $input['usuario_id'] ?? null;
+$asignador_id = $input['usuario_asignador_id'] ?? null;
+
+if (!$mesa_id || !$asignador_id) {
+    error('Datos inválidos');
+}
+
+$mesa_id = (int)$mesa_id;
+$asignador_id = (int)$asignador_id;
+$usuario_id = $usuario_id !== null ? (int)$usuario_id : null;
+
+$conn->query('SET @usuario_asignador_id = ' . $asignador_id);
+
+$stmt = $conn->prepare('UPDATE mesas SET usuario_id = ? WHERE id = ?');
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('ii', $usuario_id, $mesa_id);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al asignar mesero: ' . $stmt->error);
+}
+$stmt->close();
+
+success(true);

--- a/api/mesas/mesas.php
+++ b/api/mesas/mesas.php
@@ -1,0 +1,22 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$query = "SELECT m.id, m.nombre, m.usuario_id, u.nombre AS mesero_nombre
+          FROM mesas m
+          LEFT JOIN usuarios u ON m.usuario_id = u.id
+          ORDER BY m.id";
+$result = $conn->query($query);
+if (!$result) {
+    error('Error al obtener mesas: ' . $conn->error);
+}
+$mesas = [];
+while ($row = $result->fetch_assoc()) {
+    $mesas[] = [
+        'id' => (int)$row['id'],
+        'nombre' => $row['nombre'],
+        'usuario_id' => $row['usuario_id'] !== null ? (int)$row['usuario_id'] : null,
+        'mesero_nombre' => $row['mesero_nombre']
+    ];
+}
+success($mesas);

--- a/api/mesas/meseros.php
+++ b/api/mesas/meseros.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$query = "SELECT id, nombre FROM usuarios WHERE rol = 'mesero' AND activo = 1 ORDER BY nombre";
+$result = $conn->query($query);
+if (!$result) {
+    error('Error al obtener meseros: ' . $conn->error);
+}
+$meseros = [];
+while ($row = $result->fetch_assoc()) {
+    $meseros[] = $row;
+}
+success($meseros);

--- a/api/mesas/reportes/asignaciones_por_mesero.php
+++ b/api/mesas/reportes/asignaciones_por_mesero.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/response.php';
+
+$desde = $_GET['desde'] ?? null;
+$hasta = $_GET['hasta'] ?? null;
+if (!$desde || !$hasta) {
+    error('Fechas requeridas');
+}
+
+$stmt = $conn->prepare("SELECT l.mesero_nuevo_id AS mesero_id, u.nombre AS mesero, COUNT(*) AS asignaciones
+                        FROM log_asignaciones_mesas l
+                        JOIN usuarios u ON l.mesero_nuevo_id = u.id
+                        WHERE DATE(l.fecha_cambio) BETWEEN ? AND ?
+                        GROUP BY l.mesero_nuevo_id
+                        ORDER BY mesero");
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('ss', $desde, $hasta);
+$stmt->execute();
+$res = $stmt->get_result();
+$datos = [];
+while ($row = $res->fetch_assoc()) {
+    $datos[] = [
+        'mesero_id' => (int)$row['mesero_id'],
+        'mesero' => $row['mesero'],
+        'asignaciones' => (int)$row['asignaciones']
+    ];
+}
+$stmt->close();
+
+success($datos);

--- a/api/mesas/reportes/ventas_por_mesero.php
+++ b/api/mesas/reportes/ventas_por_mesero.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/response.php';
+
+$fecha = $_GET['fecha'] ?? date('Y-m-d');
+
+$stmt = $conn->prepare("SELECT v.usuario_id AS mesero_id, u.nombre AS mesero, SUM(v.total) AS total
+                        FROM ventas v
+                        JOIN usuarios u ON v.usuario_id = u.id
+                        WHERE DATE(v.fecha) = ? AND v.estatus = 'cerrada'
+                        GROUP BY v.usuario_id
+                        ORDER BY mesero");
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
+}
+$stmt->bind_param('s', $fecha);
+$stmt->execute();
+$res = $stmt->get_result();
+$datos = [];
+while ($row = $res->fetch_assoc()) {
+    $datos[] = [
+        'mesero_id' => (int)$row['mesero_id'],
+        'mesero' => $row['mesero'],
+        'total' => (float)$row['total']
+    ];
+}
+$stmt->close();
+
+success($datos);

--- a/utils/bd.sql
+++ b/utils/bd.sql
@@ -74,6 +74,20 @@ DELIMITER ;
 -- --------------------------------------------------------
 
 --
+-- Disparadores `mesas`
+--
+DELIMITER $$
+CREATE TRIGGER `trg_log_asignacion_mesa` AFTER UPDATE ON `mesas` FOR EACH ROW BEGIN
+    IF NEW.usuario_id <> OLD.usuario_id THEN
+        INSERT INTO log_asignaciones_mesas (mesa_id, mesero_anterior_id, mesero_nuevo_id, fecha_cambio, usuario_que_asigna_id)
+        VALUES (NEW.id, OLD.usuario_id, NEW.usuario_id, NOW(), @usuario_asignador_id);
+    END IF;
+END$$
+DELIMITER ;
+
+-- --------------------------------------------------------
+
+--
 -- Estructura de tabla para la tabla `alineacion`
 --
 
@@ -308,6 +322,21 @@ CREATE TABLE `log_mesas` (
   `usuario_id` int(11) DEFAULT NULL,
   `fecha_inicio` datetime DEFAULT NULL,
   `fecha_fin` datetime DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Estructura de tabla para la tabla `log_asignaciones_mesas`
+--
+
+CREATE TABLE `log_asignaciones_mesas` (
+  `id` int(11) NOT NULL,
+  `mesa_id` int(11) NOT NULL,
+  `mesero_anterior_id` int(11) DEFAULT NULL,
+  `mesero_nuevo_id` int(11) DEFAULT NULL,
+  `fecha_cambio` datetime DEFAULT CURRENT_TIMESTAMP,
+  `usuario_que_asigna_id` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
@@ -821,6 +850,16 @@ ALTER TABLE `log_mesas`
   ADD KEY `usuario_id` (`usuario_id`);
 
 --
+-- Indices de la tabla `log_asignaciones_mesas`
+--
+ALTER TABLE `log_asignaciones_mesas`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `mesa_id` (`mesa_id`),
+  ADD KEY `mesero_anterior_id` (`mesero_anterior_id`),
+  ADD KEY `mesero_nuevo_id` (`mesero_nuevo_id`),
+  ADD KEY `usuario_que_asigna_id` (`usuario_que_asigna_id`);
+
+--
 -- Indices de la tabla `mesas`
 --
 ALTER TABLE `mesas`
@@ -982,6 +1021,12 @@ ALTER TABLE `log_mesas`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1;
 
 --
+-- AUTO_INCREMENT de la tabla `log_asignaciones_mesas`
+--
+ALTER TABLE `log_asignaciones_mesas`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=1;
+
+--
 -- AUTO_INCREMENT de la tabla `mesas`
 --
 ALTER TABLE `mesas`
@@ -1102,6 +1147,15 @@ ALTER TABLE `log_mesas`
   ADD CONSTRAINT `log_mesas_ibfk_1` FOREIGN KEY (`mesa_id`) REFERENCES `mesas` (`id`),
   ADD CONSTRAINT `log_mesas_ibfk_2` FOREIGN KEY (`venta_id`) REFERENCES `ventas` (`id`),
   ADD CONSTRAINT `log_mesas_ibfk_3` FOREIGN KEY (`usuario_id`) REFERENCES `usuarios` (`id`);
+
+--
+-- Filtros para la tabla `log_asignaciones_mesas`
+--
+ALTER TABLE `log_asignaciones_mesas`
+  ADD CONSTRAINT `log_asignaciones_mesas_ibfk_1` FOREIGN KEY (`mesa_id`) REFERENCES `mesas` (`id`),
+  ADD CONSTRAINT `log_asignaciones_mesas_ibfk_2` FOREIGN KEY (`mesero_anterior_id`) REFERENCES `usuarios` (`id`),
+  ADD CONSTRAINT `log_asignaciones_mesas_ibfk_3` FOREIGN KEY (`mesero_nuevo_id`) REFERENCES `usuarios` (`id`),
+  ADD CONSTRAINT `log_asignaciones_mesas_ibfk_4` FOREIGN KEY (`usuario_que_asigna_id`) REFERENCES `usuarios` (`id`);
 
 --
 -- Filtros para la tabla `mesas`

--- a/vistas/mesas/asignar.js
+++ b/vistas/mesas/asignar.js
@@ -1,0 +1,63 @@
+let mesas = [];
+let meseros = [];
+const usuarioId = window.usuarioId || 0;
+
+async function cargarDatos() {
+    const m = await fetch('../../api/mesas/mesas.php').then(r => r.json());
+    const u = await fetch('../../api/mesas/meseros.php').then(r => r.json());
+    if (!m.success || !u.success) {
+        alert('Error al cargar datos');
+        return;
+    }
+    mesas = m.resultado;
+    meseros = u.resultado;
+    renderTabla();
+}
+
+function renderTabla() {
+    const tbody = document.querySelector('#tablaAsignacion tbody');
+    tbody.innerHTML = '';
+    mesas.forEach(mesa => {
+        const tr = document.createElement('tr');
+        const tdMesa = document.createElement('td');
+        tdMesa.textContent = mesa.nombre;
+        const tdSel = document.createElement('td');
+        const select = document.createElement('select');
+        select.className = 'form-control selMesero';
+        select.dataset.mesa = mesa.id;
+        select.innerHTML = '<option value="">Sin asignar</option>';
+        meseros.forEach(me => {
+            const opt = document.createElement('option');
+            opt.value = me.id;
+            opt.textContent = me.nombre;
+            if (mesa.usuario_id && mesa.usuario_id === parseInt(me.id)) {
+                opt.selected = true;
+            }
+            select.appendChild(opt);
+        });
+        if (usuarioId !== mesa.usuario_id && usuarioId !== 1) {
+            select.disabled = true;
+        }
+        select.addEventListener('change', () => asignarMesero(mesa.id, select.value));
+        tdSel.appendChild(select);
+        tr.appendChild(tdMesa);
+        tr.appendChild(tdSel);
+        tbody.appendChild(tr);
+    });
+}
+
+async function asignarMesero(mesaId, meseroId) {
+    const resp = await fetch('../../api/mesas/asignar.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mesa_id: mesaId, usuario_id: meseroId ? parseInt(meseroId) : null, usuario_asignador_id: usuarioId })
+    });
+    const data = await resp.json();
+    if (!data.success) {
+        alert(data.mensaje);
+    } else {
+        cargarDatos();
+    }
+}
+
+document.addEventListener('DOMContentLoaded', cargarDatos);

--- a/vistas/mesas/asignar.php
+++ b/vistas/mesas/asignar.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../../utils/cargar_permisos.php';
+$title = 'Asignar Mesas';
+ob_start();
+?>
+<h1>Asignar meseros a mesas</h1>
+<table id="tablaAsignacion" class="table table-bordered">
+    <thead>
+        <tr><th>Mesa</th><th>Mesero</th></tr>
+    </thead>
+    <tbody></tbody>
+</table>
+<?php require_once __DIR__ . '/../footer.php'; ?>
+<script>
+  window.usuarioId = <?php echo json_encode($_SESSION['usuario_id']); ?>;
+</script>
+<script src="asignar.js"></script>
+</body>
+</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../nav.php';
+?>

--- a/vistas/mesas/mesas2.js
+++ b/vistas/mesas/mesas2.js
@@ -1,65 +1,33 @@
-document.addEventListener('DOMContentLoaded', (event) => {
-
-  var dragSrcEl = null;
-  
-  function handleDragStart(e) {
-    this.style.opacity = '0.1';
-    this.style.border = '3px dashed #c4cad3';
-    
-    dragSrcEl = this;
-
-    e.dataTransfer.effectAllowed = 'move';
-    e.dataTransfer.setData('text/html', this.innerHTML);
-  }
-
-  function handleDragOver(e) {
-    if (e.preventDefault) {
-      e.preventDefault();
+async function cargarTablero() {
+    const resp = await fetch('../../api/mesas/mesas.php');
+    const data = await resp.json();
+    if (!data.success) {
+        alert('Error al obtener mesas');
+        return;
     }
-
-    e.dataTransfer.dropEffect = 'move';
-    
-    return false;
-  }
-
-  function handleDragEnter(e) {
-    this.classList.add('task-hover');
-  }
-
-  function handleDragLeave(e) {
-    this.classList.remove('task-hover');
-  }
-
-  function handleDrop(e) {
-    if (e.stopPropagation) {
-      e.stopPropagation(); // stops the browser from redirecting.
-    }
-    
-    if (dragSrcEl != this) {
-      dragSrcEl.innerHTML = this.innerHTML;
-      this.innerHTML = e.dataTransfer.getData('text/html');
-    }
-    
-    return false;
-  }
-
-  function handleDragEnd(e) {
-    this.style.opacity = '1';
-    this.style.border = 0;
-    
-    items.forEach(function (item) {
-      item.classList.remove('task-hover');
+    const grupos = {};
+    data.resultado.forEach(m => {
+        const nom = m.mesero_nombre || 'Sin mesero';
+        if (!grupos[nom]) grupos[nom] = [];
+        grupos[nom].push(m);
     });
-  }
-  
-  
-  let items = document.querySelectorAll('.task'); 
-  items.forEach(function(item) {
-    item.addEventListener('dragstart', handleDragStart, false);
-    item.addEventListener('dragenter', handleDragEnter, false);
-    item.addEventListener('dragover', handleDragOver, false);
-    item.addEventListener('dragleave', handleDragLeave, false);
-    item.addEventListener('drop', handleDrop, false);
-    item.addEventListener('dragend', handleDragEnd, false);
-  });
-});
+    const cont = document.getElementById('tablero-meseros');
+    cont.innerHTML = '';
+    Object.entries(grupos).forEach(([mesero, mesas]) => {
+        const col = document.createElement('div');
+        col.className = 'project-column';
+        const head = document.createElement('div');
+        head.className = 'project-column-heading';
+        head.innerHTML = `<h2 class='project-column-heading__title'>${mesero}</h2>`;
+        col.appendChild(head);
+        mesas.forEach(m => {
+            const div = document.createElement('div');
+            div.className = 'task';
+            div.textContent = m.nombre;
+            col.appendChild(div);
+        });
+        cont.appendChild(col);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', cargarTablero);

--- a/vistas/mesas/mesas2.php
+++ b/vistas/mesas/mesas2.php
@@ -1,14 +1,9 @@
 <?php
 require_once __DIR__ . '/../../utils/cargar_permisos.php';
-$path_actual = str_replace('/rest', '', $_SERVER['PHP_SELF']);
-
 $title = 'Mesas';
 ob_start();
 ?>
 <link href="../../utils/css/style2.css" rel="stylesheet">
-<!-- Page Header Start -->
-
-
 <div class="page-header mb-0">
     <div class="container">
         <div class="row">
@@ -22,156 +17,19 @@ ob_start();
         </div>
     </div>
 </div>
-
-
-<!-- Page Header End -->
-<h1>Mesas</h1>
-<div>
-    <button id="btn-unir">Unir mesas</button>
-    <select id="filtro-area"></select>
-</div>
-<div id="tablero"></div>
-<div id="modal-detalle" style="display:none;"></div>
-
-
-
 <div class='app'>
     <main class='project'>
         <div class='project-info'>
-            <h1>Homepage Design</h1>
-            <div class='project-participants'>
-                <span></span>
-                <span></span>
-                <span></span>
-                <button class='project-participants__add'>Add Participant</button>
-
-            </div>
+            <h1>Asignación actual</h1>
         </div>
-        <div class='project-tasks'>
-            <div class='project-column'>
-                <div class='project-column-heading'>
-                    <h2 class='project-column-heading__title'>Task Ready</h2><button class='project-column-heading__options'><i class="fas fa-ellipsis-h"></i></button>
-                </div>
-
-                <div class='task' draggable='true'>
-                    <div class='task__tags'><span class='task__tag task__tag--copyright'>Copywriting</span><button class='task__options'><i class="fas fa-ellipsis-h"></i></button></div>
-                    <p>Konsep hero title yang menarik</p>
-                    <div class='task__stats'>
-                        <span><time datetime="2021-11-24T20:00:00"><i class="fas fa-flag"></i>Nov 24</time></span>
-                        <span><i class="fas fa-comment"></i>2</span>
-                        <span><i class="fas fa-paperclip"></i>3</span>
-                        <span class='task__owner'></span>
-                    </div>
-                </div>
-            </div>
-            <div class='project-column'>
-                <div class='project-column-heading'>
-                    <h2 class='project-column-heading__title'>In Progress</h2><button class='project-column-heading__options'><i class="fas fa-ellipsis-h"></i></button>
-                </div>
-
-                <div class='task' draggable='true'>
-                    <div class='task__tags'><span class='task__tag task__tag--illustration'>Illustration</span><button class='task__options'><i class="fas fa-ellipsis-h"></i></button></div>
-                    <p>Create the landing page graphics for the hero slider.</p>
-                    <div class='task__stats'>
-                        <span><time datetime="2021-11-24T20:00:00"><i class="fas fa-flag"></i>Nov 24</time></span>
-                        <span><i class="fas fa-comment"></i>4</span>
-                        <span><i class="fas fa-paperclip"></i>8</span>
-                        <span class='task__owner'></span>
-                    </div>
-                </div>
-
-            </div>
-            <div class='project-column'>
-                <div class='project-column-heading'>
-                    <h2 class='project-column-heading__title'>Needs Review</h2><button class='project-column-heading__options'><i class="fas fa-ellipsis-h"></i></button>
-                </div>
-
-                <div class='task' draggable='true'>
-                    <div class='task__tags'><span class='task__tag task__tag--illustration'>Illustration</span><button class='task__options'><i class="fas fa-ellipsis-h"></i></button></div>
-                    <p>Move that one image 5px down to make Phil Happy.</p>
-                    <div class='task__stats'>
-                        <span><time datetime="2021-11-24T20:00:00"><i class="fas fa-flag"></i>Nov 24</time></span>
-                        <span><i class="fas fa-comment"></i>2</span>
-                        <span><i class="fas fa-paperclip"></i>2</span>
-                        <span class='task__owner'></span>
-                    </div>
-                </div>
-            </div>
-            <div class='project-column'>
-                <div class='project-column-heading'>
-                    <h2 class='project-column-heading__title'>Done</h2><button class='project-column-heading__options'><i class="fas fa-ellipsis-h"></i></button>
-                </div>
-                
-                <div class='task' draggable='true'>
-                    <div class='task__tags'><span class='task__tag task__tag--copyright'>Copywriting</span><button class='task__options'><i class="fas fa-ellipsis-h"></i></button></div>
-                    <p>Amend the contract details.</p>
-                    <div class='task__stats'>
-                        <span><time datetime="2021-11-24T20:00:00"><i class="fas fa-flag"></i>Nov 24</time></span>
-                        <span><i class="fas fa-comment"></i>8</span>
-                        <span><i class="fas fa-paperclip"></i>16</span>
-                        <span class='task__owner'></span>
-                    </div>
-                </div>
-
-            </div>
-
-        </div>
+        <div id='tablero-meseros' class='project-tasks'></div>
     </main>
-    <aside class='task-details'>
-        <div class='tag-progress'>
-            <h2>Task Progress</h2>
-            <div class='tag-progress'>
-                <p>Copywriting <span>3/8</span></p>
-                <progress class="progress progress--copyright" max="8" value="3"> 3 </progress>
-            </div>
-            <div class='tag-progress'>
-                <p>Illustration <span>6/10</span></p>
-                <progress class="progress progress--illustration" max="10" value="6"> 6 </progress>
-            </div>
-            <div class='tag-progress'>
-                <p>UI Design <span>2/7</span></p>
-                <progress class="progress progress--design" max="7" value="2"> 2 </progress>
-            </div>
-        </div>
-        <div class='task-activity'>
-            <h2>Recent Activity</h2>
-            <ul>
-                <li>
-                    <span class='task-icon task-icon--attachment'><i class="fas fa-paperclip"></i></span>
-                    <b>Andrea </b>uploaded 3 documents
-                    <time datetime="2021-11-24T20:00:00">Aug 10</time>
-                </li>
-                <li>
-                    <span class='task-icon task-icon--comment'><i class="fas fa-comment"></i></span>
-                    <b>Karen </b> left a comment
-                    <time datetime="2021-11-24T20:00:00">Aug 10</time>
-                </li>
-                <li>
-                    <span class='task-icon task-icon--edit'><i class="fas fa-pencil-alt"></i></span>
-                    <b>Karen </b>uploaded 3 documents
-                    <time datetime="2021-11-24T20:00:00">Aug 11</time>
-                </li>
-                <li>
-                    <span class='task-icon task-icon--attachment'><i class="fas fa-paperclip"></i></span>
-                    <b>Andrea </b>uploaded 3 documents
-                    <time datetime="2021-11-24T20:00:00">Aug 11</time>
-                </li>
-                <li>
-                    <span class='task-icon task-icon--comment'><i class="fas fa-comment"></i></span>
-                    <b>Karen </b> left a comment
-                    <time datetime="2021-11-24T20:00:00">Aug 12</time>
-                </li>
-            </ul>
-        </div>
-    </aside>
 </div>
-
 <?php require_once __DIR__ . '/../footer.php'; ?>
 <script src="mesas2.js"></script>
-<script src="mesas.js"></script>
 </body>
-
 </html>
 <?php
 $content = ob_get_clean();
 include __DIR__ . '/../nav.php';
+?>


### PR DESCRIPTION
## Summary
- add `log_asignaciones_mesas` table and trigger in SQL dump
- create endpoints to list mesas and meseros and to assign waiters
- include reporting endpoints for sales and assignments by waiter
- new page `/vistas/mesas/asignar.php` with JS logic
- simplify board view to show mesas grouped by waiter

## Testing
- `php -l api/mesas/mesas.php`
- `php -l api/mesas/meseros.php`
- `php -l api/mesas/asignar.php`
- `php -l api/mesas/reportes/ventas_por_mesero.php`
- `php -l api/mesas/reportes/asignaciones_por_mesero.php`
- `php -l vistas/mesas/asignar.php`
- `php -l vistas/mesas/mesas2.php`

------
https://chatgpt.com/codex/tasks/task_e_687edcfd59e8832b932c22384f8b99f1