### PR TITLE
Corrige campos de tarjeta y cheque en tickets

### DIFF
--- a/api/tickets/guardar_ticket.php
+++ b/api/tickets/guardar_ticket.php
@@ -109,7 +109,7 @@ $tipo_entrega     = $tipo_entrega     ?: 'N/A';
 
 $conn->begin_transaction();
 
-$insTicket  = $conn->prepare('INSERT INTO tickets (venta_id, folio, total, propina, usuario_id, tipo_pago, tipo_entrega, monto_recibido, tarjeta_id, banco_id, boucher, cheque_numero, mesa_nombre, mesero_nombre, fecha_inicio, fecha_fin, tiempo_servicio, nombre_negocio, direccion_negocio, rfc_negocio, telefono_negocio, sede_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+$insTicket  = $conn->prepare('INSERT INTO tickets (venta_id, folio, total, propina, usuario_id, tipo_pago, tipo_entrega, monto_recibido, tarjeta_marca_id, tarjeta_banco_id, boucher, cheque_banco_id, cheque_numero, mesa_nombre, mesero_nombre, fecha_inicio, fecha_fin, tiempo_servicio, nombre_negocio, direccion_negocio, rfc_negocio, telefono_negocio, sede_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
 $insDetalle = $conn->prepare('INSERT INTO ticket_detalles (ticket_id, producto_id, cantidad, precio_unitario) VALUES (?, ?, ?, ?)');
 if (!$insTicket || !$insDetalle) {
     $conn->rollback();
@@ -166,25 +166,26 @@ foreach ($subcuentas as $sub) {
         $conn->rollback();
         error('Tipo de pago o monto recibido faltante');
     }
-    $tarjeta_id = $banco_id = null;
+    $tarjeta_marca_id = $tarjeta_banco_id = null;
+    $cheque_banco_id = null;
     $boucher = $cheque_numero = null;
     if ($tipo_pago === 'boucher') {
-        $tarjeta_id = isset($sub['tarjeta_id']) ? (int)$sub['tarjeta_id'] : null;
-        $banco_id = isset($sub['banco_id']) ? (int)$sub['banco_id'] : null;
+        $tarjeta_marca_id = isset($sub['tarjeta_marca_id']) ? (int)$sub['tarjeta_marca_id'] : null;
+        $tarjeta_banco_id = isset($sub['tarjeta_banco_id']) ? (int)$sub['tarjeta_banco_id'] : null;
         $boucher = $sub['boucher'] ?? null;
-        if (!$tarjeta_id || !$banco_id || !$boucher) {
+        if (!$tarjeta_marca_id || !$tarjeta_banco_id || !$boucher) {
             $conn->rollback();
             error('Datos de tarjeta incompletos');
         }
     } elseif ($tipo_pago === 'cheque') {
         $cheque_numero = $sub['cheque_numero'] ?? null;
-        $banco_id = isset($sub['banco_id']) ? (int)$sub['banco_id'] : null;
-        if (!$cheque_numero || !$banco_id) {
+        $cheque_banco_id = isset($sub['cheque_banco_id']) ? (int)$sub['cheque_banco_id'] : null;
+        if (!$cheque_numero || !$cheque_banco_id) {
             $conn->rollback();
             error('Datos de cheque incompletos');
         }
     }
-    $insTicket->bind_param('iiddissdiisssssssssssi', $venta_id, $folio_actual, $total, $propina, $usuario_id, $tipo_pago, $tipo_entrega, $monto_recibido, $tarjeta_id, $banco_id, $boucher, $cheque_numero, $mesa_nombre, $mesero_nombre, $fecha_inicio, $fecha_fin, $tiempo_servicio, $nombre_negocio, $direccion_negocio, $rfc_negocio, $telefono_negocio, $sede_id);
+    $insTicket->bind_param('iiddissdiisisssssissssi', $venta_id, $folio_actual, $total, $propina, $usuario_id, $tipo_pago, $tipo_entrega, $monto_recibido, $tarjeta_marca_id, $tarjeta_banco_id, $boucher, $cheque_banco_id, $cheque_numero, $mesa_nombre, $mesero_nombre, $fecha_inicio, $fecha_fin, $tiempo_servicio, $nombre_negocio, $direccion_negocio, $rfc_negocio, $telefono_negocio, $sede_id);
     if (!$insTicket->execute()) {
         $conn->rollback();
         error('Error al guardar ticket: ' . $insTicket->error);

--- a/api/tickets/reimprimir_ticket.php
+++ b/api/tickets/reimprimir_ticket.php
@@ -66,14 +66,16 @@ $stmt = $conn->prepare("SELECT t.id, t.folio, t.total, t.propina, t.fecha, t.ven
                                 t.tiempo_servicio, t.nombre_negocio, t.direccion_negocio,
                                 t.rfc_negocio, t.telefono_negocio, t.sede_id,
                                 t.tipo_pago, t.monto_recibido,
-                                t.tarjeta_id, ct.nombre AS tarjeta,
-                                t.banco_id, cb.nombre AS banco,
+                                tm.nombre AS tarjeta,
+                                b1.nombre AS banco_tarjeta,
                                 t.boucher,
+                                b2.nombre AS banco_cheque,
                                 t.cheque_numero,
                                 v.tipo_entrega
                          FROM tickets t
-                         LEFT JOIN catalogo_tarjetas ct ON t.tarjeta_id = ct.id
-                         LEFT JOIN catalogo_bancos cb ON t.banco_id = cb.id
+                         LEFT JOIN catalogo_tarjetas tm ON tm.id = t.tarjeta_marca_id
+                         LEFT JOIN catalogo_bancos b1 ON b1.id = t.tarjeta_banco_id
+                         LEFT JOIN catalogo_bancos b2 ON b2.id = t.cheque_banco_id
                          LEFT JOIN ventas v ON t.venta_id = v.id
                          WHERE $cond");
 if (!$stmt) {
@@ -139,8 +141,9 @@ while ($t = $res->fetch_assoc()) {
           'telefono_negocio' => $telefono_negocio,
           'tipo_pago'        => $tipo_pago,
           'tarjeta'          => $t['tarjeta'] ?? null,
-          'banco'            => $t['banco'] ?? null,
+          'banco_tarjeta'    => $t['banco_tarjeta'] ?? null,
           'boucher'          => $t['boucher'] ?? null,
+          'banco_cheque'     => $t['banco_cheque'] ?? null,
           'cheque_numero'    => $t['cheque_numero'] ?? null,
           'tipo_entrega'     => $tipo_entrega,
           'cambio'           => (float)$cambio,

--- a/vistas/ventas/ticket.js
+++ b/vistas/ventas/ticket.js
@@ -21,12 +21,12 @@ function llenarTicket(data) {
         if (data.tipo_pago === 'boucher' && tInfo) {
             tInfo.style.display = 'block';
             document.getElementById('tarjetaMarca').textContent = data.tarjeta || 'No definido';
-            document.getElementById('tarjetaBanco').textContent = data.banco || 'No definido';
+            document.getElementById('tarjetaBanco').textContent = data.banco_tarjeta || 'No definido';
             document.getElementById('tarjetaBoucher').textContent = data.boucher || 'No definido';
         } else if (data.tipo_pago === 'cheque' && cInfo) {
             cInfo.style.display = 'block';
             document.getElementById('chequeNumero').textContent = data.cheque_numero || 'No definido';
-            document.getElementById('chequeBanco').textContent = data.banco || 'No definido';
+            document.getElementById('chequeBanco').textContent = data.banco_cheque || 'No definido';
         }
         document.getElementById('horaInicio').textContent = (data.fecha_inicio && data.fecha_inicio !== 'N/A') ? new Date(data.fecha_inicio).toLocaleString() : (data.fecha_inicio || 'N/A');
         document.getElementById('horaFin').textContent = (data.fecha_fin && data.fecha_fin !== 'N/A') ? new Date(data.fecha_fin).toLocaleString() : (data.fecha_fin || 'N/A');
@@ -356,17 +356,17 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
             const extra = {};
             if (tipo === 'boucher') {
-                extra.tarjeta_id = parseInt(document.getElementById('tarjetaMarca' + i).value) || null;
-                extra.banco_id = parseInt(document.getElementById('tarjetaBanco' + i).value) || null;
+                extra.tarjeta_marca_id = parseInt(document.getElementById('tarjetaMarca' + i).value) || null;
+                extra.tarjeta_banco_id = parseInt(document.getElementById('tarjetaBanco' + i).value) || null;
                 extra.boucher = document.getElementById('boucher' + i).value || '';
-                if (!extra.tarjeta_id || !extra.banco_id || !extra.boucher) {
+                if (!extra.tarjeta_marca_id || !extra.tarjeta_banco_id || !extra.boucher) {
                     alert('Completa datos de tarjeta en subcuenta ' + i);
                     return;
                 }
             } else if (tipo === 'cheque') {
                 extra.cheque_numero = document.getElementById('chequeNumero' + i).value || '';
-                extra.banco_id = parseInt(document.getElementById('chequeBanco' + i).value) || null;
-                if (!extra.cheque_numero || !extra.banco_id) {
+                extra.cheque_banco_id = parseInt(document.getElementById('chequeBanco' + i).value) || null;
+                if (!extra.cheque_numero || !extra.cheque_banco_id) {
                     alert('Completa datos de cheque en subcuenta ' + i);
                     return;
                 }


### PR DESCRIPTION
## Summary
- Ajusta guardado de tickets para usar `tarjeta_marca_id`, `tarjeta_banco_id` y `cheque_banco_id`
- En el frontend, envía y muestra correctamente la marca y banco de tarjeta y cheque
- Reimprime tickets con nombres descriptivos de bancos y tarjetas

## Testing
- `php -l api/tickets/guardar_ticket.php`
- `php -l api/tickets/reimprimir_ticket.php`
- `node --check vistas/ventas/ticket.js`


------
https://chatgpt.com/codex/tasks/task_e_689430f1d404832b87d153767717788a