### PR TITLE
Lock waiter to assigned table for restaurant sales

### DIFF
--- a/api/tickets/guardar_ticket.php
+++ b/api/tickets/guardar_ticket.php
@@ -7,12 +7,11 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 }
 
 $input = json_decode(file_get_contents('php://input'), true);
-if (!$input || !isset($input['venta_id'], $input['usuario_id'], $input['subcuentas']) || !is_array($input['subcuentas'])) {
+if (!$input || !isset($input['venta_id'], $input['subcuentas']) || !is_array($input['subcuentas'])) {
     error('Datos incompletos');
 }
 
 $venta_id   = (int)$input['venta_id'];
-$usuario_id = (int)$input['usuario_id'];
 $subcuentas = $input['subcuentas'];
 $sede_id    = isset($input['sede_id']) && !empty($input['sede_id']) ? (int)$input['sede_id'] : 1;
 
@@ -31,6 +30,12 @@ $venta = $resVenta->fetch_assoc();
 $stmtVenta->close();
 if (!$venta) {
     error('Venta no encontrada');
+}
+
+$usuario_id = (int)($venta['mesero_id'] ?? 0);
+if (isset($input['usuario_id']) && (int)$input['usuario_id'] !== $usuario_id) {
+    http_response_code(400);
+    error('La mesa seleccionada pertenece a otro mesero. Actualiza la pantalla e inténtalo de nuevo.');
 }
 
 $mesa_nombre = null;

--- a/api/ventas/crear_venta.php
+++ b/api/ventas/crear_venta.php
@@ -35,7 +35,7 @@ if ($tipo === 'mesa') {
     if (!$mesa_id || $repartidor_id) {
         error('Venta en mesa requiere mesa_id y sin repartidor_id');
     }
-    $estado = $conn->prepare('SELECT estado FROM mesas WHERE id = ?');
+    $estado = $conn->prepare('SELECT estado, usuario_id FROM mesas WHERE id = ?');
     if (!$estado) {
         error('Error al preparar consulta de mesa: ' . $conn->error);
     }
@@ -49,6 +49,10 @@ if ($tipo === 'mesa') {
     $estado->close();
     if (!$rowEstado) {
         error('Mesa no encontrada');
+    }
+    if ((int)($rowEstado['usuario_id'] ?? 0) !== $usuario_id) {
+        http_response_code(400);
+        error('La mesa seleccionada pertenece a otro mesero. Actualiza la pantalla e inténtalo de nuevo.');
     }
     if ($rowEstado['estado'] !== 'libre') {
         error('La mesa seleccionada no está libre');


### PR DESCRIPTION
## Summary
- Auto-populate and lock waiter when selecting a table in restaurant sales
- Validate mesa's waiter on sale creation and propagate to ticket generation

## Testing
- `php -l api/ventas/crear_venta.php`
- `php -l api/tickets/guardar_ticket.php`
- `node --check vistas/ventas/ventas.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68992a3d69bc832ba80fef33eb6b604b