### PR TITLE
Use static logo for ticket

### DIFF
--- a/api/tickets/reimprimir_ticket.php
+++ b/api/tickets/reimprimir_ticket.php
@@ -65,10 +65,9 @@ $stmt = $conn->prepare("SELECT t.id, t.folio, t.total, t.propina, t.fecha, t.ven
                                t.mesa_nombre, t.mesero_nombre, t.fecha_inicio, t.fecha_fin,
                                t.tiempo_servicio, t.nombre_negocio, t.direccion_negocio,
                                t.rfc_negocio, t.telefono_negocio, t.sede_id,
-                               t.tipo_pago, t.monto_recibido, v.tipo_entrega, s.logo_url AS logo
+                               t.tipo_pago, t.monto_recibido, v.tipo_entrega
                         FROM tickets t
                         LEFT JOIN ventas v ON t.venta_id = v.id
-                        LEFT JOIN sedes s ON t.sede_id = s.id
                         WHERE $cond");
 if (!$stmt) {
     error('Error al preparar consulta: ' . $conn->error);
@@ -135,7 +134,7 @@ while ($t = $res->fetch_assoc()) {
         'tipo_entrega'     => $tipo_entrega,
         'cambio'           => (float)$cambio,
         'total_letras'     => numeroALetras($t['total']),
-        'logo'             => $t['logo'] ?? 'N/A',
+        'logo_url'         => 'utils/logo.png',
         'sede_id'          => isset($t['sede_id']) && !empty($t['sede_id']) ? (int)$t['sede_id'] : 1,
         'productos'        => $prods
     ];

--- a/vistas/ventas/ticket.js
+++ b/vistas/ventas/ticket.js
@@ -1,5 +1,6 @@
  function llenarTicket(data) {
-        document.getElementById('logoSede').src = data.logo || '';
+        const logoSrc = data.logo_url || 'utils/logo.png';
+        document.getElementById('ticketLogo').src = logoSrc;
         document.getElementById('ventaId').textContent = data.venta_id;
         document.getElementById('fechaHora').textContent = data.fecha_fin || data.fecha || '';
         document.getElementById('folio').textContent = data.folio || '';

--- a/vistas/ventas/ticket.php
+++ b/vistas/ventas/ticket.php
@@ -46,7 +46,7 @@ ob_start();
 </div>
 
 <div id="imprimir" style="display:none;" class="custom-modal2">
-    <img id="logoSede" style="max-width:100px;" alt="logo" />
+    <img id="ticketLogo" src="utils/logo.png" alt="Logo" style="max-width:100px;">
     <h2 id="nombreRestaurante" class="section-header">Mi Restaurante</h2>
     <div id="direccionNegocio"></div>
     <div id="rfcNegocio"></div>


### PR DESCRIPTION
## Summary
- Remove logo lookup from ticket reprint API and return fixed utils/logo.png
- Load logo from provided URL or default in ticket rendering JS
- Include static logo element in ticket view

## Testing
- `php -l api/tickets/reimprimir_ticket.php`
- `php -l vistas/ventas/ticket.php`
- `node --check vistas/ventas/ticket.js && echo 'JS syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68918e1e7a0c832bb158a16456121c3f