### PR TITLE
Implement waiter kanban board

### DIFF
--- a/vistas/mesas/kanban.js
+++ b/vistas/mesas/kanban.js
@@ -1,0 +1,73 @@
+// Datos de ejemplo para meseros y mesas
+const meseros = [
+  { id: 1, nombre: "Carlos Mesero" },
+  { id: 2, nombre: "Ana Repartidora" }
+];
+
+const mesas = [
+  { id: 101, nombre: "Mesa 1", estado: "ocupada", usuario_id: 1 },
+  { id: 102, nombre: "Mesa 2", estado: "libre", usuario_id: 2 }
+];
+
+function crearColumnas() {
+  const lista = document.getElementById('kanban-list');
+  lista.innerHTML = '';
+
+  meseros.forEach(mesero => {
+    const li = document.createElement('li');
+    li.className = 'drag-column drag-column-on-hold';
+
+    const header = document.createElement('span');
+    header.className = 'drag-column-header';
+    header.innerHTML = `
+      <h2>${mesero.nombre}</h2>
+      <svg class="drag-header-more" data-target="options_${mesero.id}" fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24">
+        <path d="M0 0h24v24H0z" fill="none" />
+        <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
+      </svg>`;
+    li.appendChild(header);
+
+    const options = document.createElement('div');
+    options.className = 'drag-options';
+    options.id = `options_${mesero.id}`;
+    li.appendChild(options);
+
+    const ul = document.createElement('ul');
+    ul.className = 'drag-inner-list';
+    ul.id = String(mesero.id);
+    li.appendChild(ul);
+
+    lista.appendChild(li);
+  });
+}
+
+function agregarMesas() {
+  mesas.forEach(mesa => {
+    const card = document.createElement('li');
+    card.className = 'drag-item';
+    card.setAttribute('draggable', 'true');
+    card.innerHTML = `
+      <div class="task">
+        <h3>${mesa.nombre}</h3>
+        <p>Estado: ${mesa.estado}</p>
+        <button>Detalles</button>
+        <button>Dividir</button>
+        <button>Cambiar Estado</button>
+      </div>`;
+    const contenedor = document.getElementById(mesa.usuario_id);
+    if (contenedor) {
+      contenedor.appendChild(card);
+    }
+  });
+}
+
+function activarDrag() {
+  const lists = Array.from(document.querySelectorAll('.drag-inner-list'));
+  dragula(lists);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  crearColumnas();
+  agregarMesas();
+  activarDrag();
+});

--- a/vistas/mesas/mesas2.php
+++ b/vistas/mesas/mesas2.php
@@ -46,22 +46,7 @@ ob_start();
 </section>
 
 <div class="drag-container">
-	<ul class="drag-list">
-		<li class="drag-column drag-column-on-hold">
-			<span class="drag-column-header">
-				<h2>On Hold</h2>
-				<svg class="drag-header-more" data-target="options1" fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/</svg>
-			</span>
-				
-			<div class="drag-options" id="options1"></div>
-			
-			<ul class="drag-inner-list" id="1">
-				<li class="drag-item"></li>
-				<li class="drag-item"></li>
-			</ul>
-		</li>
-
-	</ul>
+        <ul class="drag-list" id="kanban-list"></ul>
 </div>
 
 </div>
@@ -70,7 +55,7 @@ ob_start();
 
 
 <?php require_once __DIR__ . '/../footer.php'; ?>
-<script src="mesas2.js"></script>
+<script src="kanban.js"></script>
 </body>
 </html>
 <?php


### PR DESCRIPTION
## Summary
- implement kanban container markup
- add new kanban.js to create draggable columns per waiter
- load kanban.js instead of mesas2.js

## Testing
- `php -l vistas/mesas/mesas2.php`

------
https://chatgpt.com/codex/tasks/task_e_687fed57262c832b9049a9b004661046