### PR TITLE
feat: guardar ticket e imprimir en un solo paso

### DIFF
--- a/vistas/ventas/ticket.php
+++ b/vistas/ventas/ticket.php
@@ -43,7 +43,7 @@ ob_start();
         </table>
     </div>
     <button id="agregarSub" class="btn custom-btn">Agregar subcuenta</button>
-    <button id="guardarSub" class="btn custom-btn">Guardar Tickets</button>
+    <button id="btnGuardarTicket" class="btn custom-btn">Guardar e imprimir Tickets</button>
     <div id="subcuentas"></div>
     <div id="teclado" class="mt-3"></div>
 </div>


### PR DESCRIPTION
## Summary
- Combina el guardado e impresión de tickets en un solo botón
- Genera e imprime todos los tickets de una venta usando un Blob y sin redirecciones

## Testing
- `php -l vistas/ventas/ticket.php`
- `node --check vistas/ventas/ticket.js`


------
https://chatgpt.com/codex/tasks/task_e_68960aa150dc832b8c1b9024625d4c85