### PR TITLE
Fix corte detail rendering by using existing table

### DIFF
--- a/vistas/corte_caja/corte.js
+++ b/vistas/corte_caja/corte.js
@@ -273,18 +273,16 @@ document.addEventListener('DOMContentLoaded', () => {
             dataType: 'json',
             data: JSON.stringify({ id: parseInt(corteId) })
         }).done(function (resp) {
-            const contenedor = document.getElementById('modalDetalleContenido');
+            const tablaEl = document.getElementById('tablaDetalleCorte');
+            const tablaDetalle = tablaEl ? tablaEl.querySelector('tbody') : null;
+            if (!tablaDetalle) {
+                console.error('No se encontró la tabla de detalle de corte');
+                return;
+            }
+
+            tablaDetalle.innerHTML = '';
+
             if (resp.success && Array.isArray(resp.detalles)) {
-                contenedor.innerHTML = '<h5>Desglose del corte</h5><table class="table table-sm" id="tablaDetalleCorte"></table>';
-                const tablaDetalle = document.getElementById('tablaDetalleCorte');
-                tablaDetalle.innerHTML = '';
-                const thead = `<tr>
-                    <th>Denominación</th>
-                    <th>Cantidad</th>
-                    <th>Tipo de pago</th>
-                    <th>Subtotal</th>
-                </tr>`;
-                tablaDetalle.innerHTML = thead;
                 resp.detalles.forEach(item => {
                     const fila = document.createElement('tr');
                     fila.innerHTML = `
@@ -295,14 +293,22 @@ document.addEventListener('DOMContentLoaded', () => {
                     `;
                     tablaDetalle.appendChild(fila);
                 });
+
+                if (!resp.detalles.length) {
+                    tablaDetalle.innerHTML = '<tr><td colspan="4" class="text-center">Sin datos</td></tr>';
+                }
             } else {
                 const msg = resp.mensaje || 'Error al obtener detalle';
-                contenedor.innerHTML = `<p>${msg}</p>`;
+                tablaDetalle.innerHTML = `<tr><td colspan="4" class="text-center">${msg}</td></tr>`;
             }
+
             $('#modalDetalle').modal('show');
         }).fail(function () {
-            const contenedor = document.getElementById('modalDetalleContenido');
-            contenedor.innerHTML = '<p>Error al obtener detalle</p>';
+            const tablaEl = document.getElementById('tablaDetalleCorte');
+            const tablaDetalle = tablaEl ? tablaEl.querySelector('tbody') : null;
+            if (tablaDetalle) {
+                tablaDetalle.innerHTML = '<tr><td colspan="4" class="text-center">Error al obtener detalle</td></tr>';
+            }
             $('#modalDetalle').modal('show');
         });
     });

--- a/vistas/corte_caja/corte.php
+++ b/vistas/corte_caja/corte.php
@@ -37,6 +37,33 @@ ob_start();
 <div id="resumenModal" class="custom-modal" style="display:none;"></div>
 <div id="modalDesglose" class="custom-modal" style="display:none;"></div>
 
+<!-- Modal para detalle de corte -->
+<div class="modal fade" id="modalDetalle" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Detalle de corte</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body" id="modalDetalleContenido">
+        <table id="tablaDetalleCorte" class="table table-bordered">
+          <thead>
+            <tr>
+              <th>Denominación</th>
+              <th>Cantidad</th>
+              <th>Tipo de pago</th>
+              <th>Subtotal</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
 <h2 class="section-header">Historial de Cortes</h2>
 <div class="table-responsive">
   <table id="tablaCortes" class="styled-table">


### PR DESCRIPTION
## Summary
- Add bootstrap modal with static `tablaDetalleCorte` table to show corte details.
- Populate corte detail table from API data and handle empty results to avoid null container errors.

## Testing
- `php -l vistas/corte_caja/corte.php`
- `node --check vistas/corte_caja/corte.js && echo 'JS syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_6892b32006f8832bbe1956a7b4036ba7