### PR TITLE
Registrar pagos no efectivos en desglose y mostrar en cortes

### DIFF
--- a/api/corte_caja/detalle_venta.php
+++ b/api/corte_caja/detalle_venta.php
@@ -36,11 +36,15 @@ if ($id <= 0) {
 
 try {
     // 1️⃣ Intentar obtener desglose de corte
-    $sqlDesglose = "SELECT dc.id, cd.descripcion, cd.valor, dc.cantidad, dc.tipo_pago,
+    $sqlDesglose = "SELECT dc.tipo_pago,
+                           cd.descripcion,
+                           dc.cantidad,
+                           cd.valor,
                            (cd.valor * dc.cantidad) AS subtotal
-                    FROM desglose_corte dc
+                    FROM corte_caja cc
+                    JOIN desglose_corte dc ON dc.corte_id = cc.id
                     JOIN catalogo_denominaciones cd ON cd.id = dc.denominacion_id
-                    WHERE dc.corte_id = ?";
+                    WHERE cc.id = ?";
     $stmt = $conn->prepare($sqlDesglose);
     $stmt->bind_param('i', $id);
     $stmt->execute();
@@ -50,11 +54,10 @@ try {
         $detalles = [];
         while ($row = $resDesglose->fetch_assoc()) {
             $detalles[] = [
-                'id' => (int)$row['id'],
-                'descripcion' => $row['descripcion'],
-                'valor' => (float)$row['valor'],
-                'cantidad' => (int)$row['cantidad'],
                 'tipo_pago' => $row['tipo_pago'],
+                'descripcion' => $row['descripcion'],
+                'cantidad' => (float)$row['cantidad'],
+                'valor' => (float)$row['valor'],
                 'subtotal' => round((float)$row['subtotal'], 2)
             ];
         }

--- a/vistas/corte_caja/corte.php
+++ b/vistas/corte_caja/corte.php
@@ -48,19 +48,7 @@ ob_start();
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <div class="modal-body" id="modalDetalleContenido">
-        <table id="tablaDetalleCorte" class="table table-bordered">
-          <thead>
-            <tr>
-              <th>Denominación</th>
-              <th>Cantidad</th>
-              <th>Tipo de pago</th>
-              <th>Subtotal</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </div>
+      <div class="modal-body" id="modalDetalleContenido"></div>
     </div>
   </div>
 </div>

--- a/vistas/reportes/reportes.php
+++ b/vistas/reportes/reportes.php
@@ -66,7 +66,7 @@ ob_start();
                 <th>Cheque</th>
                 <th>Fondo</th>
                 <th>Observaciones</th>
-                <th>Detalle</th>
+                <th>Desglose</th>
             </tr>
         </thead>
         <tbody>

--- a/vistas/ventas/ticket.php
+++ b/vistas/ventas/ticket.php
@@ -98,6 +98,7 @@ ob_start();
 <script>
     const catalogoTarjetas = <?php echo json_encode($tarjetas); ?>;
     const catalogoBancos = <?php echo json_encode($bancos); ?>;
+    const denominacionesUrl = '../../api/corte_caja/listar_denominaciones.php';
 </script>
 <script src="ticket.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Captura IDs de Pago Boucher y Pago Cheque y registra sus montos en `desglose_corte` al guardar tickets
- Permite guardar montos no efectivos en `guardar_desglose.php` y consulta desgloses con valor y subtotal por pago
- Muestra desgloses agrupados por tipo de pago en reportes y detalle de cortes

## Testing
- `php -l vistas/ventas/ticket.php`
- `php -l api/corte_caja/guardar_desglose.php`
- `php -l api/corte_caja/detalle_venta.php`
- `php -l vistas/reportes/reportes.php`
- `php -l vistas/corte_caja/corte.php`


------
https://chatgpt.com/codex/tasks/task_e_68941e48e040832b80138c47ffa672e2