### PR TITLE
Agregar botón para marcar productos como entregados

### DIFF
--- a/api/ventas/cambiar_estado_producto.php
+++ b/api/ventas/cambiar_estado_producto.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    error('Método no permitido');
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['detalle_id'], $input['estado'])) {
+    error('Datos inválidos');
+}
+
+$detalle_id = (int)$input['detalle_id'];
+$estado = $input['estado'];
+
+$permitidos = ['pendiente', 'en_preparacion', 'listo', 'entregado'];
+if (!in_array($estado, $permitidos, true)) {
+    error('Estado no permitido');
+}
+
+$stmt = $conn->prepare('UPDATE venta_detalles SET estado_producto = ? WHERE id = ?');
+if (!$stmt) {
+    error('Error al preparar actualización: ' . $conn->error);
+}
+$stmt->bind_param('si', $estado, $detalle_id);
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al actualizar estado: ' . $stmt->error);
+}
+$stmt->close();
+
+success(true);
+?>

--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -149,6 +149,8 @@ ob_start();
 <script>
   // ID de usuario proveniente de la sesión para operaciones en JS
   window.usuarioId = <?php echo json_encode($_SESSION['usuario_id']); ?>;
+  // ID de la venta actualmente consultada en detalle
+  window.ventaIdActual = null;
 </script>
 <script src="ventas.js"></script>
 </body>


### PR DESCRIPTION
## Resumen
- Agrega variable global para identificar la venta mostrada en detalle.
- Muestra botón **Entregar** en productos listos y llama API para actualizar su estado.
- Crea endpoint `cambiar_estado_producto.php` para validar y actualizar `estado_producto`.

## Testing
- `php -l vistas/ventas/ventas.php`
- `php -l api/ventas/cambiar_estado_producto.php`
- `node -e "new Function(require('fs').readFileSync('vistas/ventas/ventas.js','utf8'))"`


------
https://chatgpt.com/codex/tasks/task_e_68918ac81360832ba56071540ae59531