### PR TITLE
feat: add dynamic database views report

### DIFF
--- a/apis/reportes/vistas_db.php
+++ b/apis/reportes/vistas_db.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Endpoint genérico para consultar vistas de base de datos.
+ * Para agregar una nueva vista, inclúyela en el arreglo $whitelist y
+ * agrega su etiqueta legible en el mapa viewLabels de vistas_db.js.
+ */
+header('Content-Type: application/json');
+
+$whitelist = [
+    'vista_productos_mas_vendidos',
+    'vista_resumen_cortes',
+    'vista_resumen_pagos',
+    'vista_ventas_diarias',
+    'vista_ventas_por_mesero',
+    'vw_consumo_insumos',
+    'vw_corte_resumen',
+    'vw_ventas_detalladas'
+];
+
+try {
+    $view = $_GET['view'] ?? '';
+    if (!in_array($view, $whitelist, true)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Vista no permitida']);
+        exit;
+    }
+
+    $page = max(1, (int)($_GET['page'] ?? 1));
+    $perPage = (int)($_GET['per_page'] ?? 15);
+    $perPage = in_array($perPage, [15,25,50], true) ? $perPage : 15;
+    $search = trim($_GET['search'] ?? '');
+    $sortBy = $_GET['sort_by'] ?? '';
+    $sortDir = strtolower($_GET['sort_dir'] ?? 'asc');
+    $sortDir = $sortDir === 'desc' ? 'DESC' : 'ASC';
+
+    $config = __DIR__ . '/../../config/db.php';
+    if (file_exists($config)) {
+        require $config; // provee $host, $user, $pass, $db
+    }
+    $host = $host ?? getenv('DB_HOST') ?? 'localhost';
+    $db   = $db   ?? getenv('DB_NAME') ?? 'restaurante';
+    $user = $user ?? getenv('DB_USER') ?? 'root';
+    $pass = $pass ?? getenv('DB_PASS') ?? '';
+
+    $dsn = "mysql:host={$host};dbname={$db};charset=utf8mb4";
+    $pdo = new PDO($dsn, $user, $pass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+
+    $stmt = $pdo->prepare("SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :view ORDER BY ORDINAL_POSITION");
+    $stmt->execute([':view' => $view]);
+    $columnsInfo = $stmt->fetchAll();
+    if (!$columnsInfo) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Vista no encontrada']);
+        exit;
+    }
+    $columns = array_column($columnsInfo, 'COLUMN_NAME');
+    if (!in_array($sortBy, $columns, true)) {
+        $sortBy = '';
+    }
+
+    $allowedTypes = ['char','varchar','text','tinytext','mediumtext','longtext','int','bigint','smallint','mediumint','decimal','float','double','date','datetime','timestamp','time','year'];
+    $where = '';
+    $params = [];
+    if ($search !== '') {
+        $parts = [];
+        foreach ($columnsInfo as $idx => $col) {
+            if (in_array(strtolower($col['DATA_TYPE']), $allowedTypes, true)) {
+                $ph = ":s{$idx}";
+                $parts[] = "`{$col['COLUMN_NAME']}` LIKE {$ph}";
+                $params[$ph] = "%{$search}%";
+            }
+        }
+        if ($parts) {
+            $where = ' WHERE ' . implode(' OR ', $parts);
+        }
+    }
+
+    $offset = ($page - 1) * $perPage;
+
+    $countSql = "SELECT COUNT(*) FROM `{$view}`{$where}";
+    $countStmt = $pdo->prepare($countSql);
+    foreach ($params as $ph => $val) {
+        $countStmt->bindValue($ph, $val);
+    }
+    $countStmt->execute();
+    $total = (int)$countStmt->fetchColumn();
+
+    $dataSql = "SELECT * FROM `{$view}`{$where}";
+    if ($sortBy) {
+        $dataSql .= " ORDER BY `{$sortBy}` {$sortDir}";
+    }
+    $dataSql .= " LIMIT :limit OFFSET :offset";
+
+    $dataStmt = $pdo->prepare($dataSql);
+    foreach ($params as $ph => $val) {
+        $dataStmt->bindValue($ph, $val);
+    }
+    $dataStmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
+    $dataStmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+    $dataStmt->execute();
+    $rows = $dataStmt->fetchAll();
+
+    echo json_encode([
+        'columns' => $columns,
+        'rows' => $rows,
+        'total' => $total,
+        'page' => $page,
+        'per_page' => $perPage,
+    ], JSON_UNESCAPED_UNICODE);
+
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/vistas/reportes/vistas_db.js
+++ b/vistas/reportes/vistas_db.js
@@ -1,0 +1,189 @@
+/*
+ * Maneja la tabla dinámica de vistas SQL.
+ * Para agregar nuevas vistas, actualiza este mapa y la lista en
+ * /apis/reportes/vistas_db.php.
+ */
+const viewLabels = {
+    vista_productos_mas_vendidos: 'Productos más vendidos',
+    vista_resumen_cortes: 'Resumen de cortes',
+    vista_resumen_pagos: 'Resumen de pagos',
+    vista_ventas_diarias: 'Ventas diarias',
+    vista_ventas_por_mesero: 'Ventas por mesero',
+    vw_consumo_insumos: 'Consumo de insumos',
+    vw_corte_resumen: 'Corte resumen',
+    vw_ventas_detalladas: 'Ventas detalladas'
+};
+
+let currentView = sessionStorage.getItem('vistas_db_view') || 'vista_productos_mas_vendidos';
+let page = 1;
+let perPage = parseInt(sessionStorage.getItem('vistas_db_per_page') || '15', 10);
+let search = '';
+let sortBy = '';
+let sortDir = 'asc';
+
+const selectVista = document.getElementById('selectVista');
+const searchInput = document.getElementById('searchInput');
+const perPageSelect = document.getElementById('perPage');
+const thead = document.querySelector('#tablaVista thead');
+const tbody = document.querySelector('#tablaVista tbody');
+const loader = document.getElementById('loader');
+const errorDiv = document.getElementById('error');
+const paginacion = document.getElementById('paginacion');
+const paginaInfo = document.getElementById('paginaInfo');
+const prevBtn = document.getElementById('prevPage');
+const nextBtn = document.getElementById('nextPage');
+
+function buildViewOptions() {
+    selectVista.innerHTML = '';
+    Object.entries(viewLabels).forEach(([value, label]) => {
+        const opt = document.createElement('option');
+        opt.value = value;
+        opt.textContent = label;
+        if (value === currentView) opt.selected = true;
+        selectVista.appendChild(opt);
+    });
+}
+
+function sanitize(text) {
+    const div = document.createElement('div');
+    div.textContent = text == null ? '' : text;
+    return div.innerHTML;
+}
+
+async function fetchColumnsAndData() {
+    loader.style.display = 'block';
+    errorDiv.style.display = 'none';
+    const params = new URLSearchParams({
+        view: currentView,
+        page: page,
+        per_page: perPage
+    });
+    if (search) params.append('search', search);
+    if (sortBy) {
+        params.append('sort_by', sortBy);
+        params.append('sort_dir', sortDir);
+    }
+    try {
+        const res = await fetch(`../../apis/reportes/vistas_db.php?${params.toString()}`);
+        if (!res.ok) throw new Error('HTTP');
+        const data = await res.json();
+        renderTable(data.columns, data.rows);
+        renderPagination(data.total, data.page, data.per_page);
+    } catch (e) {
+        thead.innerHTML = '';
+        tbody.innerHTML = '';
+        errorDiv.textContent = 'Error al cargar datos';
+        errorDiv.style.display = 'block';
+        paginacion.style.display = 'none';
+    } finally {
+        loader.style.display = 'none';
+    }
+}
+
+function renderTable(columns, rows) {
+    const fragHead = document.createDocumentFragment();
+    const trHead = document.createElement('tr');
+    columns.forEach(col => {
+        const th = document.createElement('th');
+        th.textContent = col;
+        th.dataset.column = col;
+        if (sortBy === col) th.classList.add('ordenado', sortDir);
+        trHead.appendChild(th);
+    });
+    fragHead.appendChild(trHead);
+    thead.innerHTML = '';
+    thead.appendChild(fragHead);
+
+    const fragBody = document.createDocumentFragment();
+    if (!rows.length) {
+        const tr = document.createElement('tr');
+        const td = document.createElement('td');
+        td.textContent = 'Sin resultados';
+        td.colSpan = columns.length;
+        tr.appendChild(td);
+        fragBody.appendChild(tr);
+    } else {
+        rows.forEach(row => {
+            const tr = document.createElement('tr');
+            columns.forEach(col => {
+                const td = document.createElement('td');
+                td.innerHTML = sanitize(row[col]);
+                const lower = col.toLowerCase();
+                if (lower.includes('fecha')) {
+                    td.style.textAlign = 'center';
+                } else if (/total|monto|propina|precio|cantidad|importe|numero|id/.test(lower)) {
+                    td.style.textAlign = 'right';
+                }
+                tr.appendChild(td);
+            });
+            fragBody.appendChild(tr);
+        });
+    }
+    tbody.innerHTML = '';
+    tbody.appendChild(fragBody);
+}
+
+function renderPagination(total, pageNow, perPageNow) {
+    const totalPages = Math.max(1, Math.ceil(total / perPageNow));
+    paginaInfo.textContent = `Página ${pageNow} de ${totalPages}`;
+    prevBtn.disabled = pageNow <= 1;
+    nextBtn.disabled = pageNow >= totalPages;
+    paginacion.style.display = 'block';
+}
+
+function attachEvents() {
+    selectVista.addEventListener('change', () => {
+        currentView = selectVista.value;
+        sessionStorage.setItem('vistas_db_view', currentView);
+        page = 1;
+        fetchColumnsAndData();
+    });
+
+    perPageSelect.value = perPage;
+    perPageSelect.addEventListener('change', () => {
+        perPage = parseInt(perPageSelect.value, 10);
+        sessionStorage.setItem('vistas_db_per_page', perPage);
+        page = 1;
+        fetchColumnsAndData();
+    });
+
+    let debounce;
+    searchInput.addEventListener('input', () => {
+        clearTimeout(debounce);
+        debounce = setTimeout(() => {
+            search = searchInput.value.trim();
+            page = 1;
+            fetchColumnsAndData();
+        }, 300);
+    });
+
+    prevBtn.addEventListener('click', () => {
+        if (page > 1) {
+            page--;
+            fetchColumnsAndData();
+        }
+    });
+    nextBtn.addEventListener('click', () => {
+        page++;
+        fetchColumnsAndData();
+    });
+
+    thead.addEventListener('click', e => {
+        if (e.target.tagName === 'TH') {
+            const col = e.target.dataset.column;
+            if (sortBy === col) {
+                sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+            } else {
+                sortBy = col;
+                sortDir = 'asc';
+            }
+            fetchColumnsAndData();
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    buildViewOptions();
+    attachEvents();
+    fetchColumnsAndData();
+});

--- a/vistas/reportes/vistas_db.php
+++ b/vistas/reportes/vistas_db.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Vista para consultar vistas SQL dinámicamente.
+ * Para agregar nuevas vistas, actualiza el mapa viewLabels en vistas_db.js
+ * y la lista $whitelist en /apis/reportes/vistas_db.php.
+ */
+require_once __DIR__ . '/../../utils/cargar_permisos.php';
+$path_actual = str_replace('/rest', '', $_SERVER['PHP_SELF']);
+if (!in_array($path_actual, $_SESSION['rutas_permitidas'])) {
+    http_response_code(403);
+    echo 'Acceso no autorizado';
+    exit;
+}
+$title = 'Reportes';
+ob_start();
+?>
+
+<!-- Page Header Start -->
+<div class="page-header mb-0">
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <h2>Modulo de Reportes</h2>
+            </div>
+            <div class="col-12">
+                <a href="">Inicio</a>
+                <a href="">Reporteria del sistema</a>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- Page Header End -->
+
+<div class="container mt-5 mb-5">
+    <h1 class="titulo-seccion">Consultas de Vistas</h1>
+
+    <div class="filtros-container">
+        <label for="selectVista">Vista:</label>
+        <select id="selectVista" class="form-control-sm"></select>
+
+        <label for="searchInput">Buscar:</label>
+        <input type="text" id="searchInput" class="form-control-sm" placeholder="Buscar...">
+
+        <label for="perPage">Filas por página:</label>
+        <select id="perPage" class="form-control-sm">
+            <option value="15">15</option>
+            <option value="25">25</option>
+            <option value="50">50</option>
+        </select>
+    </div>
+
+    <div id="loader" style="display:none;">Cargando...</div>
+    <div id="error" class="text-danger mt-3" style="display:none;"></div>
+
+    <table id="tablaVista" class="mt-3">
+        <thead></thead>
+        <tbody></tbody>
+    </table>
+
+    <div id="paginacion" class="mt-3">
+        <button id="prevPage" class="btn custom-btn-sm">Anterior</button>
+        <span id="paginaInfo" class="mx-2"></span>
+        <button id="nextPage" class="btn custom-btn-sm">Siguiente</button>
+    </div>
+</div>
+<?php require_once __DIR__ . '/../footer.php'; ?>
+<script src="vistas_db.js"></script>
+</body>
+
+</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../nav.php';


### PR DESCRIPTION
## Summary
- add generic API to query whitelisted DB views with search, sorting and pagination
- new report page and JavaScript to browse different SQL views dynamically

## Testing
- `php -l apis/reportes/vistas_db.php`
- `php -l vistas/reportes/vistas_db.php`


------
https://chatgpt.com/codex/tasks/task_e_68968663ef14832b956d8acf1df18071