### PR TITLE
Handle voucher and cheque payments in cuts and listings

### DIFF
--- a/vistas/corte_caja/corte.js
+++ b/vistas/corte_caja/corte.js
@@ -412,7 +412,10 @@ document.addEventListener('DOMContentLoaded', () => {
                     html += `<h5>${tp}</h5><table class="table table-bordered"><thead><tr><th>Descripción</th><th>Cantidad</th><th>Valor</th><th>Subtotal</th></tr></thead><tbody>`;
                     arr.forEach(r => {
                         total += r.subtotal;
-                        html += `<tr><td>${r.descripcion}</td><td>${r.cantidad}</td><td>${r.valor}</td><td>${r.subtotal}</td></tr>`;
+                        const desc = r.denominacion_id === 12 ? 'Pago Boucher'
+                                     : r.denominacion_id === 13 ? 'Pago Cheque'
+                                     : r.descripcion;
+                        html += `<tr><td>${desc}</td><td>${r.cantidad}</td><td>${r.valor}</td><td>${r.subtotal}</td></tr>`;
                     });
                     html += `<tr><td colspan="3"><strong>Total</strong></td><td><strong>${total.toFixed(2)}</strong></td></tr>`;
                     html += '</tbody></table>';

--- a/vistas/corte_caja/corte.php
+++ b/vistas/corte_caja/corte.php
@@ -48,7 +48,7 @@ ob_start();
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <div class="modal-body" id="modalDetalleContenido"></div>
+      <div class="modal-body" id="modalDetalleContenido"><!-- Se llena dinámicamente con detalles de efectivo, boucher y cheque --></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Validate corte_id and record voucher/cheque payments in `desglose_corte` when saving tickets
- Skip invalid denomination rows and label voucher/cheque entries in corte details
- Group sales by `venta_id` to consolidate totals when listing ventas and show payment descriptions in corte view

## Testing
- `php -l api/tickets/guardar_ticket.php`
- `php -l api/corte_caja/detalle_venta.php`
- `php -l api/ventas/listar_ventas.php`
- `php -l vistas/corte_caja/corte.php`
- `node --check vistas/corte_caja/corte.js`


------
https://chatgpt.com/codex/tasks/task_e_6894d1ff7b28832b869f06cf10d891f9