### PR TITLE
Add payment metadata and ticket safety

### DIFF
--- a/api/tickets/reimprimir_ticket.php
+++ b/api/tickets/reimprimir_ticket.php
@@ -62,13 +62,21 @@ if (isset($input['folio'])) {
 }
 
 $stmt = $conn->prepare("SELECT t.id, t.folio, t.total, t.propina, t.fecha, t.venta_id,
-                               t.mesa_nombre, t.mesero_nombre, t.fecha_inicio, t.fecha_fin,
-                               t.tiempo_servicio, t.nombre_negocio, t.direccion_negocio,
-                               t.rfc_negocio, t.telefono_negocio, t.sede_id,
-                               t.tipo_pago, t.monto_recibido, v.tipo_entrega
-                        FROM tickets t
-                        LEFT JOIN ventas v ON t.venta_id = v.id
-                        WHERE $cond");
+                                t.mesa_nombre, t.mesero_nombre, t.fecha_inicio, t.fecha_fin,
+                                t.tiempo_servicio, t.nombre_negocio, t.direccion_negocio,
+                                t.rfc_negocio, t.telefono_negocio, t.sede_id,
+                                t.tipo_pago, t.monto_recibido,
+                                t.tarjeta_marca_id, tm.descripcion AS tarjeta_marca,
+                                t.tarjeta_banco_id, cb.descripcion AS tarjeta_banco,
+                                t.boucher,
+                                t.cheque_numero, t.cheque_banco_id, cb2.descripcion AS cheque_banco,
+                                v.tipo_entrega
+                         FROM tickets t
+                         LEFT JOIN catalogo_tarjetas tm ON t.tarjeta_marca_id = tm.id
+                         LEFT JOIN catalogo_bancos cb ON t.tarjeta_banco_id = cb.id
+                         LEFT JOIN catalogo_bancos cb2 ON t.cheque_banco_id = cb2.id
+                         LEFT JOIN ventas v ON t.venta_id = v.id
+                         WHERE $cond");
 if (!$stmt) {
     error('Error al preparar consulta: ' . $conn->error);
 }
@@ -114,30 +122,35 @@ while ($t = $res->fetch_assoc()) {
     $tipo_pago        = $t['tipo_pago']        ?? 'N/A';
     $tipo_entrega     = $t['tipo_entrega']     ?? 'N/A';
     $cambio           = max(0, ($t['monto_recibido'] ?? 0) - ($t['total'] ?? 0));
-    $tickets[] = [
-        'ticket_id'        => (int)$t['id'],
-        'folio'            => (int)$t['folio'],
-        'fecha'            => $t['fecha'] ?? 'N/A',
-        'venta_id'         => (int)$t['venta_id'],
-        'propina'          => (float)$t['propina'],
-        'total'            => (float)$t['total'],
-        'mesa_nombre'      => $mesa_nombre,
-        'mesero_nombre'    => $mesero_nombre,
-        'fecha_inicio'     => $fecha_inicio,
-        'fecha_fin'        => $fecha_fin,
-        'tiempo_servicio'  => $tiempo_servicio,
-        'nombre_negocio'   => $nombre_negocio,
-        'direccion_negocio'=> $direccion_negocio,
-        'rfc_negocio'      => $rfc_negocio,
-        'telefono_negocio' => $telefono_negocio,
-        'tipo_pago'        => $tipo_pago,
-        'tipo_entrega'     => $tipo_entrega,
-        'cambio'           => (float)$cambio,
-        'total_letras'     => numeroALetras($t['total']),
-        'logo_url'         => '../../utils/logo.png',
-        'sede_id'          => isset($t['sede_id']) && !empty($t['sede_id']) ? (int)$t['sede_id'] : 1,
-        'productos'        => $prods
-    ];
+      $tickets[] = [
+          'ticket_id'        => (int)$t['id'],
+          'folio'            => (int)$t['folio'],
+          'fecha'            => $t['fecha'] ?? 'N/A',
+          'venta_id'         => (int)$t['venta_id'],
+          'propina'          => (float)$t['propina'],
+          'total'            => (float)$t['total'],
+          'mesa_nombre'      => $mesa_nombre,
+          'mesero_nombre'    => $mesero_nombre,
+          'fecha_inicio'     => $fecha_inicio,
+          'fecha_fin'        => $fecha_fin,
+          'tiempo_servicio'  => $tiempo_servicio,
+          'nombre_negocio'   => $nombre_negocio,
+          'direccion_negocio'=> $direccion_negocio,
+          'rfc_negocio'      => $rfc_negocio,
+          'telefono_negocio' => $telefono_negocio,
+          'tipo_pago'        => $tipo_pago,
+          'tarjeta_marca'    => $t['tarjeta_marca'] ?? null,
+          'tarjeta_banco'    => $t['tarjeta_banco'] ?? null,
+          'boucher'          => $t['boucher'] ?? null,
+          'cheque_numero'    => $t['cheque_numero'] ?? null,
+          'cheque_banco'     => $t['cheque_banco'] ?? null,
+          'tipo_entrega'     => $tipo_entrega,
+          'cambio'           => (float)$cambio,
+          'total_letras'     => numeroALetras($t['total']),
+          'logo_url'         => '../../utils/logo.png',
+          'sede_id'          => isset($t['sede_id']) && !empty($t['sede_id']) ? (int)$t['sede_id'] : 1,
+          'productos'        => $prods
+      ];
 }
 $stmt->close();
 

--- a/vistas/ventas/ticket.php
+++ b/vistas/ventas/ticket.php
@@ -1,11 +1,19 @@
 <?php
 require_once __DIR__ . '/../../utils/cargar_permisos.php';
+require_once __DIR__ . '/../../config/db.php';
 $path_actual = str_replace('/rest', '', $_SERVER['PHP_SELF']);
 if (!in_array($path_actual, $_SESSION['rutas_permitidas'])) {
     http_response_code(403);
     echo 'Acceso no autorizado';
     exit;
 }
+
+// Catálogos para datos de pago
+$tarjetas = $conn->query("SELECT id, descripcion FROM catalogo_tarjetas ORDER BY descripcion")
+    ?->fetch_all(MYSQLI_ASSOC) ?? [];
+$bancos = $conn->query("SELECT id, descripcion FROM catalogo_bancos ORDER BY descripcion")
+    ?->fetch_all(MYSQLI_ASSOC) ?? [];
+
 $title = 'Ticket';
 ob_start();
 ?>
@@ -24,6 +32,7 @@ ob_start();
     </div>
 </div>
 <!-- Page Header End -->
+<div id="sinDatos" class="container mt-5">Sin datos cargados</div>
 <div id="dividir" style="display:none;" class="container mt-5">
     <h2 class="section-subheader">Dividir venta</h2>
     <div class="table-responsive">
@@ -60,6 +69,15 @@ ob_start();
         <div><strong>Mesero:</strong> <span id="meseroNombre"></span></div>
         <div><strong>Tipo entrega:</strong> <span id="tipoEntrega"></span></div>
         <div><strong>Tipo pago:</strong> <span id="tipoPago"></span></div>
+        <div id="tarjetaInfo" style="display:none;">
+            <div><strong>Marca tarjeta:</strong> <span id="tarjetaMarca"></span></div>
+            <div><strong>Banco:</strong> <span id="tarjetaBanco"></span></div>
+            <div><strong>Boucher:</strong> <span id="tarjetaBoucher"></span></div>
+        </div>
+        <div id="chequeInfo" style="display:none;">
+            <div><strong>No. Cheque:</strong> <span id="chequeNumero"></span></div>
+            <div><strong>Banco:</strong> <span id="chequeBanco"></span></div>
+        </div>
         <div><strong>Inicio:</strong> <span id="horaInicio"></span></div>
         <div><strong>Fin:</strong> <span id="horaFin"></span></div>
         <div><strong>Tiempo:</strong> <span id="tiempoServicio"></span></div>
@@ -77,7 +95,10 @@ ob_start();
 
 
 <?php require_once __DIR__ . '/../footer.php'; ?>
-
+<script>
+    const catalogoTarjetas = <?php echo json_encode($tarjetas); ?>;
+    const catalogoBancos = <?php echo json_encode($bancos); ?>;
+</script>
 <script src="ticket.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- Prevent printing ticket without data and expose card/cheque info
- Capture card and cheque metadata in tickets API and reprints
- Simplify cash breakdown and auto-include non-cash totals

## Testing
- `php -l vistas/ventas/ticket.php`
- `php -l api/tickets/guardar_ticket.php`
- `php -l api/tickets/reimprimir_ticket.php`
- `node --check vistas/ventas/ticket.js`
- `node --check vistas/corte_caja/corte.js`


------
https://chatgpt.com/codex/tasks/task_e_68936d8ba51c832b99bfdbf553c7cfce