### PR TITLE
Add debug logs for denominaciones loading

### DIFF
--- a/vistas/corte_caja/corte.js
+++ b/vistas/corte_caja/corte.js
@@ -4,6 +4,12 @@ let pagina = 1;
 let limite = 15;
 let busqueda = '';
 
+if (Array.isArray(window.catalogoDenominaciones) && catalogoDenominaciones.length > 0) {
+    console.log('Denominaciones cargadas:', catalogoDenominaciones);
+} else {
+    console.error('Error al cargar denominaciones');
+}
+
 function calcularTotalEsperado(resumen) {
     let total = 0;
     if (resumen && typeof resumen === 'object') {
@@ -159,12 +165,21 @@ function abrirModalDesglose(corteId, resumen) {
         placeholder.textContent = '--Seleccione--';
         select.appendChild(placeholder);
 
-        catalogoDenominaciones.forEach(d => {
-            const opt = document.createElement('option');
-            opt.value = d.id;
-            opt.textContent = d.descripcion;
-            select.appendChild(opt);
-        });
+        if (Array.isArray(catalogoDenominaciones) && catalogoDenominaciones.length > 0) {
+            catalogoDenominaciones.forEach(d => {
+                console.log('Agregando opción:', d.descripcion);
+                const opt = document.createElement('option');
+                opt.value = d.id;
+                opt.textContent = d.descripcion;
+                select.appendChild(opt);
+            });
+        } else {
+            console.warn('No se agregaron opciones al select. Lista vacía.');
+        }
+
+        if (select.options.length <= 1) {
+            console.warn('No se agregaron opciones al select');
+        }
         tdDen.appendChild(select);
 
         const tdCant = document.createElement('td');

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -1,3 +1,9 @@
+if (Array.isArray(window.catalogoDenominaciones) && catalogoDenominaciones.length > 0) {
+    console.log('Denominaciones cargadas:', catalogoDenominaciones);
+} else {
+    console.error('Error al cargar denominaciones');
+}
+
 async function cargarHistorial() {
     try {
         const resp = await fetch('../../api/ventas/listar_ventas.php');
@@ -187,12 +193,21 @@ function mostrarModalDesglose(dataApi) {
         placeholder.value = '';
         placeholder.textContent = '--Seleccione--';
         select.appendChild(placeholder);
-        catalogoDenominaciones.forEach(d => {
-            const opt = document.createElement('option');
-            opt.value = d.id;
-            opt.textContent = d.descripcion;
-            select.appendChild(opt);
-        });
+        if (Array.isArray(catalogoDenominaciones) && catalogoDenominaciones.length > 0) {
+            catalogoDenominaciones.forEach(d => {
+                console.log('Agregando opción:', d.descripcion);
+                const opt = document.createElement('option');
+                opt.value = d.id;
+                opt.textContent = d.descripcion;
+                select.appendChild(opt);
+            });
+        } else {
+            console.warn('No se agregaron opciones al select. Lista vacía.');
+        }
+
+        if (select.options.length <= 1) {
+            console.warn('No se agregaron opciones al select');
+        }
         tdDen.appendChild(select);
 
         const tdCant = document.createElement('td');


### PR DESCRIPTION
## Summary
- Log denominaciones on load and when populating select options for corte de caja
- Log denominaciones on load and when populating select options for ventas

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689406475fb0832b8b3399c57eec1ad1