### PR TITLE
Add temporary cash cut functionality

### DIFF
--- a/api/corte_caja/guardar_corte_temporal.php
+++ b/api/corte_caja/guardar_corte_temporal.php
@@ -1,0 +1,29 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+require_once __DIR__ . '/../../config/db.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+$corte_id = isset($input['corte_id']) ? (int)$input['corte_id'] : 0;
+$usuario_id = $_SESSION['usuario_id'] ?? 0;
+$total = isset($input['total']) ? (float)$input['total'] : 0;
+$observaciones = $input['observaciones'] ?? '';
+$datos_json = json_encode($input['datos_json'] ?? [], JSON_UNESCAPED_UNICODE);
+
+if ($corte_id <= 0 || $usuario_id <= 0) {
+    echo json_encode(['success' => false, 'message' => 'Datos incompletos']);
+    exit;
+}
+
+$stmt = $conn->prepare('INSERT INTO corte_caja_historial (corte_id, usuario_id, total, observaciones, datos_json) VALUES (?, ?, ?, ?, ?)');
+if ($stmt) {
+    $stmt->bind_param('iidss', $corte_id, $usuario_id, $total, $observaciones, $datos_json);
+    if ($stmt->execute()) {
+        echo json_encode(['success' => true, 'id' => $conn->insert_id]);
+    } else {
+        echo json_encode(['success' => false, 'message' => 'Error al guardar']);
+    }
+    $stmt->close();
+} else {
+    echo json_encode(['success' => false, 'message' => 'Error al preparar sentencia']);
+}

--- a/vistas/corte_caja/corte.php
+++ b/vistas/corte_caja/corte.php
@@ -38,6 +38,21 @@ ob_start();
 <div id="resumenModal" class="custom-modal" style="display:none;"></div>
 <div id="modalDesglose" class="custom-modal" style="display:none;"></div>
 
+<!-- Modal Corte Temporal -->
+<div id="modalCorteTemporal" class="custom-modal" style="display:none;">
+  <div class="modal-content">
+    <span id="closeCorteTemporal" class="close">&times;</span>
+    <h2>Corte Temporal</h2>
+    <div id="corteTemporalDatos" style="max-height:300px;overflow:auto;"></div>
+    <div>
+      <label>Observaciones:</label>
+      <textarea id="corteTemporalObservaciones" class="form-control"></textarea>
+    </div>
+    <br>
+    <button id="guardarCorteTemporal" class="btn custom-btn btn-success">Guardar Corte Temporal</button>
+  </div>
+</div>
+
 <!-- Modal para detalle de corte -->
 <div class="modal fade" id="modalDetalle" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog" role="document">

--- a/vistas/corte_caja/ticket_corte_temporal.php
+++ b/vistas/corte_caja/ticket_corte_temporal.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if ($id <= 0) {
+    echo 'ID inválido';
+    exit;
+}
+$stmt = $conn->prepare('SELECT datos_json FROM corte_caja_historial WHERE id = ?');
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$res = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+$datos = json_decode($res['datos_json'] ?? '{}', true);
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Ticket Corte Temporal</title>
+<style>
+body { font-family: monospace; }
+ul { list-style: none; padding: 0; }
+</style>
+</head>
+<body>
+<h2>Corte Temporal</h2>
+<ul>
+<?php foreach ($datos as $k => $v) {
+    if (!is_array($v)) {
+        echo '<li><strong>' . htmlspecialchars($k) . ':</strong> ' . htmlspecialchars((string)$v) . '</li>';
+    }
+} ?>
+</ul>
+<script>
+window.print();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Corte Temporal modal and button in cash cut view
- implement JS logic to fetch summary and save temporary cut
- create API and ticket view for temporary cut

## Testing
- `php -l api/corte_caja/guardar_corte_temporal.php`
- `php -l vistas/corte_caja/corte.php`
- `php -l vistas/corte_caja/ticket_corte_temporal.php`
- `node --check vistas/corte_caja/corte.js`


------
https://chatgpt.com/codex/tasks/task_e_689acb029154832ba00f140c9643b375