### PR TITLE
feat: limit mesa editing to assigned users

### DIFF
--- a/api/mesas/listar_mesas.php
+++ b/api/mesas/listar_mesas.php
@@ -6,12 +6,13 @@ require_once __DIR__ . '/../../utils/response.php';
 $query = "SELECT m.id, m.nombre, m.estado, m.capacidad, m.mesa_principal_id,
                 m.area_id, m.ticket_enviado, COALESCE(ca.nombre, m.area) AS area_nombre,
                 m.estado_reserva, m.nombre_reserva, m.fecha_reserva,
-                m.tiempo_ocupacion_inicio, m.usuario_id AS mesa_usuario_id,
-                v.id AS venta_id, v.usuario_id AS mesero_id, u.nombre AS mesero_nombre
+                m.tiempo_ocupacion_inicio, m.usuario_id,
+                u.nombre AS mesero_nombre,
+                v.id AS venta_id
           FROM mesas m
           LEFT JOIN catalogo_areas ca ON m.area_id = ca.id
+          LEFT JOIN usuarios u ON m.usuario_id = u.id
           LEFT JOIN ventas v ON v.mesa_id = m.id AND v.estatus = 'activa'
-          LEFT JOIN usuarios u ON v.usuario_id = u.id
           ORDER BY area_nombre, m.id";
 $result = $conn->query($query);
 
@@ -35,10 +36,9 @@ while ($row = $result->fetch_assoc()) {
         'nombre_reserva'    => $row['nombre_reserva'],
         'fecha_reserva'     => $row['fecha_reserva'],
         'tiempo_ocupacion_inicio' => $row['tiempo_ocupacion_inicio'],
-        'mesa_usuario_id'   => $row['mesa_usuario_id'] !== null ? (int)$row['mesa_usuario_id'] : null,
+        'usuario_id'        => $row['usuario_id'] !== null ? (int)$row['usuario_id'] : null,
         'venta_activa'      => $row['venta_id'] !== null,
         'venta_id'          => $row['venta_id'] !== null ? (int)$row['venta_id'] : null,
-        'mesero_id'         => $row['mesero_id'] !== null ? (int)$row['mesero_id'] : null,
         'mesero_nombre'     => $row['mesero_nombre'] ?? null
     ];
 }

--- a/api/mesas/mesas.php
+++ b/api/mesas/mesas.php
@@ -2,7 +2,7 @@
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
-$query = "SELECT m.id, m.nombre, m.usuario_id, u.nombre AS mesero_nombre
+$query = "SELECT m.id, m.nombre, m.estado, m.usuario_id, u.nombre AS mesero_nombre
           FROM mesas m
           LEFT JOIN usuarios u ON m.usuario_id = u.id
           ORDER BY m.id";
@@ -16,7 +16,8 @@ while ($row = $result->fetch_assoc()) {
         'id' => (int)$row['id'],
         'nombre' => $row['nombre'],
         'usuario_id' => $row['usuario_id'] !== null ? (int)$row['usuario_id'] : null,
-        'mesero_nombre' => $row['mesero_nombre']
+        'mesero_nombre' => $row['mesero_nombre'],
+        'estado' => $row['estado']
     ];
 }
 success($mesas);

--- a/auth/login.php
+++ b/auth/login.php
@@ -13,7 +13,7 @@ if (empty($usuario) || empty($contrasena)) {
     exit;
 }
 
-$stmt = $conn->prepare("SELECT id, usuario FROM usuarios WHERE usuario = ? AND contrasena = ?");
+$stmt = $conn->prepare("SELECT id, usuario, rol FROM usuarios WHERE usuario = ? AND contrasena = ?");
 $stmt->bind_param("ss", $usuario, $contrasena);
 $stmt->execute();
 $result = $stmt->get_result();
@@ -21,6 +21,7 @@ $usuario = $result->fetch_assoc();
 
 if ($usuario) {
     $_SESSION['usuario_id'] = $usuario['id'];
+    $_SESSION['rol'] = $usuario['rol'];
     echo json_encode(['success' => true]);
 } else {
     echo json_encode(['success' => false, 'mensaje' => 'Credenciales incorrectas']);

--- a/vistas/mesas/mesas.php
+++ b/vistas/mesas/mesas.php
@@ -55,6 +55,12 @@ ob_start();
 
 <?php require_once __DIR__ . '/../footer.php'; ?>
 
+<script>
+window.usuarioActual = {
+    id: <?= (int)($_SESSION['usuario_id'] ?? 0); ?>,
+    rol: <?= json_encode($_SESSION['rol'] ?? ''); ?>
+};
+</script>
 <script src="kanbanMesas.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose user role in session and listing APIs with mesa state
- enforce role-based editing in kanban and backend APIs
- show mesa status on Kanban cards

## Testing
- `php -l auth/login.php`
- `php -l api/mesas/listar_mesas.php`
- `php -l api/mesas/mesas.php`
- `php -l api/mesas/asignar.php`
- `php -l api/mesas/cambiar_estado.php`
- `php -l vistas/mesas/mesas.php`
- `node --check vistas/mesas/kanbanMesas.js && echo 'JS syntax OK'`

------
https://chatgpt.com/codex/tasks/task_e_689153f448d4832b87fcf348eeacae3e