### PR TITLE
Ajustar desglose de corte

### DIFF
--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -8,6 +8,7 @@ if (!in_array($path_actual, $_SESSION['rutas_permitidas'])) {
     exit;
 }
 
+// Cargar todas las denominaciones disponibles para usarlas en el JS
 $denominaciones = $conn->query("SELECT id, descripcion, valor FROM catalogo_denominaciones ORDER BY valor ASC")->fetch_all(MYSQLI_ASSOC);
 
 $title = 'Ventas';
@@ -155,6 +156,7 @@ ob_start();
     window.usuarioId = <?php echo json_encode($_SESSION['usuario_id']); ?>;
     // ID de la venta actualmente consultada en detalle
     window.ventaIdActual = null;
+    // Catálogo de denominaciones cargado desde la base de datos
     const catalogoDenominaciones = <?php echo json_encode($denominaciones); ?>;
   </script>
   <script src="ventas.js"></script>


### PR DESCRIPTION
## Summary
- Expose catalog of cash denominations from the database to the sales module so the closure modal can build denomination options.
- Rework closure breakdown UI: cash rows have fixed `efectivo` type, card/cheque totals are auto-inserted with denomination `N/A`, and differences are calculated using only cash entered.
- When saving the breakdown, send denomination IDs only for cash rows and `0` for card/cheque entries.

## Testing
- `php -l vistas/ventas/ventas.php`
- `node --check vistas/ventas/ventas.js`


------
https://chatgpt.com/codex/tasks/task_e_6893a08a1818832b8c8b144f0421d0f9