### PR TITLE
Integrar catálogos de bancos y tarjetas

### DIFF
--- a/api/tickets/catalogos_tarjeta.php
+++ b/api/tickets/catalogos_tarjeta.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$bancos = [];
+$resBancos = $conn->query("SELECT id, nombre FROM catalogo_bancos ORDER BY nombre");
+if (!$resBancos) {
+    error('Error al obtener bancos: ' . $conn->error);
+}
+while ($row = $resBancos->fetch_assoc()) {
+    $bancos[] = [
+        'id' => (int)$row['id'],
+        'nombre' => $row['nombre']
+    ];
+}
+
+$tarjetas = [];
+$resTarjetas = $conn->query("SELECT id, nombre FROM catalogo_tarjetas ORDER BY nombre");
+if (!$resTarjetas) {
+    error('Error al obtener tarjetas: ' . $conn->error);
+}
+while ($row = $resTarjetas->fetch_assoc()) {
+    $tarjetas[] = [
+        'id' => (int)$row['id'],
+        'nombre' => $row['nombre']
+    ];
+}
+
+header('Content-Type: application/json');
+echo json_encode([
+    'success' => true,
+    'bancos' => $bancos,
+    'tarjetas' => $tarjetas
+]);

--- a/api/tickets/guardar_ticket.php
+++ b/api/tickets/guardar_ticket.php
@@ -109,7 +109,7 @@ $tipo_entrega     = $tipo_entrega     ?: 'N/A';
 
 $conn->begin_transaction();
 
-$insTicket  = $conn->prepare('INSERT INTO tickets (venta_id, folio, total, propina, usuario_id, tipo_pago, tipo_entrega, monto_recibido, tarjeta_marca_id, tarjeta_banco_id, boucher, cheque_numero, cheque_banco_id, mesa_nombre, mesero_nombre, fecha_inicio, fecha_fin, tiempo_servicio, nombre_negocio, direccion_negocio, rfc_negocio, telefono_negocio, sede_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+$insTicket  = $conn->prepare('INSERT INTO tickets (venta_id, folio, total, propina, usuario_id, tipo_pago, tipo_entrega, monto_recibido, tarjeta_id, banco_id, boucher, cheque_numero, mesa_nombre, mesero_nombre, fecha_inicio, fecha_fin, tiempo_servicio, nombre_negocio, direccion_negocio, rfc_negocio, telefono_negocio, sede_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
 $insDetalle = $conn->prepare('INSERT INTO ticket_detalles (ticket_id, producto_id, cantidad, precio_unitario) VALUES (?, ?, ?, ?)');
 if (!$insTicket || !$insDetalle) {
     $conn->rollback();
@@ -166,25 +166,25 @@ foreach ($subcuentas as $sub) {
         $conn->rollback();
         error('Tipo de pago o monto recibido faltante');
     }
-    $tarjeta_marca_id = $tarjeta_banco_id = $cheque_banco_id = null;
+    $tarjeta_id = $banco_id = null;
     $boucher = $cheque_numero = null;
     if ($tipo_pago === 'boucher') {
-        $tarjeta_marca_id = isset($sub['tarjeta_marca_id']) ? (int)$sub['tarjeta_marca_id'] : null;
-        $tarjeta_banco_id = isset($sub['tarjeta_banco_id']) ? (int)$sub['tarjeta_banco_id'] : null;
+        $tarjeta_id = isset($sub['tarjeta_id']) ? (int)$sub['tarjeta_id'] : null;
+        $banco_id = isset($sub['banco_id']) ? (int)$sub['banco_id'] : null;
         $boucher = $sub['boucher'] ?? null;
-        if (!$tarjeta_marca_id || !$tarjeta_banco_id || !$boucher) {
+        if (!$tarjeta_id || !$banco_id || !$boucher) {
             $conn->rollback();
             error('Datos de tarjeta incompletos');
         }
     } elseif ($tipo_pago === 'cheque') {
         $cheque_numero = $sub['cheque_numero'] ?? null;
-        $cheque_banco_id = isset($sub['cheque_banco_id']) ? (int)$sub['cheque_banco_id'] : null;
-        if (!$cheque_numero || !$cheque_banco_id) {
+        $banco_id = isset($sub['banco_id']) ? (int)$sub['banco_id'] : null;
+        if (!$cheque_numero || !$banco_id) {
             $conn->rollback();
             error('Datos de cheque incompletos');
         }
     }
-    $insTicket->bind_param('iiddissdiississssssissi', $venta_id, $folio_actual, $total, $propina, $usuario_id, $tipo_pago, $tipo_entrega, $monto_recibido, $tarjeta_marca_id, $tarjeta_banco_id, $boucher, $cheque_numero, $cheque_banco_id, $mesa_nombre, $mesero_nombre, $fecha_inicio, $fecha_fin, $tiempo_servicio, $nombre_negocio, $direccion_negocio, $rfc_negocio, $telefono_negocio, $sede_id);
+    $insTicket->bind_param('iiddissdiisssssssssssi', $venta_id, $folio_actual, $total, $propina, $usuario_id, $tipo_pago, $tipo_entrega, $monto_recibido, $tarjeta_id, $banco_id, $boucher, $cheque_numero, $mesa_nombre, $mesero_nombre, $fecha_inicio, $fecha_fin, $tiempo_servicio, $nombre_negocio, $direccion_negocio, $rfc_negocio, $telefono_negocio, $sede_id);
     if (!$insTicket->execute()) {
         $conn->rollback();
         error('Error al guardar ticket: ' . $insTicket->error);

--- a/api/tickets/reimprimir_ticket.php
+++ b/api/tickets/reimprimir_ticket.php
@@ -66,15 +66,14 @@ $stmt = $conn->prepare("SELECT t.id, t.folio, t.total, t.propina, t.fecha, t.ven
                                 t.tiempo_servicio, t.nombre_negocio, t.direccion_negocio,
                                 t.rfc_negocio, t.telefono_negocio, t.sede_id,
                                 t.tipo_pago, t.monto_recibido,
-                                t.tarjeta_marca_id, tm.descripcion AS tarjeta_marca,
-                                t.tarjeta_banco_id, cb.descripcion AS tarjeta_banco,
+                                t.tarjeta_id, ct.nombre AS tarjeta,
+                                t.banco_id, cb.nombre AS banco,
                                 t.boucher,
-                                t.cheque_numero, t.cheque_banco_id, cb2.descripcion AS cheque_banco,
+                                t.cheque_numero,
                                 v.tipo_entrega
                          FROM tickets t
-                         LEFT JOIN catalogo_tarjetas tm ON t.tarjeta_marca_id = tm.id
-                         LEFT JOIN catalogo_bancos cb ON t.tarjeta_banco_id = cb.id
-                         LEFT JOIN catalogo_bancos cb2 ON t.cheque_banco_id = cb2.id
+                         LEFT JOIN catalogo_tarjetas ct ON t.tarjeta_id = ct.id
+                         LEFT JOIN catalogo_bancos cb ON t.banco_id = cb.id
                          LEFT JOIN ventas v ON t.venta_id = v.id
                          WHERE $cond");
 if (!$stmt) {
@@ -139,20 +138,10 @@ while ($t = $res->fetch_assoc()) {
           'rfc_negocio'      => $rfc_negocio,
           'telefono_negocio' => $telefono_negocio,
           'tipo_pago'        => $tipo_pago,
-          'tarjeta_marca'    => $t['tarjeta_marca'] ?? null,
-          'tarjeta_banco'    => $t['tarjeta_banco'] ?? null,
+          'tarjeta'          => $t['tarjeta'] ?? null,
+          'banco'            => $t['banco'] ?? null,
           'boucher'          => $t['boucher'] ?? null,
           'cheque_numero'    => $t['cheque_numero'] ?? null,
-          'cheque_banco'     => $t['cheque_banco'] ?? null,
-          'tarjeta'          => [
-              'marca'   => $t['tarjeta_marca'] ?? null,
-              'banco'   => $t['tarjeta_banco'] ?? null,
-              'boucher' => $t['boucher'] ?? null
-          ],
-          'cheque'           => [
-              'numero' => $t['cheque_numero'] ?? null,
-              'banco'  => $t['cheque_banco'] ?? null
-          ],
           'tipo_entrega'     => $tipo_entrega,
           'cambio'           => (float)$cambio,
           'total_letras'     => numeroALetras($t['total']),

--- a/vistas/ventas/ticket.php
+++ b/vistas/ventas/ticket.php
@@ -8,12 +8,6 @@ if (!in_array($path_actual, $_SESSION['rutas_permitidas'])) {
     exit;
 }
 
-// Catálogos para datos de pago
-$tarjetas = $conn->query("SELECT id, nombre FROM catalogo_tarjetas ORDER BY nombre")
-    ?->fetch_all(MYSQLI_ASSOC) ?? [];
-$bancos = $conn->query("SELECT id, nombre FROM catalogo_bancos ORDER BY nombre")
-    ?->fetch_all(MYSQLI_ASSOC) ?? [];
-
 $title = 'Ticket';
 ob_start();
 ?>
@@ -96,8 +90,7 @@ ob_start();
 
 <?php require_once __DIR__ . '/../footer.php'; ?>
 <script>
-    const catalogoTarjetas = <?php echo json_encode($tarjetas); ?>;
-    const catalogoBancos = <?php echo json_encode($bancos); ?>;
+    const catalogosUrl = '../../api/tickets/catalogos_tarjeta.php';
     const denominacionesUrl = '../../api/corte_caja/listar_denominaciones.php';
 </script>
 <script src="ticket.js"></script>


### PR DESCRIPTION
## Summary
- Agrega endpoint para obtener catálogos de bancos y tarjetas
- Carga catálogos en la pantalla de tickets y valida datos de pago
- Guarda `banco_id` y `tarjeta_id` al generar y reimprimir tickets

## Testing
- `php -l api/tickets/catalogos_tarjeta.php`
- `php -l api/tickets/guardar_ticket.php`
- `php -l api/tickets/reimprimir_ticket.php`
- `php -l vistas/ventas/ticket.php`
- `node --check vistas/ventas/ticket.js && echo 'js ok'`


------
https://chatgpt.com/codex/tasks/task_e_68942d1aeaa4832b8a8faa4b5693d450