### PR TITLE
Add real-time sales search

### DIFF
--- a/api/ventas/listar_ventas.php
+++ b/api/ventas/listar_ventas.php
@@ -5,30 +5,52 @@ require_once __DIR__ . '/../../utils/response.php';
 $limite = isset($_GET['limite']) ? max(1, intval($_GET['limite'])) : 15;
 $pagina = isset($_GET['pagina']) ? max(1, intval($_GET['pagina'])) : 1;
 $orden = $_GET['orden'] ?? 'fecha DESC';
+$busqueda = isset($_GET['busqueda']) ? trim($_GET['busqueda']) : '';
 $orden = trim($orden);
 if ($orden !== 'fecha ASC' && $orden !== 'fecha DESC') {
     $orden = 'fecha DESC';
 }
 $offset = ($pagina - 1) * $limite;
 
-$countQuery = "SELECT COUNT(*) AS total FROM vw_ventas_detalladas vw JOIN ventas v ON v.id = vw.venta_id";
-$countResult = $conn->query($countQuery);
+$baseFrom = "FROM vw_ventas_detalladas vw JOIN ventas v ON v.id = vw.venta_id LEFT JOIN tickets t ON t.venta_id = v.id";
+$where = '';
+$params = [];
+$types = '';
+if ($busqueda !== '') {
+    $like = "%{$busqueda}%";
+    $where = " WHERE t.folio LIKE ? OR t.mesa_nombre LIKE ? OR t.mesero_nombre LIKE ? OR t.tipo_pago LIKE ? OR DATE(t.fecha) LIKE ?";
+    $params = [$like, $like, $like, $like, $like];
+    $types = str_repeat('s', 5);
+}
+
+$countSql = "SELECT COUNT(*) AS total $baseFrom$where";
+$countStmt = $conn->prepare($countSql);
+if ($busqueda !== '') {
+    $countStmt->bind_param($types, ...$params);
+}
+$countStmt->execute();
+$countResult = $countStmt->get_result();
 if (!$countResult) {
     error('Error al contar ventas: ' . $conn->error);
 }
 $totalRegistros = (int)$countResult->fetch_assoc()['total'];
 $totalPaginas = (int)ceil($totalRegistros / $limite);
 
-$query = "SELECT vw.*, v.tipo_entrega, v.usuario_id, v.entregado, v.sede_id
-          FROM vw_ventas_detalladas vw
-          JOIN ventas v ON v.id = vw.venta_id
+$query = "SELECT vw.*, v.tipo_entrega, v.usuario_id, v.entregado, v.sede_id, t.folio, t.mesa_nombre, t.mesero_nombre, t.tipo_pago, t.fecha as ticket_fecha
+          $baseFrom$where
           ORDER BY $orden
-          LIMIT ? OFFSET ?";
+          LIMIT ? OFFSET ?"; 
 $stmt = $conn->prepare($query);
 if (!$stmt) {
     error('Error al preparar consulta: ' . $conn->error);
 }
-$stmt->bind_param('ii', $limite, $offset);
+if ($busqueda !== '') {
+    $typesMain = $types . 'ii';
+    $paramsMain = array_merge($params, [$limite, $offset]);
+    $stmt->bind_param($typesMain, ...$paramsMain);
+} else {
+    $stmt->bind_param('ii', $limite, $offset);
+}
 $stmt->execute();
 $result = $stmt->get_result();
 

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -7,11 +7,14 @@ if (Array.isArray(window.catalogoDenominaciones) && catalogoDenominaciones.lengt
 let currentPage = 1;
 let limit = 15;
 const order = 'fecha DESC';
+let searchQuery = '';
 
 async function cargarHistorial(page = currentPage) {
     currentPage = page;
     try {
-        const resp = await fetch(`../../api/ventas/listar_ventas.php?pagina=${currentPage}&limite=${limit}&orden=${encodeURIComponent(order)}`);
+        const resp = await fetch(
+            `../../api/ventas/listar_ventas.php?pagina=${currentPage}&limite=${limit}&orden=${encodeURIComponent(order)}&busqueda=${encodeURIComponent(searchQuery)}`
+        );
         const data = await resp.json();
         if (data.success) {
             const tbody = document.querySelector('#historial tbody');
@@ -968,6 +971,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById('recordsPerPage').addEventListener('change', e => {
         limit = parseInt(e.target.value);
+        cargarHistorial(1);
+    });
+
+    document.getElementById('buscadorVentas').addEventListener('input', e => {
+        searchQuery = e.target.value;
         cargarHistorial(1);
     });
 

--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -104,13 +104,16 @@ ob_start();
 
 <div class="container mt-5">
   <h2 class="section-header">Historial de Ventas</h2>
-  <div class="mb-2 d-flex justify-content-end">
-    <label for="recordsPerPage" class="me-2">Registros por página:</label>
-    <select id="recordsPerPage" class="form-select w-auto">
-      <option value="15">15</option>
-      <option value="25">25</option>
-      <option value="50">50</option>
-    </select>
+  <div class="mb-2 d-flex justify-content-between">
+    <input type="search" id="buscadorVentas" class="form-control w-50" placeholder="Buscar...">
+    <div class="d-flex align-items-center">
+      <label for="recordsPerPage" class="me-2">Registros por página:</label>
+      <select id="recordsPerPage" class="form-select w-auto">
+        <option value="15">15</option>
+        <option value="25">25</option>
+        <option value="50">50</option>
+      </select>
+    </div>
   </div>
   <div class="table-responsive">
     <table id="historial" class="table">


### PR DESCRIPTION
## Summary
- Add search box to sales history page for live filtering
- Send search term from frontend and reload sales list
- Filter backend query by folio, mesa, mesero, tipo de pago and date

## Testing
- `php -l api/ventas/listar_ventas.php`
- `php -l vistas/ventas/ventas.php`
- `node --check vistas/ventas/ventas.js`


------
https://chatgpt.com/codex/tasks/task_e_6894af671814832ba0b6c18672b83ec8