### PR TITLE
Ajusta manejo de sede al guardar y reimprimir tickets

### DIFF
--- a/api/tickets/reimprimir_ticket.php
+++ b/api/tickets/reimprimir_ticket.php
@@ -73,7 +73,7 @@ while ($t = $res->fetch_assoc()) {
         'direccion_negocio'=> $t['direccion_negocio'],
         'rfc_negocio'      => $t['rfc_negocio'],
         'telefono_negocio' => $t['telefono_negocio'],
-        'sede_id'          => $t['sede_id'],
+        'sede_id'          => isset($t['sede_id']) && !empty($t['sede_id']) ? (int)$t['sede_id'] : 1,
         'productos'        => $prods
     ];
 }


### PR DESCRIPTION
## Summary
- Permite definir `sede_id` desde la petición al guardar tickets con fallback a 1.
- Corrige parámetros y tipos en `bind_param` para insertar los nuevos campos de `tickets`.
- Devuelve todos los campos del ticket al reimprimir y asegura `sede_id` válido.

## Testing
- `php -l api/tickets/guardar_ticket.php`
- `php -l api/tickets/reimprimir_ticket.php`


------
https://chatgpt.com/codex/tasks/task_e_68915d25c7a0832ba90d4fe6dbad6222