### PR TITLE
Imprimir desglose de corte en nueva ventana

### DIFF
--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -399,6 +399,8 @@ function mostrarModalDesglose(dataApi) {
             });
             const data = await resp.json();
             if (data.success) {
+                // Imprimir resumen y desglose en nueva ventana
+                imprimirResumenDesglose(r, detalle);
                 modal.style.display = 'none';
                 await finalizarCorte();
             } else {
@@ -409,6 +411,24 @@ function mostrarModalDesglose(dataApi) {
             alert('Error al guardar desglose');
         }
     });
+}
+
+function imprimirResumenDesglose(resumen, desglose) {
+    const data = { ...resumen, desglose };
+    const html = '<pre>' + JSON.stringify(data, null, 2) + '</pre>';
+    const cont = document.getElementById('printResumenDesglose');
+    if (cont) {
+        cont.innerHTML = html;
+    }
+    const win = window.open('', '_blank');
+    if (win) {
+        win.document.write(html);
+        win.document.close();
+        win.focus();
+        win.print();
+    } else {
+        console.error('No fue posible abrir ventana para impresión');
+    }
 }
 
 async function finalizarCorte() {

--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -167,6 +167,8 @@ ob_start();
 <!-- Modales -->
 <div id="modal-detalles" class="custom-modal" style="display:none;"></div>
 <div id="modalDesglose" class="custom-modal" style="display:none;"></div>
+<!-- Contenedor oculto para impresión del corte con desglose -->
+<div id="printResumenDesglose" style="display:none;"></div>
 
 <!-- Modal Movimiento de Caja -->
 <div class="modal fade" id="modalMovimientoCaja" tabindex="-1" aria-hidden="true">


### PR DESCRIPTION
## Summary
- Imprime en una ventana separada el resumen del corte junto con su desglose
- Añade contenedor oculto para almacenar la información a imprimir

## Testing
- `php -l vistas/ventas/ventas.php`
- `node --check vistas/ventas/ventas.js`


------
https://chatgpt.com/codex/tasks/task_e_689acd5d0570832b88820d4627a5339c