### PR TITLE
Evitar abrir nueva pestaña al imprimir tickets y redirigir a ventas

### DIFF
--- a/vistas/ventas/ticket.js
+++ b/vistas/ventas/ticket.js
@@ -45,18 +45,29 @@ function llenarTicket(data) {
         document.getElementById('totalLetras').textContent = data.total_letras || '';
     }
 
+function redirDespuesImprimir() {
+        const redir = () => {
+            window.onafterprint = null;
+            window.location.href = 'ventas.php';
+        };
+        window.onafterprint = redir;
+        let fallbackTimer = setTimeout(redir, 8000);
+        const mql = window.matchMedia('print');
+        const mmListener = (e) => {
+            if (!e.matches) {
+                mql.removeListener(mmListener);
+                clearTimeout(fallbackTimer);
+                redir();
+            }
+        };
+        if (mql && mql.addListener) {
+            mql.addListener(mmListener);
+        }
+}
+
 function imprimirTicket() {
-        const ticketContainer = document.getElementById('ticketContainer');
-        if (!ticketContainer) return;
-        const ticketContent = ticketContainer.innerHTML;
-        const printWindow = window.open('', '', 'width=400,height=600');
-        printWindow.document.write('<html><head><title>Imprimir Ticket</title>');
-        printWindow.document.write('<link rel="stylesheet" href="../../utils/css/style.css">');
-        printWindow.document.write('</head><body>');
-        printWindow.document.write(ticketContent);
-        printWindow.document.write('</body></html>');
-        printWindow.document.close();
-        printWindow.print();
+        redirDespuesImprimir();
+        window.print();
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -448,10 +459,19 @@ document.addEventListener('DOMContentLoaded', async () => {
             tickets.forEach(t => {
                 html += generarTicketHTML(t) + '<hr>';
             });
-            html += '<script>window.onload=function(){window.print();}</script></body></html>';
+            html += `<script>
+function redir(){window.onafterprint=null;if(window.opener){window.opener.location.href='ventas.php';}window.close();}
+window.onafterprint=redir;
+let fallbackTimer=setTimeout(redir,8000);
+const mql=window.matchMedia('print');
+const mmListener=(e)=>{if(!e.matches){mql.removeListener(mmListener);clearTimeout(fallbackTimer);redir();}};
+if(mql&&mql.addListener){mql.addListener(mmListener);}
+window.onload=function(){window.print();};
+</script></body></html>`;
             const blob = new Blob([html], { type: 'text/html' });
             const url = URL.createObjectURL(blob);
-            window.open(url, '_blank');
+            const w = window.open(url, '_blank');
+            if (w) w.focus();
         } catch (err) {
             console.error('Error al imprimir tickets', err);
         }

--- a/vistas/ventas/ticket.php
+++ b/vistas/ventas/ticket.php
@@ -42,8 +42,8 @@ ob_start();
             <tbody></tbody>
         </table>
     </div>
-    <button id="agregarSub" class="btn custom-btn">Agregar subcuenta</button>
-    <button id="btnGuardarTicket" class="btn custom-btn">Guardar e imprimir Tickets</button>
+    <button id="agregarSub" class="btn custom-btn" type="button">Agregar subcuenta</button>
+    <button id="btnGuardarTicket" class="btn custom-btn" type="button">Guardar e imprimir Tickets</button>
     <div id="subcuentas"></div>
     <div id="teclado" class="mt-3"></div>
 </div>
@@ -84,7 +84,7 @@ ob_start();
         <div id="totalLetras"></div>
         <p>Gracias por su compra</p>
     </div>
-    <button id="btnImprimir" class="btn custom-btn">Imprimir</button>
+    <button id="btnImprimir" class="btn custom-btn" type="button">Imprimir</button>
 </div>
 
 


### PR DESCRIPTION
## Summary
- Cambiada la lógica de impresión en ventas para navegar a `ticket.php?venta=` en la misma ventana.
- Ajustado ticket.js para redirigir a `ventas.php` tras imprimir usando `onafterprint` y temporizador de respaldo.
- Asegurados botones de ticket.php para evitar submits accidentales.

## Testing
- `php -l vistas/ventas/ticket.php`
- `php -l vistas/ventas/ventas.php`
- `node --check vistas/ventas/ventas.js`
- `node --check vistas/ventas/ticket.js`


------
https://chatgpt.com/codex/tasks/task_e_68997b929f6c832bbbcb5cfac174ad10