### PR TITLE
Track folio range in corte de caja

### DIFF
--- a/utils/bd.sql
+++ b/utils/bd.sql
@@ -156,6 +156,8 @@ CREATE TABLE `corte_caja` (
   `id` int(11) NOT NULL,
   `usuario_id` int(11) NOT NULL,
   `fecha_inicio` datetime NOT NULL DEFAULT current_timestamp(),
+  `folio_inicio` int(11) DEFAULT NULL,
+  `folio_fin` int(11) DEFAULT NULL,
   `fecha_fin` datetime DEFAULT NULL,
   `total` decimal(10,2) DEFAULT NULL,
   `observaciones` text DEFAULT NULL,


### PR DESCRIPTION
## Summary
- record folio_inicio when opening a corte based on existing tickets
- capture folio_fin on corte closure
- document new folio fields in database schema

## Testing
- `php -l api/corte_caja/iniciar_corte.php`
- `php -l api/corte_caja/cerrar_corte.php`

------
https://chatgpt.com/codex/tasks/task_e_68991e297f84832b85cde8055fcf0260