### PR TITLE
feat: expose tables in report selector

### DIFF
--- a/api/reportes/vistas_db.php
+++ b/api/reportes/vistas_db.php
@@ -14,7 +14,16 @@ $whitelist = [
     'vista_ventas_por_mesero',
     'vw_consumo_insumos',
     'vw_corte_resumen',
-    'vw_ventas_detalladas'
+    'vw_ventas_detalladas',
+    'logs_accion',
+    'log_asignaciones_mesas',
+    'log_mesas',
+    'movimientos_insumos',
+    'fondo',
+    'insumos',
+    'tickets',
+    'ventas',
+    'qrs_insumo'
 ];
 
 try {

--- a/vistas/reportes/vistas_db.js
+++ b/vistas/reportes/vistas_db.js
@@ -11,7 +11,16 @@ const viewLabels = {
     vista_ventas_por_mesero: 'Ventas por mesero',
     vw_consumo_insumos: 'Consumo de insumos',
     vw_corte_resumen: 'Corte resumen',
-    vw_ventas_detalladas: 'Ventas detalladas'
+    vw_ventas_detalladas: 'Ventas detalladas',
+    logs_accion: 'Log de acciones',
+    log_asignaciones_mesas: 'Asignaciones de mesas (log)',
+    log_mesas: 'Log de mesas',
+    movimientos_insumos: 'Movimientos de insumos',
+    fondo: 'Fondo de caja',
+    insumos: 'Insumos',
+    tickets: 'Tickets',
+    ventas: 'Ventas',
+    qrs_insumo: 'QR de insumos'
 };
 
 let currentView = sessionStorage.getItem('vistas_db_view') || 'vista_productos_mas_vendidos';


### PR DESCRIPTION
## Summary
- allow selecting reporting tables like logs_accion and ventas
- whitelist new reporting tables in API

## Testing
- `node --check vistas/reportes/vistas_db.js && echo 'JS syntax OK'`
- `php -l api/reportes/vistas_db.php`


------
https://chatgpt.com/codex/tasks/task_e_6898bca59c9c832b95519eff2e3ed438