### PR TITLE
feat: add dynamic report sources

### DIFF
--- a/api/reportes/vistas_db.php
+++ b/api/reportes/vistas_db.php
@@ -1,41 +1,37 @@
 <?php
 /**
- * Endpoint genérico para consultar vistas de base de datos.
- * Para agregar una nueva vista, inclúyela en el arreglo $whitelist y
- * agrega su etiqueta legible en el mapa viewLabels de vistas_db.js.
+ * Endpoint para listar fuentes (vistas/tablas) y obtener datos paginados.
+ *
+ * Mantiene compatibilidad con la versión anterior que recibía parámetros:
+ *   view, page, per_page, search, sort_by, sort_dir
+ * y retornaba un arreglo plano de columnas.
+ *
+ * Nueva interfaz:
+ *   ?action=list  => {ok:true, views:[...], tables:[...]}
+ *   ?action=data&source=...&page=1&pageSize=25&q=...&orderBy=col&orderDir=asc
+ *                  => {ok:true, source:"...", page:1, pageSize:25, total:0,
+ *                      columns:[{key,label,type}], rows:[...]}
  */
+
 header('Content-Type: application/json');
 
-$whitelist = [
-    'vista_productos_mas_vendidos',
-    'vista_resumen_cortes',
-    'vista_resumen_pagos',
-    'vista_ventas_diarias',
-    'vista_ventas_por_mesero',
-    'vw_consumo_insumos',
-    'vw_corte_resumen',
-    'vw_ventas_detalladas'
+$fixedTables = [
+    'logs_accion',
+    'log_asignaciones_mesas',
+    'log_mesas',
+    'movimientos_insumos',
+    'fondo',
+    'insumos',
+    'tickets',
+    'ventas',
+    'qrs_insumo'
 ];
 
 try {
-    $view = $_GET['view'] ?? '';
-    if (!in_array($view, $whitelist, true)) {
-        http_response_code(400);
-        echo json_encode(['error' => 'Vista no permitida']);
-        exit;
-    }
-
-    $page = max(1, (int)($_GET['page'] ?? 1));
-    $perPage = (int)($_GET['per_page'] ?? 15);
-    $perPage = in_array($perPage, [15,25,50], true) ? $perPage : 15;
-    $search = trim($_GET['search'] ?? '');
-    $sortBy = $_GET['sort_by'] ?? '';
-    $sortDir = strtolower($_GET['sort_dir'] ?? 'asc');
-    $sortDir = $sortDir === 'desc' ? 'DESC' : 'ASC';
-
+    // --- Conexión a la base de datos ---
     $config = __DIR__ . '/../../config/db.php';
     if (file_exists($config)) {
-        require $config; // provee $host, $user, $pass, $db
+        require $config; // define $host, $user, $pass, $db si existen
     }
     $host = $host ?? getenv('DB_HOST') ?? 'localhost';
     $db   = $db   ?? getenv('DB_NAME') ?? 'restaurante';
@@ -48,29 +44,76 @@ try {
         PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
     ]);
 
-    $stmt = $pdo->prepare("SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :view ORDER BY ORDINAL_POSITION");
-    $stmt->execute([':view' => $view]);
+    $action = $_GET['action'] ?? '';
+
+    if ($action === 'list') {
+        // Devuelve vistas disponibles y tablas fijas
+        $stmt = $pdo->query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA = DATABASE() ORDER BY TABLE_NAME");
+        $views = $stmt->fetchAll(PDO::FETCH_COLUMN);
+        echo json_encode([
+            'ok' => true,
+            'views' => $views,
+            'tables' => $fixedTables
+        ], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+
+    // Parametrización unificada (nuevo y legacy)
+    $source   = $_GET['source']   ?? $_GET['view']     ?? '';
+    if ($source === '') {
+        http_response_code(400);
+        echo json_encode(['ok' => false, 'error' => 'Parámetro source/view requerido']);
+        exit;
+    }
+
+    // Obtener lista de vistas para validación
+    $viewsStmt = $pdo->query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA = DATABASE()");
+    $views = $viewsStmt->fetchAll(PDO::FETCH_COLUMN);
+    $allowedSources = array_merge($views, $fixedTables);
+    if (!in_array($source, $allowedSources, true)) {
+        http_response_code(400);
+        echo json_encode(['ok' => false, 'error' => 'Fuente no permitida']);
+        exit;
+    }
+
+    $page     = max(1, (int)($_GET['page'] ?? 1));
+    $pageSize = (int)($_GET['pageSize'] ?? $_GET['per_page'] ?? 15);
+    $pageSize = in_array($pageSize, [15, 25, 50], true) ? $pageSize : 15;
+    $q        = trim($_GET['q'] ?? $_GET['search'] ?? '');
+    $orderBy  = $_GET['orderBy'] ?? $_GET['sort_by'] ?? '';
+    $orderDir = strtolower($_GET['orderDir'] ?? $_GET['sort_dir'] ?? 'asc');
+    $orderDir = $orderDir === 'desc' ? 'DESC' : 'ASC';
+
+    // Obtener metadata de columnas
+    $stmt = $pdo->prepare("SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :tbl ORDER BY ORDINAL_POSITION");
+    $stmt->execute([':tbl' => $source]);
     $columnsInfo = $stmt->fetchAll();
     if (!$columnsInfo) {
         http_response_code(400);
-        echo json_encode(['error' => 'Vista no encontrada']);
+        echo json_encode(['ok' => false, 'error' => 'Fuente no encontrada']);
         exit;
     }
-    $columns = array_column($columnsInfo, 'COLUMN_NAME');
-    if (!in_array($sortBy, $columns, true)) {
-        $sortBy = '';
+
+    $columnNames = array_column($columnsInfo, 'COLUMN_NAME');
+    if (!in_array($orderBy, $columnNames, true)) {
+        $orderBy = $columnNames[0]; // orden por primera columna
     }
 
-    $allowedTypes = ['char','varchar','text','tinytext','mediumtext','longtext','int','bigint','smallint','mediumint','decimal','float','double','date','datetime','timestamp','time','year'];
+    // Construcción de cláusula WHERE para búsqueda
+    $allowedTypes = [
+        'char','varchar','text','tinytext','mediumtext','longtext',
+        'int','bigint','smallint','mediumint','decimal','float','double',
+        'date','datetime','timestamp','time','year'
+    ];
     $where = '';
     $params = [];
-    if ($search !== '') {
+    if ($q !== '') {
         $parts = [];
         foreach ($columnsInfo as $idx => $col) {
             if (in_array(strtolower($col['DATA_TYPE']), $allowedTypes, true)) {
                 $ph = ":s{$idx}";
                 $parts[] = "`{$col['COLUMN_NAME']}` LIKE {$ph}";
-                $params[$ph] = "%{$search}%";
+                $params[$ph] = "%{$q}%";
             }
         }
         if ($parts) {
@@ -78,9 +121,10 @@ try {
         }
     }
 
-    $offset = ($page - 1) * $perPage;
+    $offset = ($page - 1) * $pageSize;
 
-    $countSql = "SELECT COUNT(*) FROM `{$view}`{$where}";
+    // Conteo total
+    $countSql = "SELECT COUNT(*) FROM `{$source}`{$where}";
     $countStmt = $pdo->prepare($countSql);
     foreach ($params as $ph => $val) {
         $countStmt->bindValue($ph, $val);
@@ -88,30 +132,58 @@ try {
     $countStmt->execute();
     $total = (int)$countStmt->fetchColumn();
 
-    $dataSql = "SELECT * FROM `{$view}`{$where}";
-    if ($sortBy) {
-        $dataSql .= " ORDER BY `{$sortBy}` {$sortDir}";
-    }
-    $dataSql .= " LIMIT :limit OFFSET :offset";
-
+    // Datos
+    $colsList = '`' . implode('`,`', $columnNames) . '`';
+    $dataSql = "SELECT {$colsList} FROM `{$source}`{$where} ORDER BY `{$orderBy}` {$orderDir} LIMIT :limit OFFSET :offset";
     $dataStmt = $pdo->prepare($dataSql);
     foreach ($params as $ph => $val) {
         $dataStmt->bindValue($ph, $val);
     }
-    $dataStmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
+    $dataStmt->bindValue(':limit', $pageSize, PDO::PARAM_INT);
     $dataStmt->bindValue(':offset', $offset, PDO::PARAM_INT);
     $dataStmt->execute();
     $rows = $dataStmt->fetchAll();
 
-    echo json_encode([
-        'columns' => $columns,
-        'rows' => $rows,
-        'total' => $total,
-        'page' => $page,
-        'per_page' => $perPage,
-    ], JSON_UNESCAPED_UNICODE);
+    if ($action === 'data') {
+        // Nueva respuesta estructurada
+        $typeMap = [
+            'char' => 'string', 'varchar' => 'string', 'text' => 'string',
+            'tinytext' => 'string', 'mediumtext' => 'string', 'longtext' => 'string',
+            'int' => 'number', 'bigint' => 'number', 'smallint' => 'number',
+            'mediumint' => 'number', 'decimal' => 'number', 'float' => 'number', 'double' => 'number',
+            'date' => 'date', 'datetime' => 'datetime', 'timestamp' => 'datetime',
+            'time' => 'time', 'year' => 'number'
+        ];
+        $colsMeta = array_map(function($c) use ($typeMap) {
+            $type = strtolower($c['DATA_TYPE']);
+            return [
+                'key' => $c['COLUMN_NAME'],
+                'label' => $c['COLUMN_NAME'],
+                'type' => $typeMap[$type] ?? 'string'
+            ];
+        }, $columnsInfo);
 
+        echo json_encode([
+            'ok' => true,
+            'source' => $source,
+            'page' => $page,
+            'pageSize' => $pageSize,
+            'total' => $total,
+            'columns' => $colsMeta,
+            'rows' => $rows
+        ], JSON_UNESCAPED_UNICODE);
+    } else {
+        // Respuesta legacy
+        echo json_encode([
+            'columns' => $columnNames,
+            'rows' => $rows,
+            'total' => $total,
+            'page' => $page,
+            'per_page' => $pageSize
+        ], JSON_UNESCAPED_UNICODE);
+    }
 } catch (Exception $e) {
     http_response_code(500);
-    echo json_encode(['error' => $e->getMessage()]);
+    echo json_encode(['ok' => false, 'error' => $e->getMessage()]);
 }
+

--- a/vistas/reportes/reportes.js
+++ b/vistas/reportes/reportes.js
@@ -149,12 +149,12 @@ async function listarFuentes() {
     const select = document.getElementById('selectFuente');
     if (!select) return;
     try {
-        const resp = await fetch(`${apiReportes}?action=list_sources`);
+        const resp = await fetch(`${apiReportes}?action=list`);
         const data = await resp.json();
         select.innerHTML = '';
         const ogV = document.createElement('optgroup');
-        ogV.label = 'Vistas';
-        data.views.forEach(v => {
+        ogV.label = 'Vistas de BD';
+        (data.views || []).forEach(v => {
             const o = document.createElement('option');
             o.value = v;
             o.textContent = v;
@@ -162,20 +162,18 @@ async function listarFuentes() {
         });
         const ogT = document.createElement('optgroup');
         ogT.label = 'Tablas';
-        data.tables.forEach(t => {
+        (data.tables || []).forEach(t => {
             const o = document.createElement('option');
             o.value = t;
             o.textContent = t;
             ogT.appendChild(o);
         });
-        if (data.views.length) {
-            select.appendChild(ogV);
-            select.appendChild(ogT);
+        select.appendChild(ogV);
+        select.appendChild(ogT);
+        if (data.views && data.views.length) {
             select.value = data.views[0];
-        } else {
-            select.appendChild(ogV);
-            select.appendChild(ogT);
-            if (data.tables.length) select.value = data.tables[0];
+        } else if (data.tables && data.tables.length) {
+            select.value = data.tables[0];
         }
         fuenteActual = select.value;
         cargarFuente();
@@ -193,33 +191,33 @@ async function cargarFuente() {
     loader.style.display = 'block';
     tbody.innerHTML = '';
     const params = new URLSearchParams({
-        action: 'fetch',
+        action: 'data',
         source: fuenteActual,
         page: pagina,
         pageSize: tamPagina
     });
     if (termino) params.append('q', termino);
     if (ordenCol) {
-        params.append('sortBy', ordenCol);
-        params.append('sortDir', ordenDir);
+        params.append('orderBy', ordenCol);
+        params.append('orderDir', ordenDir);
     }
     try {
         const resp = await fetch(`${apiReportes}?${params.toString()}`);
         const data = await resp.json();
         loader.style.display = 'none';
-        if (data.error) {
+        if (!data.ok) {
             thead.innerHTML = '';
-            tbody.innerHTML = `<tr><td colspan="1">${data.error}</td></tr>`;
+            tbody.innerHTML = `<tr><td colspan="1">${data.error || 'Error'}</td></tr>`;
             document.getElementById('infoReportes').textContent = '';
             return;
         }
-        thead.innerHTML = '<tr>' + data.columns.map(c => `<th data-col="${c}">${c}</th>`).join('') + '</tr>';
+        thead.innerHTML = '<tr>' + data.columns.map(c => `<th data-col="${c.key}">${c.label}</th>`).join('') + '</tr>';
         if (!data.rows.length) {
             tbody.innerHTML = `<tr><td colspan="${data.columns.length}">Sin resultados</td></tr>`;
         } else {
             data.rows.forEach(r => {
                 const tr = document.createElement('tr');
-                tr.innerHTML = data.columns.map(c => `<td>${r[c] !== null ? r[c] : ''}</td>`).join('');
+                tr.innerHTML = data.columns.map(c => `<td>${r[c.key] !== null ? r[c.key] : ''}</td>`).join('');
                 tbody.appendChild(tr);
             });
         }
@@ -242,6 +240,8 @@ function initReportesDinamicos() {
     select.addEventListener('change', () => {
         fuenteActual = select.value;
         pagina = 1;
+        ordenCol = '';
+        ordenDir = 'asc';
         cargarFuente();
     });
     document.getElementById('buscarFuente').addEventListener('input', e => {

--- a/vistas/reportes/reportes.php
+++ b/vistas/reportes/reportes.php
@@ -75,8 +75,8 @@ ob_start();
     </table>
 
 </div>
-<div class="container mt-5 mb-5">
-    <h2 class="section-header">Consulta de Vistas y Tablas</h2>
+<details class="container mt-5 mb-5">
+    <summary class="section-header">Consulta de Vistas y Tablas</summary>
 
     <div class="filtros-container">
         <label for="selectFuente">Fuente:</label>
@@ -105,7 +105,7 @@ ob_start();
         <span id="infoReportes" class="mx-2"></span>
         <button id="nextReportes" class="btn custom-btn-sm">Siguiente</button>
     </div>
-</div>
+</details>
 <?php require_once __DIR__ . '/../footer.php'; ?>
 <script src="reportes.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- support listing fixed tables alongside DB views in reports API
- return unified paginated data for any source with search and ordering
- allow front-end to switch between views and tables dynamically

## Testing
- `php -l api/reportes/vistas_db.php`
- `php -l vistas/reportes/reportes.php`
- `node --check vistas/reportes/reportes.js`


------
https://chatgpt.com/codex/tasks/task_e_689695701f84832b9c082db37f65b273