### PR TITLE
Use denomination catalog for cash breakdown

### DIFF
--- a/api/corte_caja/detalle_venta.php
+++ b/api/corte_caja/detalle_venta.php
@@ -36,9 +36,11 @@ if ($id <= 0) {
 
 try {
     // 1️⃣ Intentar obtener desglose de corte
-    $sqlDesglose = "SELECT denominacion, cantidad, tipo_pago,
-                           (denominacion * cantidad) AS subtotal
-                    FROM desglose_corte WHERE corte_id = ?";
+    $sqlDesglose = "SELECT dc.id, cd.descripcion, cd.valor, dc.cantidad, dc.tipo_pago,
+                           (cd.valor * dc.cantidad) AS subtotal
+                    FROM desglose_corte dc
+                    JOIN catalogo_denominaciones cd ON cd.id = dc.denominacion_id
+                    WHERE dc.corte_id = ?";
     $stmt = $conn->prepare($sqlDesglose);
     $stmt->bind_param('i', $id);
     $stmt->execute();
@@ -48,7 +50,9 @@ try {
         $detalles = [];
         while ($row = $resDesglose->fetch_assoc()) {
             $detalles[] = [
-                'denominacion' => (float)$row['denominacion'],
+                'id' => (int)$row['id'],
+                'descripcion' => $row['descripcion'],
+                'valor' => (float)$row['valor'],
                 'cantidad' => (int)$row['cantidad'],
                 'tipo_pago' => $row['tipo_pago'],
                 'subtotal' => round((float)$row['subtotal'], 2)

--- a/api/corte_caja/listar_cortes.php
+++ b/api/corte_caja/listar_cortes.php
@@ -71,12 +71,13 @@ $stmt->close();
 
 $query = "SELECT v.corte_id AS id, v.fecha_inicio, v.fecha_fin, v.total, v.cajero AS usuario,
                  cc.observaciones, cc.fondo_inicial,
-                 SUM(CASE WHEN dc.tipo_pago='efectivo' THEN dc.denominacion*dc.cantidad ELSE 0 END) AS efectivo,
-                 SUM(CASE WHEN dc.tipo_pago='boucher' THEN dc.denominacion*dc.cantidad ELSE 0 END) AS boucher,
-                 SUM(CASE WHEN dc.tipo_pago='cheque' THEN dc.denominacion*dc.cantidad ELSE 0 END) AS cheque
+                 SUM(CASE WHEN dc.tipo_pago='efectivo' THEN cd.valor*dc.cantidad ELSE 0 END) AS efectivo,
+                 SUM(CASE WHEN dc.tipo_pago='boucher' THEN cd.valor*dc.cantidad ELSE 0 END) AS boucher,
+                 SUM(CASE WHEN dc.tipo_pago='cheque' THEN cd.valor*dc.cantidad ELSE 0 END) AS cheque
           FROM vw_corte_resumen v
           JOIN corte_caja cc ON cc.id = v.corte_id
           LEFT JOIN desglose_corte dc ON dc.corte_id = v.corte_id
+          LEFT JOIN catalogo_denominaciones cd ON cd.id = dc.denominacion_id
           $where
           GROUP BY v.corte_id
           ORDER BY v.fecha_inicio DESC

--- a/vistas/corte_caja/corte.js
+++ b/vistas/corte_caja/corte.js
@@ -148,10 +148,31 @@ function abrirModalDesglose(corteId, resumen) {
 
     function agregarFila() {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td><input type="number" step="0.01" class="denominacion"></td>`+
-            `<td><input type="number" min="0" class="cantidad" value="0"></td>`+
-            `<td><select class="tipo"><option value="efectivo">efectivo</option><option value="cheque">cheque</option><option value="boucher">boucher</option></select></td>`+
-            `<td><button class="btn custom-btn delFila">X</button></td>`;
+
+        const tdDen = document.createElement('td');
+        const select = document.createElement('select');
+        select.classList.add('denominacion');
+        catalogoDenominaciones.forEach(d => {
+            const opt = document.createElement('option');
+            opt.value = d.id;
+            opt.textContent = `${d.descripcion} ($${d.valor})`;
+            select.appendChild(opt);
+        });
+        tdDen.appendChild(select);
+
+        const tdCant = document.createElement('td');
+        tdCant.innerHTML = `<input type="number" min="0" class="cantidad" value="0">`;
+
+        const tdTipo = document.createElement('td');
+        tdTipo.innerHTML = `<select class="tipo"><option value="efectivo">efectivo</option><option value="cheque">cheque</option><option value="boucher">boucher</option></select>`;
+
+        const tdDel = document.createElement('td');
+        tdDel.innerHTML = `<button class="btn custom-btn delFila">X</button>`;
+
+        tr.appendChild(tdDen);
+        tr.appendChild(tdCant);
+        tr.appendChild(tdTipo);
+        tr.appendChild(tdDel);
         tbody.appendChild(tr);
         tr.querySelector('.delFila').addEventListener('click', () => { tr.remove(); calcular(); });
         tr.querySelectorAll('input,select').forEach(el => el.addEventListener('input', calcular));
@@ -161,13 +182,15 @@ function abrirModalDesglose(corteId, resumen) {
         const filas = Array.from(tbody.querySelectorAll('tr'));
         let total = 0;
         filas.forEach(f => {
-            const d = parseFloat(f.querySelector('.denominacion').value) || 0;
+            const id = parseInt(f.querySelector('.denominacion').value);
+            const denom = catalogoDenominaciones.find(d => d.id === id);
+            const valor = denom ? parseFloat(denom.valor) : 0;
             const c = parseInt(f.querySelector('.cantidad').value) || 0;
             const t = f.querySelector('.tipo').value;
             if (t === 'efectivo') {
-                total += d * c;
+                total += valor * c;
             } else {
-                total += d;
+                total += valor;
             }
         });
         modal.querySelector('#totalDesglose').textContent = total.toFixed(2);
@@ -185,7 +208,7 @@ function abrirModalDesglose(corteId, resumen) {
     modal.querySelector('#guardarDesglose').addEventListener('click', async () => {
         const filas = Array.from(tbody.querySelectorAll('tr'));
         const detalle = filas.map(tr => ({
-            denominacion: parseFloat(tr.querySelector('.denominacion').value) || 0,
+            denominacion_id: parseInt(tr.querySelector('.denominacion').value),
             cantidad: parseInt(tr.querySelector('.cantidad').value) || 0,
             tipo_pago: tr.querySelector('.tipo').value
         })).filter(d => d.cantidad > 0 || d.tipo_pago !== 'efectivo');
@@ -339,7 +362,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 resp.detalles.forEach(item => {
                     const fila = document.createElement('tr');
                     fila.innerHTML = `
-                        <td>${item.denominacion}</td>
+                        <td>${item.descripcion}</td>
                         <td>${item.cantidad}</td>
                         <td>${item.tipo_pago}</td>
                         <td>$${parseFloat(item.subtotal).toFixed(2)}</td>

--- a/vistas/corte_caja/corte.php
+++ b/vistas/corte_caja/corte.php
@@ -1,11 +1,15 @@
 <?php
 require_once __DIR__ . '/../../utils/cargar_permisos.php';
+require_once __DIR__ . '/../../config/db.php';
 $path_actual = str_replace('/rest', '', $_SERVER['PHP_SELF']);
 if (!in_array($path_actual, $_SESSION['rutas_permitidas'])) {
     http_response_code(403);
     echo 'Acceso no autorizado';
     exit;
 }
+
+$denominaciones = $conn->query("SELECT id, descripcion, valor FROM catalogo_denominaciones ORDER BY valor ASC")->fetch_all(MYSQLI_ASSOC);
+
 $title = 'Corte de Caja';
 ob_start();
 ?>
@@ -100,6 +104,9 @@ ob_start();
 
 </div>
 <?php require_once __DIR__ . '/../footer.php'; ?>
+<script>
+    const catalogoDenominaciones = <?php echo json_encode($denominaciones); ?>;
+</script>
 <script src="corte.js"></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- load denomination catalog in corte.php and expose to client
- replace numeric inputs with denomination selector and send `denominacion_id`
- persist and query breakdown using denomination catalog values

## Testing
- `php -l vistas/corte_caja/corte.php`
- `php -l api/corte_caja/guardar_desglose.php`
- `php -l api/corte_caja/detalle_venta.php`
- `php -l api/corte_caja/listar_cortes.php`
- `node --check vistas/corte_caja/corte.js`


------
https://chatgpt.com/codex/tasks/task_e_6892ce628d98832ba5911de5bd394fde