### PR TITLE
Add kitchen kanban view and consolidated API

### DIFF
--- a/api/cocina/listar_productos_cocina.php
+++ b/api/cocina/listar_productos_cocina.php
@@ -1,0 +1,48 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+$sql = "
+SELECT
+  v.tipo_entrega,
+  CASE
+    WHEN v.tipo_entrega = 'mesa' THEN m.nombre
+    WHEN v.tipo_entrega = 'domicilio' THEN CONCAT('Domicilio - ', r.nombre)
+    ELSE 'Venta rápida'
+  END AS destino,
+  p.nombre AS producto,
+  d.cantidad,
+  d.created_at AS hora,
+  d.estado_producto AS estado,
+  d.observaciones,
+  d.id AS detalle_id
+FROM venta_detalles d
+JOIN ventas v ON v.id = d.venta_id
+LEFT JOIN mesas m ON m.id = v.mesa_id
+LEFT JOIN repartidores r ON r.id = v.repartidor_id
+JOIN productos p ON p.id = d.producto_id
+WHERE (1=1)
+  AND (
+    d.estado_producto <> 'entregado'
+    OR (d.estado_producto = 'entregado' AND DATE(d.created_at) = CURDATE())
+  )
+ORDER BY FIELD(d.estado_producto,'pendiente','en_preparacion','listo','entregado'),
+         destino, d.created_at
+";
+$res = $conn->query($sql);
+if (!$res) { error('Error al obtener productos: ' . $conn->error); }
+
+$out = [];
+while ($row = $res->fetch_assoc()) {
+  $out[] = [
+    'destino'       => $row['destino'],
+    'tipo'          => $row['tipo_entrega'],
+    'producto'      => $row['producto'],
+    'cantidad'      => (int)$row['cantidad'],
+    'hora'          => $row['hora'],
+    'estado'        => $row['estado'],
+    'observaciones' => $row['observaciones'],
+    'detalle_id'    => (int)$row['detalle_id']
+  ];
+}
+success($out);

--- a/vistas/cocina/cocina2.js
+++ b/vistas/cocina/cocina2.js
@@ -1,0 +1,131 @@
+(() => {
+  const API_BASE = '/api/cocina';
+  const qs = s => document.querySelector(s);
+  const qsa = s => Array.from(document.querySelectorAll(s));
+
+  const cols = {
+    pendiente: qs('#col-pendiente'),
+    en_preparacion: qs('#col-preparacion'),
+    listo: qs('#col-listo'),
+    entregado: qs('#col-entregado')
+  };
+
+  const filtroInput = qs('#txtFiltro');
+  const tipoEntregaSel = qs('#selTipoEntrega');
+  const btnRefrescar = qs('#btnRefrescar');
+
+  let cache = [];
+
+  const allowedNext = {
+    pendiente: 'en_preparacion',
+    en_preparacion: 'listo',
+    listo: 'entregado'
+  };
+
+  function render(items){
+    Object.values(cols).forEach(c => c.innerHTML = '');
+    const txt = (filtroInput.value || '').toLowerCase();
+    const tipo = (tipoEntregaSel.value || '').toLowerCase();
+
+    items.forEach(it => {
+      if (txt){
+        const hay = (it.producto + ' ' + it.destino).toLowerCase().includes(txt);
+        if (!hay) return;
+      }
+      if (tipo && it.tipo !== tipo) return;
+
+      const card = document.createElement('div');
+      card.className = 'kanban-item';
+      card.draggable = true;
+      card.dataset.id = it.detalle_id;
+      card.dataset.estado = it.estado;
+      card.innerHTML = `
+        <div class='title'>${it.producto} <small>x${it.cantidad}</small></div>
+        <div class='meta'>
+          <span>${it.destino}</span>
+          <span>${formatHora(it.hora)}</span>
+          ${it.observaciones ? `<span>Obs: ${escapeHtml(it.observaciones)}</span>` : ''}
+        </div>
+      `;
+      bindDrag(card);
+      (cols[it.estado] || cols.pendiente).appendChild(card);
+    });
+  }
+
+  function formatHora(s){
+    try { return new Date(s.replace(' ', 'T')).toLocaleTimeString(); } catch(e){ return s; }
+  }
+  function escapeHtml(s){
+    const div = document.createElement('div');
+    div.innerText = s;
+    return div.innerHTML;
+  }
+
+  function bindDrag(el){
+    el.addEventListener('dragstart', ev => {
+      ev.dataTransfer.setData('text/plain', el.dataset.id);
+      setTimeout(()=> el.classList.add('dragging'), 0);
+    });
+    el.addEventListener('dragend', ()=> el.classList.remove('dragging'));
+  }
+
+  qsa('.kanban-dropzone').forEach(zone => {
+    zone.addEventListener('dragover', ev => { ev.preventDefault(); zone.classList.add('drag-over'); });
+    zone.addEventListener('dragleave', ()=> zone.classList.remove('drag-over'));
+    zone.addEventListener('drop', async ev => {
+      ev.preventDefault();
+      zone.classList.remove('drag-over');
+      const id = ev.dataTransfer.getData('text/plain');
+      const card = document.querySelector(`.kanban-item[data-id='${id}']`);
+      if (!card) return;
+
+      const current = card.dataset.estado;
+      const nuevoEstado = zone.closest('.kanban-board').dataset.status;
+      if (allowedNext[current] !== nuevoEstado){
+        alert('Transición no permitida');
+        return;
+      }
+      const ok = await cambiarEstado(+id, nuevoEstado);
+      if (ok){
+        card.dataset.estado = nuevoEstado;
+        zone.appendChild(card);
+        const idx = cache.findIndex(x => x.detalle_id === +id);
+        if (idx >= 0) cache[idx].estado = nuevoEstado;
+      }
+    });
+  });
+
+  async function cargar(){
+    const res = await fetch(`${API_BASE}/listar_productos_cocina.php`);
+    if (!res.ok){ alert('Error al cargar comandas'); return; }
+    const json = await res.json();
+    if (!json.success){ alert(json.message || 'Error'); return; }
+    cache = json.resultado || json.data || json;
+    render(cache);
+  }
+
+  async function cambiarEstado(detalle_id, nuevo_estado){
+    try{
+      const res = await fetch(`${API_BASE}/cambiar_estado_producto.php`, {
+        method:'POST',
+        headers:{ 'Content-Type':'application/json' },
+        body: JSON.stringify({ detalle_id, nuevo_estado })
+      });
+      const data = await res.json();
+      if (!res.ok || data.success === false){
+        alert(data.message || 'No se pudo cambiar el estado');
+        return false;
+      }
+      return true;
+    }catch(e){
+      alert('Error de red');
+      return false;
+    }
+  }
+
+  filtroInput.addEventListener('input', ()=> render(cache));
+  tipoEntregaSel.addEventListener('change', ()=> render(cache));
+  btnRefrescar.addEventListener('click', cargar);
+
+  cargar();
+})();

--- a/vistas/cocina/cocina2.php
+++ b/vistas/cocina/cocina2.php
@@ -1,0 +1,82 @@
+<?php
+require_once __DIR__ . '/../../utils/cargar_permisos.php';
+$path_actual = str_replace('/rest', '', $_SERVER['PHP_SELF']);
+if (!in_array($path_actual, $_SESSION['rutas_permitidas'])) {
+    http_response_code(403);
+    echo 'Acceso no autorizado';
+    exit;
+}
+$title = 'Cocina (Kanban)';
+ob_start();
+?>
+<div class="page-header mb-0">
+  <div class="container">
+    <div class="row"><div class="col-12"><h2>Módulo de Cocina (Kanban)</h2></div></div>
+  </div>
+</div>
+
+<div class="container my-3">
+  <div class="d-flex gap-2 align-items-center flex-wrap">
+    <input id="txtFiltro" type="text" class="form-control" placeholder="Filtrar por producto/destino" style="max-width:280px">
+    <select id="selTipoEntrega" class="form-control" style="max-width:180px">
+      <option value="">Todos</option>
+      <option value="mesa">Mesa</option>
+      <option value="domicilio">Domicilio</option>
+      <option value="rapido">Rápido</option>
+    </select>
+    <button id="btnRefrescar" class="btn btn-primary">Refrescar</button>
+  </div>
+</div>
+
+<style>
+  .kanban-container { display:grid; gap:12px; grid-template-columns: repeat(4, minmax(0, 1fr)); padding: 0 16px 24px; }
+  @media (max-width: 1200px){ .kanban-container { grid-template-columns: repeat(2, 1fr);} }
+  @media (max-width: 700px){ .kanban-container { grid-template-columns: 1fr;} }
+
+  .kanban-board { background:#fff; border-radius:10px; box-shadow:0 2px 8px rgba(0,0,0,.08); display:flex; flex-direction:column; min-height: 65vh; }
+  .kanban-board h3 { margin:0; padding:12px 14px; font-size:16px; font-weight:700; color:#222; border-bottom:1px solid #eee; border-top-left-radius:10px; border-top-right-radius:10px; }
+  .kanban-dropzone { flex:1; padding:10px; min-height:200px; overflow:auto; }
+
+  .kanban-item { background:#fafafa; border:1px solid #e9e9e9; border-left:4px solid transparent; border-radius:8px; padding:10px; margin-bottom:8px; cursor:grab; }
+  .kanban-item:active { cursor:grabbing; }
+  .kanban-item .title { font-weight:600; line-height:1.2; }
+  .kanban-item .meta { font-size:12px; color:#666; display:flex; gap:10px; flex-wrap:wrap; margin-top:6px; }
+  .drag-over { outline:2px dashed #999; outline-offset: -6px; }
+
+  /* colores por estado */
+  .board-pendiente h3 { background:#ffefef; border-color:#ffd4d4; }
+  .board-pendiente .kanban-item { border-left-color:#e74c3c; }
+  .board-preparacion h3 { background:#fff4e6; border-color:#ffd9a6; }
+  .board-preparacion .kanban-item { border-left-color:#f39c12; }
+  .board-listo h3 { background:#e9fbf1; border-color:#c8f0d9; }
+  .board-listo .kanban-item { border-left-color:#27ae60; }
+  .board-entregado h3 { background:#f5f5f5; border-color:#e5e5e5; }
+  .board-entregado .kanban-item { border-left-color:#7f8c8d; opacity:.85; }
+</style>
+
+<div id="kanban" class="kanban-container">
+  <div class="kanban-board board-pendiente" data-status="pendiente">
+    <h3>Pendiente</h3>
+    <div class="kanban-dropzone" id="col-pendiente"></div>
+  </div>
+  <div class="kanban-board board-preparacion" data-status="en_preparacion">
+    <h3>En preparación</h3>
+    <div class="kanban-dropzone" id="col-preparacion"></div>
+  </div>
+  <div class="kanban-board board-listo" data-status="listo">
+    <h3>Listo</h3>
+    <div class="kanban-dropzone" id="col-listo"></div>
+  </div>
+  <div class="kanban-board board-entregado" data-status="entregado">
+    <h3>Entregado</h3>
+    <div class="kanban-dropzone" id="col-entregado"></div>
+  </div>
+</div>
+
+<?php require_once __DIR__ . '/../footer.php'; ?>
+<script src="cocina2.js"></script>
+</body>
+</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../nav.php';


### PR DESCRIPTION
## Summary
- Add alternative kitchen Kanban interface with four status columns and toolbar filters.
- Load and manage kitchen items via new consolidated API and drag-and-drop workflow.
- Provide endpoint to fetch all kitchen products across states for Kanban view.

## Testing
- `php -l api/cocina/listar_productos_cocina.php`
- `php -l api/cocina/cambiar_estado_producto.php`
- `php -l vistas/cocina/cocina2.php`


------
https://chatgpt.com/codex/tasks/task_e_689902152dfc832b86dd828895a9f37b