### PR TITLE
Precargar y ocultar boucher/cheque en cierre de caja

### DIFF
--- a/api/corte_caja/cerrar_corte.php
+++ b/api/corte_caja/cerrar_corte.php
@@ -41,6 +41,52 @@ $fecha_inicio   = $row['fecha_inicio'];
 $fondo_inicial  = (float)($row['fondo_inicial'] ?? 0);
 $stmt->close();
 
+// Calcular totales de boucher y cheque del corte abierto
+$sqlNoEf = "SELECT
+    SUM(CASE WHEN t.tipo_pago='boucher' THEN t.total ELSE 0 END) AS total_boucher,
+    SUM(CASE WHEN t.tipo_pago='cheque'  THEN t.total ELSE 0 END) AS total_cheque
+FROM tickets t
+JOIN ventas v ON v.id = t.venta_id
+WHERE v.estatus = 'cerrada'
+  AND v.corte_id IS NULL
+  AND t.fecha >= ?
+  AND v.usuario_id = ?";
+
+$stmtNoEf = $conn->prepare($sqlNoEf);
+if (!$stmtNoEf) {
+    error('Error al calcular totales de no efectivo: ' . $conn->error);
+}
+$stmtNoEf->bind_param('si', $fecha_inicio, $usuario_id);
+$stmtNoEf->execute();
+$totNoEf = $stmtNoEf->get_result()->fetch_assoc();
+$stmtNoEf->close();
+
+$totalBoucher = (float)($totNoEf['total_boucher'] ?? 0);
+$totalCheque  = (float)($totNoEf['total_cheque'] ?? 0);
+
+// Registrar boucher y cheque en desglose_corte
+$insNe = $conn->prepare('INSERT INTO desglose_corte (corte_id, denominacion, cantidad, tipo_pago, denominacion_id) VALUES (?, ?, ?, ?, ?)');
+if (!$insNe) {
+    error('Error al preparar inserción de no efectivo: ' . $conn->error);
+}
+$den = 1.00;
+$cant = $totalBoucher;
+$tipo = 'boucher';
+$denId = 12;
+$insNe->bind_param('iddsi', $corte_id, $den, $cant, $tipo, $denId);
+if (!$insNe->execute()) {
+    $insNe->close();
+    error('Error al guardar boucher: ' . $insNe->error);
+}
+$cant = $totalCheque;
+$tipo = 'cheque';
+$denId = 13;
+if (!$insNe->execute()) {
+    $insNe->close();
+    error('Error al guardar cheque: ' . $insNe->error);
+}
+$insNe->close();
+
 // Calcular total de ventas del periodo
 $fecha_fin = date('Y-m-d H:i:s');
 // Total de ventas (sin propinas)

--- a/api/corte_caja/guardar_desglose.php
+++ b/api/corte_caja/guardar_desglose.php
@@ -44,33 +44,21 @@ $totales = [
 $filasValidas = [];
 foreach ($detalle as $fila) {
     $tipo = $fila['tipo_pago'] ?? 'efectivo';
-    if ($tipo === 'efectivo') {
-        $id = (int)($fila['denominacion_id'] ?? 0);
-        $cantidad = (int)($fila['cantidad'] ?? 0);
-        if ($cantidad <= 0) {
-            continue;
-        }
-        if (!$id || !isset($catalogo[$id])) {
-            error('Selecciona una denominación válida en todas las filas de efectivo');
-        }
-        $valor = $catalogo[$id];
-        $totales['efectivo'] += $valor * $cantidad;
-        $filasValidas[] = [$valor, $cantidad, $tipo, $id];
-    } else {
-        $monto = (float)($fila['cantidad'] ?? 0);
-        if ($monto <= 0) {
-            continue;
-        }
-        $id = isset($fila['denominacion_id']) ? (int)$fila['denominacion_id'] : 0;
-        $totales[$tipo] += $monto;
-        if ($id && isset($catalogo[$id])) {
-            $valor = $catalogo[$id];
-            $filasValidas[] = [$valor, $monto, $tipo, $id];
-        } else {
-            // Compatibilidad con llamadas anteriores sin denominacion_id
-            $filasValidas[] = [$monto, 1, $tipo, null];
-        }
+    if ($tipo !== 'efectivo') {
+        // Los montos no efectivos se calculan automáticamente al cerrar
+        continue;
     }
+    $id = (int)($fila['denominacion_id'] ?? 0);
+    $cantidad = (int)($fila['cantidad'] ?? 0);
+    if ($cantidad <= 0) {
+        continue;
+    }
+    if (!$id || !isset($catalogo[$id])) {
+        error('Selecciona una denominación válida en todas las filas de efectivo');
+    }
+    $valor = $catalogo[$id];
+    $totales['efectivo'] += $valor * $cantidad;
+    $filasValidas[] = [$valor, $cantidad, $tipo, $id];
 }
 
 if (!$filasValidas) {
@@ -96,6 +84,6 @@ foreach ($filasValidas as $f) {
 $ins->close();
 $conn->commit();
 
-$totalGeneral = $totales['efectivo'] + $totales['boucher'] + $totales['cheque'];
+$totalGeneral = $totales['efectivo'];
 success(['totales' => $totales, 'total_general' => $totalGeneral]);
 ?>

--- a/api/corte_caja/totales_no_efectivo.php
+++ b/api/corte_caja/totales_no_efectivo.php
@@ -1,0 +1,39 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+require_once __DIR__ . '/../../config/db.php';
+
+if (!isset($_SESSION['usuario_id'])) {
+    echo json_encode([
+        'success' => false,
+        'mensaje' => 'Sesión no iniciada'
+    ]);
+    exit;
+}
+
+$usuario_id = (int)$_SESSION['usuario_id'];
+
+$sql = "SELECT
+    SUM(CASE WHEN t.tipo_pago='boucher' THEN t.total ELSE 0 END) AS total_boucher,
+    SUM(CASE WHEN t.tipo_pago='cheque'  THEN t.total ELSE 0 END) AS total_cheque
+FROM tickets t
+JOIN ventas v   ON v.id = t.venta_id
+JOIN corte_caja c ON c.usuario_id = ? AND c.fecha_fin IS NULL
+WHERE v.estatus = 'cerrada'
+  AND v.corte_id IS NULL
+  AND t.fecha >= c.fecha_inicio";
+
+$stmt = $conn->prepare($sql);
+$stmt->bind_param('i', $usuario_id);
+$stmt->execute();
+$res = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+
+$boucher = (float)($res['total_boucher'] ?? 0);
+$cheque  = (float)($res['total_cheque'] ?? 0);
+
+echo json_encode([
+    'success' => true,
+    'boucher' => $boucher,
+    'cheque'  => $cheque
+]);

--- a/vistas/corte_caja/corte.js
+++ b/vistas/corte_caja/corte.js
@@ -150,8 +150,18 @@ async function abrirModalDesglose(corteId, dataApi) {
     const totalFinal = parseFloat(dataApi.totalFinal) || 0;
     const totalAEntregar = parseFloat(dataApi.totalAEntregar) || 0;
 
-    const montoBoucher = resumen.boucher ? (parseFloat(resumen.boucher.total) || 0) : 0;
-    const montoCheque = resumen.cheque ? (parseFloat(resumen.cheque.total) || 0) : 0;
+    let montoBoucher = 0;
+    let montoCheque = 0;
+    try {
+        const respNE = await fetch('../../api/corte_caja/totales_no_efectivo.php');
+        const dataNE = await respNE.json();
+        if (dataNE.success) {
+            montoBoucher = parseFloat(dataNE.boucher) || 0;
+            montoCheque  = parseFloat(dataNE.cheque) || 0;
+        }
+    } catch (e) {
+        console.error('No se pudo precargar boucher/cheque', e);
+    }
 
     const modal = document.getElementById('modalDesglose');
     let html = '<div style="background:#fff;border:1px solid #333;padding:10px;">';
@@ -190,42 +200,25 @@ async function abrirModalDesglose(corteId, dataApi) {
         frag.appendChild(div);
     });
 
-    const divBoucher = document.createElement('div');
-    divBoucher.className = 'grupo-pago';
-    divBoucher.dataset.tipo = 'boucher';
-    divBoucher.innerHTML = `<label>Boucher</label>` +
-        `<input type="number" class="cantidad" data-valor="1" data-tipo="boucher" min="0" step="0.01" value="${montoBoucher.toFixed(2)}">` +
-        `<span class="subtotal">$${montoBoucher.toFixed(2)}</span>`;
-    frag.appendChild(divBoucher);
-
-    const divCheque = document.createElement('div');
-    divCheque.className = 'grupo-pago';
-    divCheque.dataset.tipo = 'cheque';
-    divCheque.innerHTML = `<label>Cheque</label>` +
-        `<input type="number" class="cantidad" data-valor="1" data-tipo="cheque" min="0" step="0.01" value="${montoCheque.toFixed(2)}">` +
-        `<span class="subtotal">$${montoCheque.toFixed(2)}</span>`;
-    frag.appendChild(divCheque);
-
     cont.appendChild(frag);
 
     function calcular() {
-        const totales = { efectivo: 0, boucher: 0, cheque: 0 };
+        let totalEfectivo = 0;
         cont.querySelectorAll('.grupo-pago').forEach(gr => {
             const inp = gr.querySelector('.cantidad');
-            const tipo = inp.dataset.tipo;
             const valor = parseFloat(inp.dataset.valor) || 0;
             const cantidad = parseFloat(inp.value) || 0;
-            const subtotal = tipo === 'efectivo' ? valor * cantidad : cantidad;
+            const subtotal = valor * cantidad;
             gr.querySelector('.subtotal').textContent = `$${subtotal.toFixed(2)}`;
-            totales[tipo] += subtotal;
+            totalEfectivo += subtotal;
         });
-        document.getElementById('totalEfectivo').textContent = totales.efectivo.toFixed(2);
-        document.getElementById('totalBoucher').textContent = totales.boucher.toFixed(2);
-        document.getElementById('totalCheque').textContent = totales.cheque.toFixed(2);
-        const totalGeneral = totales.efectivo + totales.boucher + totales.cheque;
+        document.getElementById('totalEfectivo').textContent = totalEfectivo.toFixed(2);
+        document.getElementById('totalBoucher').textContent = montoBoucher.toFixed(2);
+        document.getElementById('totalCheque').textContent = montoCheque.toFixed(2);
+        const totalGeneral = totalEfectivo + montoBoucher + montoCheque;
         document.getElementById('totalDesglose').textContent = totalGeneral.toFixed(2);
         document.getElementById('difDesglose').textContent = (totalGeneral - totalFinal).toFixed(2);
-        document.getElementById('difEfectivo').textContent = (totalAEntregar - totales.efectivo).toFixed(2);
+        document.getElementById('difEfectivo').textContent = (totalAEntregar - totalEfectivo).toFixed(2);
     }
 
     modal.querySelectorAll('.cantidad').forEach(inp => inp.addEventListener('input', calcular));
@@ -241,23 +234,14 @@ async function abrirModalDesglose(corteId, dataApi) {
         const detalle = [];
         cont.querySelectorAll('.grupo-pago').forEach(gr => {
             const inp = gr.querySelector('.cantidad');
-            const tipo = inp.dataset.tipo;
             const cantidad = parseFloat(inp.value) || 0;
             if (cantidad <= 0) return;
-            if (tipo === 'efectivo') {
-                detalle.push({
-                    denominacion_id: parseInt(inp.dataset.id, 10),
-                    cantidad: parseInt(cantidad, 10),
-                    tipo_pago: tipo,
-                    denominacion: parseFloat(inp.dataset.valor)
-                });
-            } else {
-                detalle.push({
-                    cantidad,
-                    tipo_pago: tipo,
-                    denominacion: cantidad
-                });
-            }
+            detalle.push({
+                denominacion_id: parseInt(inp.dataset.id, 10),
+                cantidad: parseInt(cantidad, 10),
+                tipo_pago: 'efectivo',
+                denominacion: parseFloat(inp.dataset.valor)
+            });
         });
         if (!detalle.length) {
             alert('Ingresa al menos una cantidad mayor a cero');


### PR DESCRIPTION
## Summary
- Add endpoint to compute non-cash totals for current shift
- Auto-store boucher and cheque totals on cash closing, ignoring client edits
- Hide and disable boucher/cheque inputs in close modal and preload values

## Testing
- `php -l api/corte_caja/totales_no_efectivo.php`
- `php -l api/corte_caja/guardar_desglose.php`
- `php -l api/corte_caja/cerrar_corte.php`
- `node --check vistas/corte_caja/corte.js`


------
https://chatgpt.com/codex/tasks/task_e_68992e012f9c832bb9a78adce3da7755