### PR TITLE
feat: add global search for ventas

### DIFF
--- a/api/ventas/listar_ventas.php
+++ b/api/ventas/listar_ventas.php
@@ -18,9 +18,9 @@ $params = [];
 $types = '';
 if ($busqueda !== '') {
     $like = "%{$busqueda}%";
-    $where = " WHERE t.folio LIKE ? OR t.mesa_nombre LIKE ? OR t.mesero_nombre LIKE ? OR t.tipo_pago LIKE ? OR DATE(t.fecha) LIKE ?";
-    $params = [$like, $like, $like, $like, $like];
-    $types = str_repeat('s', 5);
+    $where = " WHERE CONCAT_WS(' ', v.id, t.folio, v.fecha, v.total, v.estatus, v.tipo_entrega, t.tipo_pago, vw.usuario, t.mesa_nombre, t.mesero_nombre) LIKE ?";
+    $params = [$like];
+    $types = 's';
 }
 
 $countSql = "SELECT COUNT(*) AS total $baseFrom$where";

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -975,7 +975,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.getElementById('buscadorVentas').addEventListener('input', e => {
-        searchQuery = e.target.value;
+        searchQuery = e.target.value.trim();
         cargarHistorial(1);
     });
 


### PR DESCRIPTION
## Summary
- implement global search across sales columns using CONCAT_WS
- trim search input and trigger reload on change

## Testing
- `php -l api/ventas/listar_ventas.php`
- `node --check vistas/ventas/ventas.js && echo 'JS OK'`


------
https://chatgpt.com/codex/tasks/task_e_6894b4d0e164832bbb79c417cb6c5330