### PR TITLE
Fix expected total calculation for cash breakdown

### DIFF
--- a/vistas/corte_caja/corte.php
+++ b/vistas/corte_caja/corte.php
@@ -30,7 +30,7 @@ ob_start();
 <h1 class="section-header">Corte de Caja</h1>
 
 <div id="corteActual" class="mb-3">
-  <button class="btn custom-btn" id="btnIniciar" class="btn btn-primary">Iniciar Corte</button>
+  <button class="btn custom-btn btn-primary" id="btnIniciar">Iniciar Corte</button>
 </div>
 
 <!-- Modales -->


### PR DESCRIPTION
## Summary
- compute expected total by summing sales and tips for all payment methods
- validate API response before showing cash breakdown modal
- clean up markup for starting cut button

## Testing
- `php -l vistas/corte_caja/corte.php`
- `node --check vistas/corte_caja/corte.js`

------
https://chatgpt.com/codex/tasks/task_e_689231c76440832b9c0ea59318b75657