### PR TITLE
feat: add cash register movements

### DIFF
--- a/api/corte_caja/movimiento_caja.php
+++ b/api/corte_caja/movimiento_caja.php
@@ -1,0 +1,65 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../config/db.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false, 'error' => 'Método no permitido']);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+$tipo   = $input['tipo_movimiento'] ?? '';
+$monto  = isset($input['monto']) ? (float)$input['monto'] : 0;
+$motivo = trim($input['motivo'] ?? '');
+
+if (!in_array($tipo, ['deposito', 'retiro'], true)) {
+    echo json_encode(['success' => false, 'error' => 'Tipo de movimiento inválido']);
+    exit;
+}
+if ($monto <= 0) {
+    echo json_encode(['success' => false, 'error' => 'El monto debe ser mayor a 0']);
+    exit;
+}
+if ($motivo === '') {
+    echo json_encode(['success' => false, 'error' => 'Motivo requerido']);
+    exit;
+}
+
+if (!isset($_SESSION['usuario_id'])) {
+    echo json_encode(['success' => false, 'error' => 'Sesión no iniciada']);
+    exit;
+}
+$usuario_id = (int)$_SESSION['usuario_id'];
+
+$stmt = $conn->prepare("SELECT id FROM corte_caja WHERE usuario_id = ? AND fecha_fin IS NULL ORDER BY id DESC LIMIT 1");
+if (!$stmt) {
+    echo json_encode(['success' => false, 'error' => 'Error al consultar corte: ' . $conn->error]);
+    exit;
+}
+$stmt->bind_param('i', $usuario_id);
+$stmt->execute();
+$res = $stmt->get_result();
+if ($row = $res->fetch_assoc()) {
+    $corte_id = (int)$row['id'];
+} else {
+    echo json_encode(['success' => false, 'error' => 'No hay corte abierto']);
+    $stmt->close();
+    exit;
+}
+$stmt->close();
+
+$fecha = date('Y-m-d H:i:s');
+$stmt = $conn->prepare("INSERT INTO movimientos_caja (corte_id, usuario_id, tipo_movimiento, monto, motivo, fecha) VALUES (?,?,?,?,?,?)");
+if (!$stmt) {
+    echo json_encode(['success' => false, 'error' => 'Error al preparar inserción: ' . $conn->error]);
+    exit;
+}
+$stmt->bind_param('iisdss', $corte_id, $usuario_id, $tipo, $monto, $motivo, $fecha);
+if ($stmt->execute()) {
+    echo json_encode(['success' => true, 'message' => 'Movimiento registrado correctamente']);
+} else {
+    echo json_encode(['success' => false, 'error' => 'Error al registrar movimiento: ' . $stmt->error]);
+}
+$stmt->close();

--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -118,6 +118,12 @@ ob_start();
   </div>
 </div>
 
+<!-- Botones de movimientos de caja -->
+<div class="container mt-3 mb-3 text-center">
+  <button id="btnDeposito" class="btn btn-success me-2">Depósito a caja</button>
+  <button id="btnRetiro" class="btn btn-danger">Retiro de caja</button>
+</div>
+
 <div class="container mt-5">
   <h2 class="section-header">Historial de Ventas</h2>
   <div class="mb-2 d-flex justify-content-between">
@@ -161,6 +167,45 @@ ob_start();
 <!-- Modales -->
 <div id="modal-detalles" class="custom-modal" style="display:none;"></div>
 <div id="modalDesglose" class="custom-modal" style="display:none;"></div>
+
+<!-- Modal Movimiento de Caja -->
+<div class="modal fade" id="modalMovimientoCaja" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Movimiento de caja</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="formMovimientoCaja">
+          <div class="mb-3">
+            <label for="tipoMovimiento" class="form-label">Tipo de movimiento</label>
+            <select id="tipoMovimiento" class="form-select">
+              <option value="deposito">Depósito</option>
+              <option value="retiro">Retiro</option>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label for="montoMovimiento" class="form-label">Monto</label>
+            <input type="number" step="0.01" class="form-control" id="montoMovimiento" required>
+          </div>
+          <div class="mb-3">
+            <label for="motivoMovimiento" class="form-label">Motivo</label>
+            <textarea id="motivoMovimiento" class="form-control" required></textarea>
+          </div>
+          <div class="mb-3">
+            <label for="fechaMovimiento" class="form-label">Fecha</label>
+            <input type="text" class="form-control" id="fechaMovimiento" readonly>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="button" class="btn btn-primary" id="guardarMovimiento">Guardar</button>
+      </div>
+    </div>
+  </div>
+</div>
 
 
   <?php require_once __DIR__ . '/../footer.php'; ?>


### PR DESCRIPTION
## Summary
- add deposit and withdrawal buttons with modal on sales view
- handle cash movement registration via JS
- create API endpoint to persist cash register movements

## Testing
- `php -l vistas/ventas/ventas.php`
- `php -l api/corte_caja/movimiento_caja.php`


------
https://chatgpt.com/codex/tasks/task_e_689ab7013d20832b9cc77ca11da1f210