### PR TITLE
feat: export corte summary to csv

### DIFF
--- a/api/corte_caja/exportar_corte_csv.php
+++ b/api/corte_caja/exportar_corte_csv.php
@@ -1,36 +1,81 @@
 <?php
+session_start();
 require_once __DIR__ . '/../../config/db.php';
 
-$corte_id = null;
-if (isset($_GET['corte_id'])) {
-    $corte_id = (int)$_GET['corte_id'];
-} elseif (isset($_GET['id'])) {
-    $corte_id = (int)$_GET['id'];
-}
+// Obtener corte_id desde GET o sesión, como en resumen_corte_actual.php
+$corte_id = isset($_GET['corte_id']) ? (int)$_GET['corte_id'] : ($_SESSION['corte_id'] ?? null);
 if (!$corte_id) {
     die('corte_id requerido');
 }
 
-$query = $conn->prepare('SELECT v.id, v.fecha, SUM(t.total) AS total, u.nombre AS usuario, SUM(t.propina) AS propina
-                         FROM ventas v
-                         LEFT JOIN tickets t ON t.venta_id = v.id
-                         JOIN usuarios u ON v.usuario_id = u.id
-                         WHERE v.corte_id = ?
-                         GROUP BY v.id
-                         ORDER BY v.fecha');
-if (!$query) {
-    die('Error');
-}
-$query->bind_param('i', $corte_id);
-$query->execute();
-$res = $query->get_result();
+// Consulta idéntica a resumen_corte_actual.php
+$sql = "SELECT
+    t.tipo_pago,
+    SUM(t.total)   AS total,
+    SUM(t.propina) AS propina
+FROM ventas v
+JOIN tickets t ON t.venta_id = v.id
+WHERE v.estatus = 'cerrada'
+  AND v.corte_id = ?
+GROUP BY t.tipo_pago";
 
-header('Content-Type: text/csv');
-header('Content-Disposition: attachment; filename="corte_' . $corte_id . '.csv"');
+$stmt = $conn->prepare($sql);
+$stmt->bind_param('i', $corte_id);
+$stmt->execute();
+$res = $stmt->get_result();
 
-echo "ID,Fecha,Total,Usuario,Propina\n";
+$totalProductos = 0;
+$totalPropinas  = 0;
+$rows = [];
 while ($row = $res->fetch_assoc()) {
-    echo $row['id'] . ',' . $row['fecha'] . ',' . $row['total'] . ',' . $row['usuario'] . ',' . $row['propina'] . "\n";
+    $total   = (float)$row['total'];
+    $propina = (float)$row['propina'];
+    $productos = $total - $propina;
+    $rows[] = [
+        'tipo_pago'        => $row['tipo_pago'],
+        'productos'        => $productos,
+        'propina'          => $propina,
+        'total_con_propina'=> $total
+    ];
+    $totalProductos += $productos;
+    $totalPropinas  += $propina;
 }
-$query->close();
+$stmt->close();
+
+// Fondo inicial y total final
+$stmtFondo = $conn->prepare('SELECT fondo_inicial FROM corte_caja WHERE id = ?');
+$stmtFondo->bind_param('i', $corte_id);
+$stmtFondo->execute();
+$rowFondo = $stmtFondo->get_result()->fetch_assoc();
+$fondo = (float)($rowFondo['fondo_inicial'] ?? 0);
+$stmtFondo->close();
+
+$totalEsperado = $totalProductos + $totalPropinas;
+$totalFinal    = $totalEsperado + $fondo;
+
+// Configuración de encabezados para descarga CSV con BOM UTF-8
+header('Content-Type: text/csv; charset=utf-8');
+header('Content-Disposition: attachment; filename="corte_' . $corte_id . '.csv"');
+echo "\xEF\xBB\xBF"; // BOM
+
+// Encabezados
+echo "tipo_pago,total_productos,total_propina,total_con_propina\n";
+
+// Filas de datos
+foreach ($rows as $r) {
+    echo $r['tipo_pago'] . ','
+       . number_format($r['productos'], 2, '.', '') . ','
+       . number_format($r['propina'], 2, '.', '') . ','
+       . number_format($r['total_con_propina'], 2, '.', '') . "\n";
+}
+
+// Totales
+echo 'TOTAL,'
+   . number_format($totalProductos, 2, '.', '') . ','
+   . number_format($totalPropinas, 2, '.', '') . ','
+   . number_format($totalEsperado, 2, '.', '') . "\n";
+
+echo 'FONDO,,,'. number_format($fondo, 2, '.', '') . "\n";
+
+echo 'TOTAL_FINAL,,,'. number_format($totalFinal, 2, '.', '') . "\n";
 ?>

--- a/vistas/corte_caja/corte.js
+++ b/vistas/corte_caja/corte.js
@@ -494,6 +494,6 @@ document.addEventListener('DOMContentLoaded', () => {
     // Exportar corte
     $(document).on('click', '.exportarCsv', function () {
         const corteId = $(this).data('id');
-        window.open('../../api/corte_caja/exportar_corte_csv.php?id=' + corteId, '_blank');
+        window.open('../../api/corte_caja/exportar_corte_csv.php?corte_id=' + corteId, '_blank');
     });
 });


### PR DESCRIPTION
## Summary
- export corte summary to CSV mirroring resumen_corte_actual query
- update corte.js to send corte_id when exporting

## Testing
- `php -l api/corte_caja/exportar_corte_csv.php`
- `node --check vistas/corte_caja/corte.js`


------
https://chatgpt.com/codex/tasks/task_e_6896298ae5c8832b843e3bf3f2e6a483