### PR TITLE
feat: include venue data in ticket printing

### DIFF
--- a/api/tickets/reimprimir_ticket.php
+++ b/api/tickets/reimprimir_ticket.php
@@ -19,7 +19,10 @@ if (isset($input['folio'])) {
     $param = (int)$input['venta_id'];
 }
 
-$stmt = $conn->prepare("SELECT t.id, t.folio, t.total, t.propina, t.fecha, t.venta_id
+$stmt = $conn->prepare("SELECT t.id, t.folio, t.total, t.propina, t.fecha, t.venta_id,
+                               t.mesa_nombre, t.mesero_nombre, t.fecha_inicio, t.fecha_fin,
+                               t.tiempo_servicio, t.nombre_negocio, t.direccion_negocio,
+                               t.rfc_negocio, t.telefono_negocio, t.sede_id
                         FROM tickets t WHERE $cond");
 if (!$stmt) {
     error('Error al preparar consulta: ' . $conn->error);
@@ -55,13 +58,23 @@ while ($t = $res->fetch_assoc()) {
     $det->close();
 
     $tickets[] = [
-        'ticket_id' => (int)$t['id'],
-        'folio'     => (int)$t['folio'],
-        'fecha'     => $t['fecha'],
-        'venta_id'  => (int)$t['venta_id'],
-        'propina'   => (float)$t['propina'],
-        'total'     => (float)$t['total'],
-        'productos' => $prods
+        'ticket_id'        => (int)$t['id'],
+        'folio'            => (int)$t['folio'],
+        'fecha'            => $t['fecha'],
+        'venta_id'         => (int)$t['venta_id'],
+        'propina'          => (float)$t['propina'],
+        'total'            => (float)$t['total'],
+        'mesa_nombre'      => $t['mesa_nombre'],
+        'mesero_nombre'    => $t['mesero_nombre'],
+        'fecha_inicio'     => $t['fecha_inicio'],
+        'fecha_fin'        => $t['fecha_fin'],
+        'tiempo_servicio'  => $t['tiempo_servicio'],
+        'nombre_negocio'   => $t['nombre_negocio'],
+        'direccion_negocio'=> $t['direccion_negocio'],
+        'rfc_negocio'      => $t['rfc_negocio'],
+        'telefono_negocio' => $t['telefono_negocio'],
+        'sede_id'          => $t['sede_id'],
+        'productos'        => $prods
     ];
 }
 $stmt->close();

--- a/api/ventas/crear_venta.php
+++ b/api/ventas/crear_venta.php
@@ -25,8 +25,9 @@ $usuario_id    = isset($input['usuario_id']) ? (int) $input['usuario_id'] : null
 $corte_id      = isset($input['corte_id']) ? (int) $input['corte_id'] : null;
 $productos     = isset($input['productos']) && is_array($input['productos']) ? $input['productos'] : null;
 $observacion   = isset($input['observacion']) ? $input['observacion'] : null;
+$sede_id       = isset($input['sede_id']) ? (int)$input['sede_id'] : null;
 
-if (!$tipo || !$usuario_id || !$productos) {
+if (!$tipo || !$usuario_id || !$productos || !$sede_id) {
     error('Datos incompletos para crear la venta');
 }
 
@@ -107,17 +108,17 @@ $nueva_venta = false;
 
 if (!isset($venta_id)) {
     if ($tipo === 'domicilio') {
-        $stmt = $conn->prepare('INSERT INTO ventas (mesa_id, repartidor_id, usuario_id, tipo_entrega, total, observacion, corte_id, cajero_id, fecha_asignacion) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW())');
+        $stmt = $conn->prepare('INSERT INTO ventas (mesa_id, repartidor_id, usuario_id, tipo_entrega, total, observacion, corte_id, cajero_id, fecha_asignacion, sede_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW(), ?)');
     } else {
-        $stmt = $conn->prepare('INSERT INTO ventas (mesa_id, repartidor_id, usuario_id, tipo_entrega, total, observacion, corte_id, cajero_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
+        $stmt = $conn->prepare('INSERT INTO ventas (mesa_id, repartidor_id, usuario_id, tipo_entrega, total, observacion, corte_id, cajero_id, sede_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
     }
     if (!$stmt) {
         error('Error al preparar venta: ' . $conn->error);
     }
     if ($tipo === 'domicilio') {
-        $stmt->bind_param('iiisdsii', $mesa_id, $repartidor_id, $usuario_id, $tipo, $total, $observacion, $corte_id, $cajero_id);
+        $stmt->bind_param('iiisdsiii', $mesa_id, $repartidor_id, $usuario_id, $tipo, $total, $observacion, $corte_id, $cajero_id, $sede_id);
     } else {
-        $stmt->bind_param('iiisdsii', $mesa_id, $repartidor_id, $usuario_id, $tipo, $total, $observacion, $corte_id, $cajero_id);
+        $stmt->bind_param('iiisdsiii', $mesa_id, $repartidor_id, $usuario_id, $tipo, $total, $observacion, $corte_id, $cajero_id, $sede_id);
     }
     if (!$stmt->execute()) {
         error('Error al crear venta: ' . $stmt->error);

--- a/api/ventas/crear_venta_mesa.php
+++ b/api/ventas/crear_venta_mesa.php
@@ -18,8 +18,9 @@ if (!$input) {
 
 $mesa_id   = isset($input['mesa_id']) ? (int)$input['mesa_id'] : null;
 $productos = isset($input['productos']) && is_array($input['productos']) ? $input['productos'] : null;
+$sede_id   = isset($input['sede_id']) ? (int)$input['sede_id'] : null;
 
-if (!$mesa_id || !$productos) {
+if (!$mesa_id || !$productos || !$sede_id) {
     error('Datos incompletos');
 }
 
@@ -63,12 +64,12 @@ foreach ($productos as $p) {
     $total += $p['cantidad'] * $p['precio_unitario'];
 }
 
-$stmt = $conn->prepare('INSERT INTO ventas (mesa_id, tipo_entrega, total, corte_id, cajero_id) VALUES (?, ?, ?, ?, ?)');
+$stmt = $conn->prepare('INSERT INTO ventas (mesa_id, tipo_entrega, total, corte_id, cajero_id, sede_id) VALUES (?, ?, ?, ?, ?, ?)');
 if (!$stmt) {
     error('Error al preparar venta: ' . $conn->error);
 }
 $tipo = 'mesa';
-$stmt->bind_param('isdii', $mesa_id, $tipo, $total, $corte_id, $cajero_id);
+$stmt->bind_param('isdiii', $mesa_id, $tipo, $total, $corte_id, $cajero_id, $sede_id);
 if (!$stmt->execute()) {
     $stmt->close();
     error('Error al crear venta: ' . $stmt->error);

--- a/api/ventas/listar_ventas.php
+++ b/api/ventas/listar_ventas.php
@@ -2,7 +2,7 @@
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
-$query = "SELECT vw.*, v.tipo_entrega, v.usuario_id, v.entregado
+$query = "SELECT vw.*, v.tipo_entrega, v.usuario_id, v.entregado, v.sede_id
           FROM vw_ventas_detalladas vw
           JOIN ventas v ON v.id = vw.venta_id
           ORDER BY vw.fecha DESC"; // Lógica reemplazada por base de datos: ver bd.sql (Vista)

--- a/vistas/ventas/ticket.php
+++ b/vistas/ventas/ticket.php
@@ -47,9 +47,18 @@ ob_start();
 
 <div id="imprimir" style="display:none;" class="custom-modal2">
     <h2 id="nombreRestaurante" class="section-header">Mi Restaurante</h2>
+    <div id="direccionNegocio"></div>
+    <div id="rfcNegocio"></div>
+    <div id="telefonoNegocio"></div>
     <div id="fechaHora" style="margin-bottom:10px;"></div>
     <div><strong>Folio:</strong> <span id="folio"></span></div>
     <div><strong>Venta:</strong> <span id="ventaId"></span></div>
+    <div><strong>Sede:</strong> <span id="sedeId"></span></div>
+    <div><strong>Mesa:</strong> <span id="mesaNombre"></span></div>
+    <div><strong>Mesero:</strong> <span id="meseroNombre"></span></div>
+    <div><strong>Inicio:</strong> <span id="horaInicio"></span></div>
+    <div><strong>Fin:</strong> <span id="horaFin"></span></div>
+    <div><strong>Tiempo:</strong> <span id="tiempoServicio"></span></div>
     <table id="productos" class="table" style="margin-top: 10px;">
         <tbody></tbody>
     </table>

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -40,6 +40,7 @@ async function cargarHistorial() {
 }
 
 const usuarioId = window.usuarioId || 1; // ID del cajero proveniente de la sesión
+const sedeId = window.sedeId || 1;
 let corteIdActual = null;
 let catalogo = [];
 let productos = [];
@@ -550,7 +551,8 @@ async function registrarVenta() {
         usuario_id,
         observacion: (tipo === 'domicilio' || tipo === 'rapido') ? observacion : '',
         productos,
-        corte_id: corteIdActual
+        corte_id: corteIdActual,
+        sede_id: sedeId
     };
 
     try {
@@ -661,12 +663,18 @@ async function verDetalles(id) {
             document.getElementById('imprimirTicket').addEventListener('click', () => {
                 const venta = ventasData[id] || {};
                 const total = venta.total || info.productos.reduce((s, p) => s + parseFloat(p.subtotal), 0);
+                let sede = venta.sede_id || sedeId;
+                if (!venta.sede_id) {
+                    const entrada = prompt('Indica sede', sedeId);
+                    if (entrada) sede = parseInt(entrada) || sede;
+                }
                 const payload = {
                     venta_id: parseInt(id),
                     usuario_id: venta.usuario_id || 1,
                     fecha: venta.fecha || '',
                     productos: info.productos,
-                    total
+                    total,
+                    sede_id: sede
                 };
                 localStorage.setItem('ticketData', JSON.stringify(payload));
                 const mesaParam = venta.mesa_id ? `&mesa=${venta.mesa_id}` : '';
@@ -773,12 +781,18 @@ async function imprimirSolicitud(mesaId, ventaId) {
             const info = data.resultado || data;
             const venta = ventasData[ventaId] || {};
             const total = venta.total || info.productos.reduce((s, p) => s + parseFloat(p.subtotal), 0);
+            let sede = venta.sede_id || sedeId;
+            if (!venta.sede_id) {
+                const entrada = prompt('Indica sede', sedeId);
+                if (entrada) sede = parseInt(entrada) || sede;
+            }
             const payload = {
                 venta_id: parseInt(ventaId),
                 usuario_id: venta.usuario_id || 1,
                 fecha: venta.fecha || '',
                 productos: info.productos,
-                total
+                total,
+                sede_id: sede
             };
             localStorage.setItem('ticketData', JSON.stringify(payload));
             const w = window.open(`ticket.php?venta=${ventaId}&mesa=${mesaId}`, '_blank');


### PR DESCRIPTION
## Summary
- save table, waiter, timing and venue details when generating tickets
- expose new ticket fields for reprints and display them in ticket view
- pass `sede_id` through sales flows and ticket printing

## Testing
- `php -l api/tickets/guardar_ticket.php`
- `php -l api/tickets/reimprimir_ticket.php`
- `php -l api/ventas/crear_venta.php`
- `php -l api/ventas/crear_venta_mesa.php`
- `php -l api/ventas/listar_ventas.php`
- `php -l vistas/ventas/ticket.php`
- `node --check vistas/ventas/ticket.js`
- `node --check vistas/ventas/ventas.js`


------
https://chatgpt.com/codex/tasks/task_e_689146a401c4832bb0773faf22240cae