### PR TITLE
Add rapido delivery flow for sales

### DIFF
--- a/api/tickets/guardar_ticket.php
+++ b/api/tickets/guardar_ticket.php
@@ -16,7 +16,7 @@ $usuario_id = (int)$input['usuario_id'];
 $subcuentas = $input['subcuentas'];
 
 // Obtener datos de la venta y de la sede
-$stmtVenta = $conn->prepare('SELECT mesa_id, usuario_id AS mesero_id, fecha_inicio, sede_id FROM ventas WHERE id = ?');
+$stmtVenta = $conn->prepare('SELECT mesa_id, usuario_id AS mesero_id, fecha_inicio, sede_id, tipo_entrega FROM ventas WHERE id = ?');
 if (!$stmtVenta) {
     error('Error al preparar datos de venta: ' . $conn->error);
 }
@@ -33,7 +33,10 @@ if (!$venta) {
 }
 
 $mesa_nombre = null;
-if (!empty($venta['mesa_id'])) {
+$tipo_entrega = $venta['tipo_entrega'] ?? '';
+if ($tipo_entrega === 'rapido') {
+    $mesa_nombre = 'Venta rápida';
+} elseif (!empty($venta['mesa_id'])) {
     $m = $conn->prepare('SELECT nombre FROM mesas WHERE id = ?');
     if ($m) {
         $m->bind_param('i', $venta['mesa_id']);

--- a/api/ventas/crear_venta.php
+++ b/api/ventas/crear_venta.php
@@ -57,6 +57,10 @@ if ($tipo === 'mesa') {
     if (!$repartidor_id || $mesa_id) {
         error('Venta a domicilio requiere repartidor_id y sin mesa_id');
     }
+} elseif ($tipo === 'rapido') {
+    if ($mesa_id || $repartidor_id) {
+        error('Venta rápida no debe incluir mesa ni repartidor');
+    }
 } else {
     error('Tipo de venta inválido');
 }

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -13,7 +13,11 @@ async function cargarHistorial() {
                 const accion = v.estatus !== 'cancelada'
                     ? `<button class="btn custom-btn btn-cancelar" data-id="${id}">Cancelar</button>`
                     : '';
-                const destino = v.tipo_entrega === 'mesa' ? v.mesa : v.repartidor;
+                const destino = v.tipo_entrega === 'mesa'
+                    ? v.mesa
+                    : v.tipo_entrega === 'domicilio'
+                        ? v.repartidor
+                        : 'Venta rápida';
                 const entregado = v.tipo_entrega === 'domicilio'
                     ? (parseInt(v.entregado) === 1 ? 'Entregado' : 'No entregado')
                     : 'N/A';
@@ -537,11 +541,14 @@ async function registrarVenta() {
         if (!libre) {
             return;
         }
-    } else {
+    } else if (tipo === 'domicilio') {
         if (isNaN(repartidor_id) || !repartidor_id) {
             alert('Selecciona un repartidor válido');
             return;
         }
+    } else if (tipo !== 'rapido') {
+        alert('Tipo de entrega inválido');
+        return;
     }
 
     const payload = {
@@ -608,7 +615,11 @@ async function verDetalles(id) {
         if (data.success) {
             const info = data.resultado || data;
             const contenedor = document.getElementById('modal-detalles');
-            const destino = info.tipo_entrega === 'mesa' ? info.mesa : info.repartidor;
+            const destino = info.tipo_entrega === 'mesa'
+                ? info.mesa
+                : info.tipo_entrega === 'domicilio'
+                    ? info.repartidor
+                    : 'Venta rápida';
             let html = `<h3>Detalle de venta</h3>
                         <p>Tipo: ${info.tipo_entrega}<br>Destino: ${destino}<br>Mesero: ${info.mesero}</p>`;
             html += `<table border="1"><thead><tr><th>Producto</th><th>Cant</th><th>Precio</th><th>Subtotal</th><th>Estatus</th><th></th></tr></thead><tbody>`;
@@ -830,7 +841,8 @@ function verificarActivacionProductos() {
   // Mostrar si hay alguno seleccionado según tipo de entrega
   if (
     (tipoEntrega === 'mesa' && mesa) ||
-    (tipoEntrega === 'domicilio' && repartidor)
+    (tipoEntrega === 'domicilio' && repartidor) ||
+    tipoEntrega === 'rapido'
   ) {
     seccionProductos.style.display = 'block';
   } else {
@@ -871,6 +883,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (tipo === 'mesa') {
             document.getElementById('observacion').value = '';
         }
+        verificarActivacionProductos();
     });
 
     // Delegación de eventos con jQuery para botones dinámicos


### PR DESCRIPTION
## Summary
- handle `rapido` orders on sales page without mesa or repartidor
- allow backend to create rapido sales
- label rapido sales as "Venta rápida" on tickets

## Testing
- `node --check vistas/ventas/ventas.js`
- `php -l api/ventas/crear_venta.php`
- `php -l api/tickets/guardar_ticket.php`


------
https://chatgpt.com/codex/tasks/task_e_68915711c074832babb76ce7b49d8478