### PR TITLE
Add date range filter for corte reports

### DIFF
--- a/api/corte_caja/listar_cortes.php
+++ b/api/corte_caja/listar_cortes.php
@@ -3,8 +3,10 @@ require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
 $usuario_id = null;
-$inicio = null;
-$fin = null;
+$inicio = null; // deprecated
+$fin = null;    // deprecated
+$fecha_inicio = $_REQUEST['fecha_inicio'] ?? null;
+$fecha_fin = $_REQUEST['fecha_fin'] ?? null;
 $limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 15;
 $offset = isset($_GET['offset']) ? (int)$_GET['offset'] : 0;
 $search = isset($_GET['search']) ? trim($_GET['search']) : '';
@@ -27,14 +29,21 @@ if ($usuario_id) {
     $params[] = $usuario_id;
     $types .= 'i';
 }
-if ($inicio) {
-    $conditions[] = 'cc.fecha_inicio >= ?';
-    $params[] = $inicio;
+// Compatibilidad con parámetros antiguos
+if (!$fecha_inicio && $inicio) {
+    $fecha_inicio = $inicio;
+}
+if (!$fecha_fin && $fin) {
+    $fecha_fin = $fin;
+}
+if ($fecha_inicio) {
+    $conditions[] = 'DATE(v.fecha_inicio) >= ?';
+    $params[] = $fecha_inicio;
     $types .= 's';
 }
-if ($fin) {
-    $conditions[] = 'cc.fecha_inicio <= ?';
-    $params[] = $fin;
+if ($fecha_fin) {
+    $conditions[] = 'DATE(v.fecha_fin) <= ?';
+    $params[] = $fecha_fin;
     $types .= 's';
 }
 $searchParams = [];

--- a/vistas/corte_caja/corte.php
+++ b/vistas/corte_caja/corte.php
@@ -54,6 +54,13 @@ ob_start();
 </div>
 
 <h2 class="section-header">Historial de Cortes</h2>
+<div class="mb-2">
+  <label for="fechaInicio">Inicio:</label>
+  <input type="date" id="fechaInicio" class="form-control form-control-sm d-inline-block">
+  <label for="fechaFin" class="ml-2">Fin:</label>
+  <input type="date" id="fechaFin" class="form-control form-control-sm d-inline-block">
+  <button id="btnFiltrar" class="btn custom-btn-sm ml-2">Filtrar</button>
+</div>
 <div class="d-flex justify-content-between mb-2">
   <div>
     <label for="selectRegistros">Mostrar</label>
@@ -73,10 +80,15 @@ ob_start();
     <thead>
       <tr>
         <th style="color:#fff">ID</th>
-        <th style="color:#fff">Cajero</th>
         <th style="color:#fff">Fecha inicio</th>
         <th style="color:#fff">Fecha fin</th>
+        <th style="color:#fff">Usuario</th>
+        <th style="color:#fff">Efectivo</th>
+        <th style="color:#fff">Boucher</th>
+        <th style="color:#fff">Cheque</th>
+        <th style="color:#fff">Fondo inicial</th>
         <th style="color:#fff">Total</th>
+        <th style="color:#fff">Observaciones</th>
         <th style="color:#fff">Detalle</th>
       </tr>
     </thead>


### PR DESCRIPTION
## Summary
- display all corte fields in history table with currency formatting
- support filtering cortes by date range
- add date range inputs and filter button in corte history

## Testing
- `node --check vistas/corte_caja/corte.js`
- `php -l api/corte_caja/listar_cortes.php`
- `php -l vistas/corte_caja/corte.php`


------
https://chatgpt.com/codex/tasks/task_e_6894dc69e8e0832b90f99193f28f23a4