### PR TITLE
feat: add dynamic report sources

### DIFF
--- a/api/reportes/vistas_db.php
+++ b/api/reportes/vistas_db.php
@@ -1,117 +1,155 @@
 <?php
-/**
- * Endpoint genérico para consultar vistas de base de datos.
- * Para agregar una nueva vista, inclúyela en el arreglo $whitelist y
- * agrega su etiqueta legible en el mapa viewLabels de vistas_db.js.
- */
 header('Content-Type: application/json');
 
-$whitelist = [
-    'vista_productos_mas_vendidos',
-    'vista_resumen_cortes',
-    'vista_resumen_pagos',
-    'vista_ventas_diarias',
-    'vista_ventas_por_mesero',
-    'vw_consumo_insumos',
-    'vw_corte_resumen',
-    'vw_ventas_detalladas'
+require_once __DIR__ . '/../../config/db.php';
+
+$action = $_GET['action'] ?? '';
+
+$allowedTables = [
+    'logs_accion',
+    'log_asignaciones_mesas',
+    'log_mesas',
+    'movimientos_insumos',
+    'fondo',
+    'insumos',
+    'tickets',
+    'ventas',
+    'qrs_insumo'
 ];
 
 try {
-    $view = $_GET['view'] ?? '';
-    if (!in_array($view, $whitelist, true)) {
-        http_response_code(400);
-        echo json_encode(['error' => 'Vista no permitida']);
+    if ($action === 'list_sources') {
+        $views = [];
+        $sql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA = DATABASE() ORDER BY TABLE_NAME";
+        if ($res = $conn->query($sql)) {
+            while ($row = $res->fetch_assoc()) {
+                $views[] = $row['TABLE_NAME'];
+            }
+            $res->free();
+        }
+        echo json_encode(['views' => $views, 'tables' => $allowedTables], JSON_UNESCAPED_UNICODE);
         exit;
     }
 
-    $page = max(1, (int)($_GET['page'] ?? 1));
-    $perPage = (int)($_GET['per_page'] ?? 15);
-    $perPage = in_array($perPage, [15,25,50], true) ? $perPage : 15;
-    $search = trim($_GET['search'] ?? '');
-    $sortBy = $_GET['sort_by'] ?? '';
-    $sortDir = strtolower($_GET['sort_dir'] ?? 'asc');
-    $sortDir = $sortDir === 'desc' ? 'DESC' : 'ASC';
+    if ($action === 'fetch') {
+        $source = $_GET['source'] ?? '';
+        if ($source === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'Falta el parámetro source']);
+            exit;
+        }
 
-    $config = __DIR__ . '/../../config/db.php';
-    if (file_exists($config)) {
-        require $config; // provee $host, $user, $pass, $db
-    }
-    $host = $host ?? getenv('DB_HOST') ?? 'localhost';
-    $db   = $db   ?? getenv('DB_NAME') ?? 'restaurante';
-    $user = $user ?? getenv('DB_USER') ?? 'root';
-    $pass = $pass ?? getenv('DB_PASS') ?? '';
+        $views = [];
+        $vsql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA = DATABASE()";
+        if ($vres = $conn->query($vsql)) {
+            while ($row = $vres->fetch_assoc()) {
+                $views[] = $row['TABLE_NAME'];
+            }
+            $vres->free();
+        }
 
-    $dsn = "mysql:host={$host};dbname={$db};charset=utf8mb4";
-    $pdo = new PDO($dsn, $user, $pass, [
-        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-    ]);
+        if (in_array($source, $views, true)) {
+            $sourceType = 'vista';
+        } elseif (in_array($source, $allowedTables, true)) {
+            $sourceType = 'tabla';
+        } else {
+            http_response_code(400);
+            echo json_encode(['error' => 'Fuente no permitida']);
+            exit;
+        }
 
-    $stmt = $pdo->prepare("SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :view ORDER BY ORDINAL_POSITION");
-    $stmt->execute([':view' => $view]);
-    $columnsInfo = $stmt->fetchAll();
-    if (!$columnsInfo) {
-        http_response_code(400);
-        echo json_encode(['error' => 'Vista no encontrada']);
-        exit;
-    }
-    $columns = array_column($columnsInfo, 'COLUMN_NAME');
-    if (!in_array($sortBy, $columns, true)) {
-        $sortBy = '';
-    }
+        $page = max(1, (int)($_GET['page'] ?? 1));
+        $pageSize = (int)($_GET['pageSize'] ?? 15);
+        $pageSize = in_array($pageSize, [15, 25, 50], true) ? $pageSize : 15;
+        $q = trim($_GET['q'] ?? '');
+        $sortBy = $_GET['sortBy'] ?? '';
+        $sortDir = strtolower($_GET['sortDir'] ?? 'asc') === 'desc' ? 'DESC' : 'ASC';
 
-    $allowedTypes = ['char','varchar','text','tinytext','mediumtext','longtext','int','bigint','smallint','mediumint','decimal','float','double','date','datetime','timestamp','time','year'];
-    $where = '';
-    $params = [];
-    if ($search !== '') {
-        $parts = [];
-        foreach ($columnsInfo as $idx => $col) {
-            if (in_array(strtolower($col['DATA_TYPE']), $allowedTypes, true)) {
-                $ph = ":s{$idx}";
-                $parts[] = "`{$col['COLUMN_NAME']}` LIKE {$ph}";
-                $params[$ph] = "%{$search}%";
+        $stmtCols = $conn->prepare("SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION");
+        $stmtCols->bind_param('s', $source);
+        $stmtCols->execute();
+        $colsRes = $stmtCols->get_result();
+        $columnsInfo = [];
+        while ($row = $colsRes->fetch_assoc()) {
+            $columnsInfo[] = $row;
+        }
+        $stmtCols->close();
+        if (!$columnsInfo) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Fuente no encontrada']);
+            exit;
+        }
+
+        $columns = array_column($columnsInfo, 'COLUMN_NAME');
+        if (!in_array($sortBy, $columns, true)) {
+            $sortBy = '';
+        }
+
+        $where = '';
+        $params = [];
+        $types = '';
+        if ($q !== '') {
+            $parts = [];
+            foreach ($columnsInfo as $col) {
+                $parts[] = "CAST(`{$col['COLUMN_NAME']}` AS CHAR) LIKE ?";
+                $params[] = "%{$q}%";
+                $types .= 's';
+            }
+            if ($parts) {
+                $where = ' WHERE (' . implode(' OR ', $parts) . ')';
             }
         }
-        if ($parts) {
-            $where = ' WHERE ' . implode(' OR ', $parts);
+
+        $countSql = "SELECT COUNT(*) FROM `{$source}`{$where}";
+        $stmtCount = $conn->prepare($countSql);
+        if ($params) {
+            $stmtCount->bind_param($types, ...$params);
         }
+        $stmtCount->execute();
+        $stmtCount->bind_result($total);
+        $stmtCount->fetch();
+        $stmtCount->close();
+
+        $offset = ($page - 1) * $pageSize;
+        $selectCols = '`' . implode('`,`', $columns) . '`';
+        $dataSql = "SELECT {$selectCols} FROM `{$source}`{$where}";
+        if ($sortBy) {
+            $dataSql .= " ORDER BY `{$sortBy}` {$sortDir}";
+        } else {
+            $dataSql .= " ORDER BY 1";
+        }
+        $dataSql .= " LIMIT ? OFFSET ?";
+
+        $stmtData = $conn->prepare($dataSql);
+        $bindTypes = $types . 'ii';
+        $bindValues = $params;
+        $bindValues[] = $pageSize;
+        $bindValues[] = $offset;
+        $stmtData->bind_param($bindTypes, ...$bindValues);
+        $stmtData->execute();
+        $resData = $stmtData->get_result();
+        $rows = [];
+        while ($row = $resData->fetch_assoc()) {
+            $rows[] = $row;
+        }
+        $stmtData->close();
+
+        echo json_encode([
+            'source' => $source,
+            'sourceType' => $sourceType,
+            'columns' => $columns,
+            'rows' => $rows,
+            'page' => $page,
+            'pageSize' => $pageSize,
+            'total' => (int)$total
+        ], JSON_UNESCAPED_UNICODE);
+        exit;
     }
 
-    $offset = ($page - 1) * $perPage;
-
-    $countSql = "SELECT COUNT(*) FROM `{$view}`{$where}";
-    $countStmt = $pdo->prepare($countSql);
-    foreach ($params as $ph => $val) {
-        $countStmt->bindValue($ph, $val);
-    }
-    $countStmt->execute();
-    $total = (int)$countStmt->fetchColumn();
-
-    $dataSql = "SELECT * FROM `{$view}`{$where}";
-    if ($sortBy) {
-        $dataSql .= " ORDER BY `{$sortBy}` {$sortDir}";
-    }
-    $dataSql .= " LIMIT :limit OFFSET :offset";
-
-    $dataStmt = $pdo->prepare($dataSql);
-    foreach ($params as $ph => $val) {
-        $dataStmt->bindValue($ph, $val);
-    }
-    $dataStmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
-    $dataStmt->bindValue(':offset', $offset, PDO::PARAM_INT);
-    $dataStmt->execute();
-    $rows = $dataStmt->fetchAll();
-
-    echo json_encode([
-        'columns' => $columns,
-        'rows' => $rows,
-        'total' => $total,
-        'page' => $page,
-        'per_page' => $perPage,
-    ], JSON_UNESCAPED_UNICODE);
-
-} catch (Exception $e) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Acción inválida']);
+} catch (Throwable $e) {
     http_response_code(500);
     echo json_encode(['error' => $e->getMessage()]);
 }
+

--- a/vistas/reportes/reportes.js
+++ b/vistas/reportes/reportes.js
@@ -1,4 +1,5 @@
 const usuarioId = 1; // En producción usar id de sesión
+const apiReportes = '../../api/reportes/vistas_db.php';
 
 async function cargarUsuarios() {
     const sel = document.getElementById('filtroUsuario');
@@ -135,6 +136,151 @@ async function resumenActual() {
     }
 }
 
+// --- Reportes dinámicos de vistas/tablas ---
+let fuenteActual = '';
+let pagina = 1;
+let tamPagina = 15;
+let termino = '';
+let ordenCol = '';
+let ordenDir = 'asc';
+let debounceTimer;
+
+async function listarFuentes() {
+    const select = document.getElementById('selectFuente');
+    if (!select) return;
+    try {
+        const resp = await fetch(`${apiReportes}?action=list_sources`);
+        const data = await resp.json();
+        select.innerHTML = '';
+        const ogV = document.createElement('optgroup');
+        ogV.label = 'Vistas';
+        data.views.forEach(v => {
+            const o = document.createElement('option');
+            o.value = v;
+            o.textContent = v;
+            ogV.appendChild(o);
+        });
+        const ogT = document.createElement('optgroup');
+        ogT.label = 'Tablas';
+        data.tables.forEach(t => {
+            const o = document.createElement('option');
+            o.value = t;
+            o.textContent = t;
+            ogT.appendChild(o);
+        });
+        if (data.views.length) {
+            select.appendChild(ogV);
+            select.appendChild(ogT);
+            select.value = data.views[0];
+        } else {
+            select.appendChild(ogV);
+            select.appendChild(ogT);
+            if (data.tables.length) select.value = data.tables[0];
+        }
+        fuenteActual = select.value;
+        cargarFuente();
+    } catch (err) {
+        console.error(err);
+    }
+}
+
+async function cargarFuente() {
+    const tabla = document.getElementById('tablaReportes');
+    if (!tabla) return;
+    const thead = tabla.querySelector('thead');
+    const tbody = tabla.querySelector('tbody');
+    const loader = document.getElementById('reportesLoader');
+    loader.style.display = 'block';
+    tbody.innerHTML = '';
+    const params = new URLSearchParams({
+        action: 'fetch',
+        source: fuenteActual,
+        page: pagina,
+        pageSize: tamPagina
+    });
+    if (termino) params.append('q', termino);
+    if (ordenCol) {
+        params.append('sortBy', ordenCol);
+        params.append('sortDir', ordenDir);
+    }
+    try {
+        const resp = await fetch(`${apiReportes}?${params.toString()}`);
+        const data = await resp.json();
+        loader.style.display = 'none';
+        if (data.error) {
+            thead.innerHTML = '';
+            tbody.innerHTML = `<tr><td colspan="1">${data.error}</td></tr>`;
+            document.getElementById('infoReportes').textContent = '';
+            return;
+        }
+        thead.innerHTML = '<tr>' + data.columns.map(c => `<th data-col="${c}">${c}</th>`).join('') + '</tr>';
+        if (!data.rows.length) {
+            tbody.innerHTML = `<tr><td colspan="${data.columns.length}">Sin resultados</td></tr>`;
+        } else {
+            data.rows.forEach(r => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = data.columns.map(c => `<td>${r[c] !== null ? r[c] : ''}</td>`).join('');
+                tbody.appendChild(tr);
+            });
+        }
+        const inicio = data.total ? ((data.page - 1) * data.pageSize + 1) : 0;
+        const fin = Math.min(data.page * data.pageSize, data.total);
+        document.getElementById('infoReportes').textContent = `Mostrando ${inicio}-${fin} de ${data.total}`;
+        document.getElementById('prevReportes').disabled = data.page <= 1;
+        document.getElementById('nextReportes').disabled = data.page * data.pageSize >= data.total;
+    } catch (err) {
+        loader.style.display = 'none';
+        console.error(err);
+        tbody.innerHTML = `<tr><td colspan="1">Error al cargar</td></tr>`;
+    }
+}
+
+function initReportesDinamicos() {
+    const select = document.getElementById('selectFuente');
+    if (!select) return;
+    listarFuentes();
+    select.addEventListener('change', () => {
+        fuenteActual = select.value;
+        pagina = 1;
+        cargarFuente();
+    });
+    document.getElementById('buscarFuente').addEventListener('input', e => {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+            termino = e.target.value;
+            pagina = 1;
+            cargarFuente();
+        }, 300);
+    });
+    document.getElementById('tamPagina').addEventListener('change', e => {
+        tamPagina = parseInt(e.target.value, 10);
+        pagina = 1;
+        cargarFuente();
+    });
+    document.getElementById('prevReportes').addEventListener('click', () => {
+        if (pagina > 1) {
+            pagina--;
+            cargarFuente();
+        }
+    });
+    document.getElementById('nextReportes').addEventListener('click', () => {
+        pagina++;
+        cargarFuente();
+    });
+    document.querySelector('#tablaReportes thead').addEventListener('click', e => {
+        if (e.target.tagName === 'TH') {
+            const col = e.target.dataset.col;
+            if (ordenCol === col) {
+                ordenDir = ordenDir === 'asc' ? 'desc' : 'asc';
+            } else {
+                ordenCol = col;
+                ordenDir = 'asc';
+            }
+            cargarFuente();
+        }
+    });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     cargarUsuarios();
     cargarHistorial();
@@ -143,4 +289,5 @@ document.addEventListener('DOMContentLoaded', () => {
     if (btn) btn.addEventListener('click', cargarHistorial);
     const imp = document.getElementById('btnImprimir');
     if (imp) imp.addEventListener('click', () => window.print());
+    initReportesDinamicos();
 });

--- a/vistas/reportes/reportes.php
+++ b/vistas/reportes/reportes.php
@@ -75,6 +75,37 @@ ob_start();
     </table>
 
 </div>
+<div class="container mt-5 mb-5">
+    <h2 class="section-header">Consulta de Vistas y Tablas</h2>
+
+    <div class="filtros-container">
+        <label for="selectFuente">Fuente:</label>
+        <select id="selectFuente" class="form-control-sm"></select>
+
+        <label for="buscarFuente">Buscar:</label>
+        <input type="text" id="buscarFuente" class="form-control-sm" placeholder="Buscar...">
+
+        <label for="tamPagina">Filas por página:</label>
+        <select id="tamPagina" class="form-control-sm">
+            <option value="15">15</option>
+            <option value="25">25</option>
+            <option value="50">50</option>
+        </select>
+    </div>
+
+    <div id="reportesLoader" style="display:none;">Cargando...</div>
+
+    <table id="tablaReportes" class="mt-3">
+        <thead></thead>
+        <tbody></tbody>
+    </table>
+
+    <div id="paginacionReportes" class="mt-3">
+        <button id="prevReportes" class="btn custom-btn-sm">Anterior</button>
+        <span id="infoReportes" class="mx-2"></span>
+        <button id="nextReportes" class="btn custom-btn-sm">Siguiente</button>
+    </div>
+</div>
 <?php require_once __DIR__ . '/../footer.php'; ?>
 <script src="reportes.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add toolbar and dynamic table for viewing DB views and whitelisted tables
- implement frontend logic for pagination, search, and sorting
- provide API to list sources and fetch paginated data securely

## Testing
- `php -l rest/vistas/reportes/reportes.php`
- `php -l rest/api/reportes/vistas_db.php`
- `node --check rest/vistas/reportes/reportes.js`


------
https://chatgpt.com/codex/tasks/task_e_689692afae64832b95d07d3706dcada4