### PR TITLE
Add temporary cut feature

### DIFF
--- a/api/corte_caja/guardar_corte_temporal.php
+++ b/api/corte_caja/guardar_corte_temporal.php
@@ -1,0 +1,30 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+require_once '../../config/db.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    echo json_encode(['success' => false, 'message' => 'Datos inválidos']);
+    exit;
+}
+
+$corte_id     = isset($input['corte_id']) ? (int)$input['corte_id'] : 0;
+$usuario_id   = isset($input['usuario_id']) ? (int)$input['usuario_id'] : 0;
+$total        = isset($input['total']) ? (float)$input['total'] : 0;
+$observaciones = $input['observaciones'] ?? '';
+$datos_json    = $input['datos_json'] ?? '';
+
+$stmt = $conn->prepare('INSERT INTO corte_caja_historial (corte_id, usuario_id, total, observaciones, datos_json) VALUES (?, ?, ?, ?, ?)');
+if (!$stmt) {
+    echo json_encode(['success' => false, 'message' => $conn->error]);
+    exit;
+}
+$stmt->bind_param('iidss', $corte_id, $usuario_id, $total, $observaciones, $datos_json);
+if ($stmt->execute()) {
+    echo json_encode(['success' => true, 'id' => $stmt->insert_id]);
+} else {
+    echo json_encode(['success' => false, 'message' => $stmt->error]);
+}
+$stmt->close();
+?>

--- a/vistas/corte_caja/imprimir_corte_temporal.php
+++ b/vistas/corte_caja/imprimir_corte_temporal.php
@@ -1,0 +1,39 @@
+<?php
+header('Content-Type: text/html; charset=utf-8');
+$datos = [];
+if (isset($_GET['datos'])) {
+    $json = $_GET['datos'];
+    $datos = json_decode($json, true);
+    if (!is_array($datos)) {
+        $datos = [];
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="utf-8" />
+<title>Corte Temporal</title>
+<style>
+    table { border-collapse: collapse; width: 100%; }
+    td, th { border: 1px solid #000; padding: 4px; }
+</style>
+</head>
+<body onload="window.print()">
+<h2>Corte Temporal</h2>
+<table>
+<tbody>
+<?php foreach ($datos as $k => $v): ?>
+    <?php if (is_array($v)): ?>
+        <tr><th colspan="2"><?php echo htmlspecialchars($k); ?></th></tr>
+        <?php foreach ($v as $k2 => $v2): ?>
+            <tr><td><?php echo htmlspecialchars($k2); ?></td><td><?php echo htmlspecialchars(is_array($v2) ? json_encode($v2) : $v2); ?></td></tr>
+        <?php endforeach; ?>
+    <?php else: ?>
+        <tr><td><?php echo htmlspecialchars($k); ?></td><td><?php echo htmlspecialchars($v); ?></td></tr>
+    <?php endif; ?>
+<?php endforeach; ?>
+</tbody>
+</table>
+</body>
+</html>

--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -167,6 +167,18 @@ ob_start();
 <!-- Modales -->
 <div id="modal-detalles" class="custom-modal" style="display:none;"></div>
 <div id="modalDesglose" class="custom-modal" style="display:none;"></div>
+<!-- Modal Corte Temporal -->
+<div id="modalCorteTemporal" class="custom-modal" style="display:none;">
+  <div class="modal-content">
+    <span id="closeModalCorteTemporal" class="close">&times;</span>
+    <h2>Corte Temporal</h2>
+    <div id="corteTemporalDatos"></div>
+    <label for="observacionesCorteTemp">Observaciones:</label>
+    <textarea id="observacionesCorteTemp" rows="3" style="width:100%;"></textarea>
+    <br><br>
+    <button id="guardarCorteTemporal" class="btn btn-success">Guardar Corte Temporal</button>
+  </div>
+</div>
 <!-- Contenedor oculto para impresión del corte con desglose -->
 <div id="printResumenDesglose" style="display:none;"></div>
 


### PR DESCRIPTION
## Summary
- add modal and button to trigger temporary cut
- implement frontend logic to fetch, save, and print temporary cut
- create API and print view for temporary cut persistence

## Testing
- `php -l api/corte_caja/guardar_corte_temporal.php`
- `php -l vistas/ventas/ventas.php`
- `php -l vistas/corte_caja/imprimir_corte_temporal.php`
- `node --check vistas/ventas/ventas.js`


------
https://chatgpt.com/codex/tasks/task_e_689ad0a07684832bb8a7b0724330a675