### PR TITLE
Default sede_id to 1 when missing

### DIFF
--- a/api/tickets/guardar_ticket.php
+++ b/api/tickets/guardar_ticket.php
@@ -65,10 +65,7 @@ $fecha_inicio = $venta['fecha_inicio'] ?? null;
 $fecha_fin = date('Y-m-d H:i:s');
 $tiempo_servicio = $fecha_inicio ? (int) ((strtotime($fecha_fin) - strtotime($fecha_inicio)) / 60) : 0;
 
-$sede_id = isset($venta['sede_id']) ? (int)$venta['sede_id'] : 0;
-if (!$sede_id) {
-    error('La venta no tiene sede asignada');
-}
+$sede_id = isset($venta['sede_id']) && !empty($venta['sede_id']) ? (int)$venta['sede_id'] : 1;
 $stmtSede = $conn->prepare('SELECT nombre, direccion, rfc, telefono, activo FROM sedes WHERE id = ?');
 if (!$stmtSede) {
     error('Error al preparar datos de sede: ' . $conn->error);

--- a/api/ventas/crear_venta.php
+++ b/api/ventas/crear_venta.php
@@ -25,9 +25,9 @@ $usuario_id    = isset($input['usuario_id']) ? (int) $input['usuario_id'] : null
 $corte_id      = isset($input['corte_id']) ? (int) $input['corte_id'] : null;
 $productos     = isset($input['productos']) && is_array($input['productos']) ? $input['productos'] : null;
 $observacion   = isset($input['observacion']) ? $input['observacion'] : null;
-$sede_id       = isset($input['sede_id']) ? (int)$input['sede_id'] : null;
+$sede_id       = isset($input['sede_id']) && !empty($input['sede_id']) ? (int)$input['sede_id'] : 1;
 
-if (!$tipo || !$usuario_id || !$productos || !$sede_id) {
+if (!$tipo || !$usuario_id || !$productos) {
     error('Datos incompletos para crear la venta');
 }
 

--- a/api/ventas/crear_venta_mesa.php
+++ b/api/ventas/crear_venta_mesa.php
@@ -18,9 +18,9 @@ if (!$input) {
 
 $mesa_id   = isset($input['mesa_id']) ? (int)$input['mesa_id'] : null;
 $productos = isset($input['productos']) && is_array($input['productos']) ? $input['productos'] : null;
-$sede_id   = isset($input['sede_id']) ? (int)$input['sede_id'] : null;
+$sede_id   = isset($input['sede_id']) && !empty($input['sede_id']) ? (int)$input['sede_id'] : 1;
 
-if (!$mesa_id || !$productos || !$sede_id) {
+if (!$mesa_id || !$productos) {
     error('Datos incompletos');
 }
 


### PR DESCRIPTION
## Summary
- Default sede_id to 1 when generating tickets
- Allow sales creation without providing sede_id, using sede 1 by default

## Testing
- `php -l api/tickets/guardar_ticket.php`
- `php -l api/ventas/crear_venta_mesa.php`
- `php -l api/ventas/crear_venta.php`


------
https://chatgpt.com/codex/tasks/task_e_68915b592ce8832b80ed1f167e97e3ad