### PR TITLE
Add AJAX pagination and search to corte history table

### DIFF
--- a/api/corte_caja/listar_cortes.php
+++ b/api/corte_caja/listar_cortes.php
@@ -5,6 +5,9 @@ require_once __DIR__ . '/../../utils/response.php';
 $usuario_id = null;
 $inicio = null;
 $fin = null;
+$limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 15;
+$offset = isset($_GET['offset']) ? (int)$_GET['offset'] : 0;
+$search = isset($_GET['search']) ? trim($_GET['search']) : '';
 
 if (isset($_GET['usuario_id'])) {
     $usuario_id = (int)$_GET['usuario_id'];
@@ -34,7 +37,37 @@ if ($fin) {
     $params[] = $fin;
     $types .= 's';
 }
+$searchParams = [];
+if ($search !== '') {
+    $conditions[] = "(CAST(v.corte_id AS CHAR) LIKE ? OR v.cajero LIKE ? OR v.fecha_inicio LIKE ? OR v.fecha_fin LIKE ? OR CAST(v.total AS CHAR) LIKE ?)";
+    $searchLike = "%$search%";
+    for ($i = 0; $i < 5; $i++) {
+        $searchParams[] = $searchLike;
+    }
+    $types .= 'sssss';
+}
 $where = $conditions ? 'WHERE ' . implode(' AND ', $conditions) : '';
+$countQuery = "SELECT COUNT(DISTINCT v.corte_id) AS total
+               FROM vw_corte_resumen v
+               JOIN corte_caja cc ON cc.id = v.corte_id
+               LEFT JOIN desglose_corte dc ON dc.corte_id = v.corte_id
+               $where";
+$stmt = $conn->prepare($countQuery);
+if (!$stmt) {
+    error('Error al preparar conteo: ' . $conn->error);
+}
+if ($params || $search !== '') {
+    $bindParams = array_merge($params, $searchParams);
+    $stmt->bind_param($types, ...$bindParams);
+}
+if (!$stmt->execute()) {
+    $stmt->close();
+    error('Error al ejecutar conteo: ' . $stmt->error);
+}
+$res = $stmt->get_result();
+$totalRow = $res->fetch_assoc();
+$total = (int)$totalRow['total'];
+$stmt->close();
 
 $query = "SELECT v.corte_id AS id, v.fecha_inicio, v.fecha_fin, v.total, v.cajero AS usuario,
                  cc.observaciones, cc.fondo_inicial,
@@ -46,15 +79,15 @@ $query = "SELECT v.corte_id AS id, v.fecha_inicio, v.fecha_fin, v.total, v.cajer
           LEFT JOIN desglose_corte dc ON dc.corte_id = v.corte_id
           $where
           GROUP BY v.corte_id
-          ORDER BY v.fecha_inicio DESC"; // Lógica reemplazada por base de datos: ver bd.sql (Vista)
+          ORDER BY v.fecha_inicio DESC
+          LIMIT ? OFFSET ?"; // Lógica reemplazada por base de datos: ver bd.sql (Vista)
 
 $stmt = $conn->prepare($query);
 if (!$stmt) {
     error('Error al preparar consulta: ' . $conn->error);
 }
-if ($params) {
-    $stmt->bind_param($types, ...$params);
-}
+$bindParams = array_merge($params, $searchParams, [$limit, $offset]);
+$stmt->bind_param($types . 'ii', ...$bindParams);
 if (!$stmt->execute()) {
     $stmt->close();
     error('Error al ejecutar consulta: ' . $stmt->error);
@@ -77,5 +110,6 @@ while ($row = $res->fetch_assoc()) {
 }
 $stmt->close();
 
-success($cortes);
+success(['total' => $total, 'cortes' => $cortes]);
 ?>
+

--- a/vistas/corte_caja/corte.php
+++ b/vistas/corte_caja/corte.php
@@ -65,6 +65,20 @@ ob_start();
 </div>
 
 <h2 class="section-header">Historial de Cortes</h2>
+<div class="d-flex justify-content-between mb-2">
+  <div>
+    <label for="selectRegistros">Mostrar</label>
+    <select id="selectRegistros" class="custom-select custom-select-sm">
+      <option value="15">15</option>
+      <option value="25">25</option>
+      <option value="50">50</option>
+    </select>
+    <span>registros</span>
+  </div>
+  <div>
+    <input type="text" id="buscarCorte" class="form-control form-control-sm" placeholder="Buscar...">
+  </div>
+</div>
 <div class="table-responsive">
   <table id="tablaCortes" class="styled-table">
     <thead>
@@ -82,6 +96,7 @@ ob_start();
     </tbody>
   </table>
 </div>
+<div id="paginacion" class="mt-2"></div>
 
 </div>
 <?php require_once __DIR__ . '/../footer.php'; ?>
@@ -91,3 +106,4 @@ ob_start();
 <?php
 $content = ob_get_clean();
 include __DIR__ . '/../nav.php';
+


### PR DESCRIPTION
## Summary
- Add page size selector, search field, and pagination container to corte history view
- Implement client-side pagination and live search with AJAX updates
- Extend listar_cortes API to support limit/offset/search and return total results

## Testing
- `php -l api/corte_caja/listar_cortes.php`
- `php -l vistas/corte_caja/corte.php`
- `node --check vistas/corte_caja/corte.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_6892b8b73bac832b979b574d8dcaba1e