### PR TITLE
feat: add sales pagination and filters

### DIFF
--- a/api/ventas/listar_ventas.php
+++ b/api/ventas/listar_ventas.php
@@ -2,20 +2,47 @@
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
+$limite = isset($_GET['limite']) ? max(1, intval($_GET['limite'])) : 15;
+$pagina = isset($_GET['pagina']) ? max(1, intval($_GET['pagina'])) : 1;
+$orden = $_GET['orden'] ?? 'fecha DESC';
+$orden = trim($orden);
+if ($orden !== 'fecha ASC' && $orden !== 'fecha DESC') {
+    $orden = 'fecha DESC';
+}
+$offset = ($pagina - 1) * $limite;
+
+$countQuery = "SELECT COUNT(*) AS total FROM vw_ventas_detalladas vw JOIN ventas v ON v.id = vw.venta_id";
+$countResult = $conn->query($countQuery);
+if (!$countResult) {
+    error('Error al contar ventas: ' . $conn->error);
+}
+$totalRegistros = (int)$countResult->fetch_assoc()['total'];
+$totalPaginas = (int)ceil($totalRegistros / $limite);
+
 $query = "SELECT vw.*, v.tipo_entrega, v.usuario_id, v.entregado, v.sede_id
           FROM vw_ventas_detalladas vw
           JOIN ventas v ON v.id = vw.venta_id
-          ORDER BY vw.fecha DESC"; // Lógica reemplazada por base de datos: ver bd.sql (Vista)
-$result = $conn->query($query);
-
-if (!$result) {
-    error('Error al obtener ventas: ' . $conn->error);
+          ORDER BY $orden
+          LIMIT ? OFFSET ?";
+$stmt = $conn->prepare($query);
+if (!$stmt) {
+    error('Error al preparar consulta: ' . $conn->error);
 }
+$stmt->bind_param('ii', $limite, $offset);
+$stmt->execute();
+$result = $stmt->get_result();
 
 $ventas = [];
 while ($row = $result->fetch_assoc()) {
     $ventas[] = $row;
 }
 
-success($ventas);
+$data = [
+    'ventas' => $ventas,
+    'total_registros' => $totalRegistros,
+    'pagina_actual' => $pagina,
+    'total_paginas' => $totalPaginas
+];
+
+success($data);
 ?>

--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -104,6 +104,14 @@ ob_start();
 
 <div class="container mt-5">
   <h2 class="section-header">Historial de Ventas</h2>
+  <div class="mb-2 d-flex justify-content-end">
+    <label for="recordsPerPage" class="me-2">Registros por página:</label>
+    <select id="recordsPerPage" class="form-select w-auto">
+      <option value="15">15</option>
+      <option value="25">25</option>
+      <option value="50">50</option>
+    </select>
+  </div>
   <div class="table-responsive">
     <table id="historial" class="table">
       <thead>
@@ -124,6 +132,7 @@ ob_start();
       </tbody>
     </table>
   </div>
+  <div id="paginacion" class="mt-2"></div>
 </div>
 
 


### PR DESCRIPTION
## Summary
- add limit, page and order params to sales API with paginated response
- render sales table with page size selector and numeric pagination
- highlight today's sales rows and reload on selector changes

## Testing
- `php -l api/ventas/listar_ventas.php`
- `php -l vistas/ventas/ventas.php`
- `node --check vistas/ventas/ventas.js`
- `php api/ventas/listar_ventas.php | head` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894ab860950832bb45f18bad862992b