### PR TITLE
Refactor corte de caja denominations

### DIFF
--- a/api/corte_caja/listar_denominaciones.php
+++ b/api/corte_caja/listar_denominaciones.php
@@ -1,0 +1,22 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+try {
+    $res = $conn->query('SELECT id, valor, descripcion FROM catalogo_denominaciones ORDER BY valor ASC');
+    if (!$res) {
+        error('Error al obtener denominaciones: ' . $conn->error);
+    }
+    $denoms = [];
+    while ($row = $res->fetch_assoc()) {
+        $denoms[] = [
+            'id' => (int)$row['id'],
+            'valor' => (float)$row['valor'],
+            'descripcion' => $row['descripcion']
+        ];
+    }
+    success($denoms);
+} catch (Throwable $e) {
+    error('Error al obtener denominaciones: ' . $e->getMessage());
+}
+?>

--- a/vistas/corte_caja/corte.php
+++ b/vistas/corte_caja/corte.php
@@ -1,14 +1,11 @@
 <?php
 require_once __DIR__ . '/../../utils/cargar_permisos.php';
-require_once __DIR__ . '/../../config/db.php';
 $path_actual = str_replace('/rest', '', $_SERVER['PHP_SELF']);
 if (!in_array($path_actual, $_SESSION['rutas_permitidas'])) {
     http_response_code(403);
     echo 'Acceso no autorizado';
     exit;
 }
-
-$denominaciones = $conn->query("SELECT id, descripcion, valor FROM catalogo_denominaciones ORDER BY valor ASC")->fetch_all(MYSQLI_ASSOC);
 
 $title = 'Corte de Caja';
 ob_start();
@@ -104,9 +101,6 @@ ob_start();
 
 </div>
 <?php require_once __DIR__ . '/../footer.php'; ?>
-<script>
-    const catalogoDenominaciones = <?php echo json_encode($denominaciones); ?>;
-</script>
 <script src="corte.js"></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- Load catalog denominations from new endpoint and remove hardcoded table usage.
- Replace the old dynamic table with grouped inputs per payment type, updating subtotals and totals.
- Expose API endpoint to fetch `catalogo_denominaciones` values.

## Testing
- `php -l api/corte_caja/listar_denominaciones.php`
- `php -l vistas/corte_caja/corte.php`
- `node --check vistas/corte_caja/corte.js`


------
https://chatgpt.com/codex/tasks/task_e_689411c40d74832ba18a4e5fc116d5a7