### PR TITLE
Track delivery time for sold products

### DIFF
--- a/api/cocina/cambiar_estado_producto.php
+++ b/api/cocina/cambiar_estado_producto.php
@@ -56,7 +56,11 @@ if (!isset($transiciones[$actual]) || $transiciones[$actual] !== $nuevo_estado) 
 
 // La actualización del estado ya no depende de triggers o procedimientos
 // almacenados. Todo se realiza directamente desde PHP.
-$upd = $conn->prepare('UPDATE venta_detalles SET estado_producto = ? WHERE id = ?');
+if ($nuevo_estado === 'entregado') {
+    $upd = $conn->prepare("UPDATE venta_detalles SET estado_producto = ?, entregado_hr = IF(entregado_hr IS NULL, NOW(), entregado_hr) WHERE id = ?");
+} else {
+    $upd = $conn->prepare('UPDATE venta_detalles SET estado_producto = ? WHERE id = ?');
+}
 if (!$upd) {
     error('Error al preparar actualización: ' . $conn->error);
 }

--- a/api/cocina/listar_entregados.php
+++ b/api/cocina/listar_entregados.php
@@ -11,6 +11,8 @@ $query = "SELECT
             p.nombre AS producto,
             d.cantidad,
             d.created_at,
+            d.entregado_hr,
+            d.estado_producto,
             d.id AS detalle_id
           FROM venta_detalles d
           JOIN ventas v ON v.id = d.venta_id
@@ -28,12 +30,14 @@ if (!$result) {
 $entregados = [];
 while ($row = $result->fetch_assoc()) {
     $entregados[] = [
-        'destino'    => $row['destino'],
-        'tipo'       => $row['tipo_entrega'],
-        'producto'   => $row['producto'],
-        'cantidad'   => (int) $row['cantidad'],
-        'hora'       => $row['created_at'],
-        'detalle_id' => (int) $row['detalle_id']
+        'destino'      => $row['destino'],
+        'tipo'         => $row['tipo_entrega'],
+        'producto'     => $row['producto'],
+        'cantidad'     => (int) $row['cantidad'],
+        'hora'         => $row['entregado_hr'],
+        'entregado_hr' => $row['entregado_hr'],
+        'estado'       => $row['estado_producto'],
+        'detalle_id'   => (int) $row['detalle_id']
     ];
 }
 

--- a/api/cocina/listar_pendientes.php
+++ b/api/cocina/listar_pendientes.php
@@ -11,6 +11,7 @@ $query = "SELECT
             p.nombre AS producto,
             d.cantidad,
             d.created_at,
+            d.entregado_hr,
             d.estado_producto,
             d.observaciones,
             d.id AS detalle_id
@@ -33,6 +34,7 @@ while ($row = $result->fetch_assoc()) {
         'producto'      => $row['producto'],
         'cantidad'      => (int) $row['cantidad'],
         'hora'          => $row['created_at'],
+        'entregado_hr'  => $row['entregado_hr'],
         'estado'        => $row['estado_producto'],
         'observaciones' => $row['observaciones'],
         'detalle_id'    => (int) $row['detalle_id']

--- a/api/mesas/detalle_venta.php
+++ b/api/mesas/detalle_venta.php
@@ -36,7 +36,8 @@ $info->close();
 $stmt = $conn->prepare(
     'SELECT vd.id, p.nombre, vd.cantidad, vd.precio_unitario,
             (vd.cantidad * vd.precio_unitario) AS subtotal,
-            vd.estado_producto
+            vd.estado_producto,
+            vd.entregado_hr
      FROM venta_detalles vd
      JOIN productos p ON vd.producto_id = p.id
      WHERE vd.venta_id = ?'

--- a/api/mesas/marcar_entregado.php
+++ b/api/mesas/marcar_entregado.php
@@ -34,7 +34,7 @@ if (!$detalle) {
     error('Detalle no encontrado');
 }
 
-$upd = $conn->prepare("UPDATE venta_detalles SET estado_producto = 'entregado' WHERE id = ?");
+$upd = $conn->prepare("UPDATE venta_detalles SET estado_producto = 'entregado', entregado_hr = IF(entregado_hr IS NULL, NOW(), entregado_hr) WHERE id = ?");
 if (!$upd) {
     error('Error al preparar actualización: ' . $conn->error);
 }

--- a/api/ventas/cambiar_estado_producto.php
+++ b/api/ventas/cambiar_estado_producto.php
@@ -19,7 +19,11 @@ if (!in_array($estado, $permitidos, true)) {
     error('Estado no permitido');
 }
 
-$stmt = $conn->prepare('UPDATE venta_detalles SET estado_producto = ? WHERE id = ?');
+if ($estado === 'entregado') {
+    $stmt = $conn->prepare("UPDATE venta_detalles SET estado_producto = ?, entregado_hr = IF(entregado_hr IS NULL, NOW(), entregado_hr) WHERE id = ?");
+} else {
+    $stmt = $conn->prepare('UPDATE venta_detalles SET estado_producto = ? WHERE id = ?');
+}
 if (!$stmt) {
     error('Error al preparar actualización: ' . $conn->error);
 }

--- a/api/ventas/detalle_venta.php
+++ b/api/ventas/detalle_venta.php
@@ -42,7 +42,7 @@ $info->close();
 
 $stmt = $conn->prepare(
     'SELECT vd.id, vd.producto_id, p.nombre, vd.cantidad, vd.precio_unitario, ' .
-    '(vd.cantidad * vd.precio_unitario) AS subtotal, vd.estado_producto ' .
+    '(vd.cantidad * vd.precio_unitario) AS subtotal, vd.estado_producto, vd.entregado_hr ' .
     'FROM venta_detalles vd ' .
     'JOIN productos p ON vd.producto_id = p.id ' .
     'WHERE vd.venta_id = ?'

--- a/vistas/cocina/cocina.js
+++ b/vistas/cocina/cocina.js
@@ -88,7 +88,7 @@ async function cargarEntregados() {
                     contCards.appendChild(header);
                     grupo = p.destino;
                 }
-                const t = tiempoTranscurrido(p.hora);
+                const t = tiempoTranscurrido(p.entregado_hr);
                 const card = document.createElement('div');
                 card.className = 'menu-item';
                 card.innerHTML = `

--- a/vistas/cocina/cocina2.js
+++ b/vistas/cocina/cocina2.js
@@ -42,7 +42,7 @@
         <div class='title'>${it.producto} <small>x${it.cantidad}</small></div>
         <div class='meta'>
           <span>${it.destino}</span>
-          <span>${formatHora(it.hora)}</span>
+          <span>${formatHora(it.estado === 'entregado' ? it.entregado_hr : it.hora)}</span>
           ${it.observaciones ? `<span>Obs: ${escapeHtml(it.observaciones)}</span>` : ''}
         </div>
       `;

--- a/vistas/mesas/kanbanMesas.js
+++ b/vistas/mesas/kanbanMesas.js
@@ -278,7 +278,7 @@ function cerrarModal() {
 function mostrarModalDetalle(datos, ventaId, mesaId, estado, meseroId) {
     const modal = document.getElementById('modal-detalle');
     let html = `<h3>Mesa ${datos.mesa} - Venta ${ventaId || ''}</h3>`;
-    html += `<table border="1"><thead><tr><th>Producto</th><th>Cantidad</th><th>Precio</th><th>Subtotal</th><th>Estatus</th><th></th><th></th></tr></thead><tbody>`;
+    html += `<table border="1"><thead><tr><th>Producto</th><th>Cantidad</th><th>Precio</th><th>Subtotal</th><th>Estatus</th><th>Hora entrega</th><th></th><th></th></tr></thead><tbody>`;
     datos.productos.forEach(p => {
         const est = p.estado_producto;
         const btnEliminar = (est !== 'en_preparacion' && est !== 'entregado')
@@ -288,7 +288,8 @@ function mostrarModalDetalle(datos, ventaId, mesaId, estado, meseroId) {
         const btnEntregar = est !== 'entregado'
             ? `<button class="entregar" data-id="${p.id}" ${puedeEntregar ? '' : 'disabled'}>Marcar como entregado</button>`
             : '';
-        html += `<tr><td>${p.nombre}</td><td>${p.cantidad}</td><td>${p.precio_unitario}</td><td>${p.subtotal}</td><td>${textoEstado(est)}</td><td>${btnEliminar}</td><td>${btnEntregar}</td></tr>`;
+        const hora = p.entregado_hr ? p.entregado_hr : '';
+        html += `<tr><td>${p.nombre}</td><td>${p.cantidad}</td><td>${p.precio_unitario}</td><td>${p.subtotal}</td><td>${textoEstado(est)}</td><td>${hora}</td><td>${btnEliminar}</td><td>${btnEntregar}</td></tr>`;
     });
     html += `</tbody></table>`;
     html += `<h4>Mesero</h4>`;

--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -1260,7 +1260,7 @@ async function verDetalles(id) {
                     : 'Venta rápida';
             let html = `<h3>Detalle de venta</h3>
                         <p>Tipo: ${info.tipo_entrega}<br>Destino: ${destino}<br>Mesero: ${info.mesero}</p>`;
-            html += `<table border="1"><thead><tr><th>Producto</th><th>Cant</th><th>Precio</th><th>Subtotal</th><th>Estatus</th><th></th></tr></thead><tbody>`;
+            html += `<table border="1"><thead><tr><th>Producto</th><th>Cant</th><th>Precio</th><th>Subtotal</th><th>Estatus</th><th>Hora entrega</th><th></th></tr></thead><tbody>`;
             info.productos.forEach(p => {
                 const btnEliminar = p.estado_producto !== 'entregado'
                     ? `<button class="btn custom-btn delDetalle" data-id="${p.id}">Eliminar</button>`
@@ -1269,7 +1269,8 @@ async function verDetalles(id) {
                     ? ` <button class="btn btn-success btn-entregar" data-id="${p.id}">Entregar</button>`
                     : '';
                 const est = (p.estado_producto || '').replace('_', ' ');
-                html += `<tr><td>${p.nombre}</td><td>${p.cantidad}</td><td>${p.precio_unitario}</td><td>${p.subtotal}</td><td>${est}</td>` +
+                const hora = p.entregado_hr ? p.entregado_hr : '';
+                html += `<tr><td>${p.nombre}</td><td>${p.cantidad}</td><td>${p.precio_unitario}</td><td>${p.subtotal}</td><td>${est}</td><td>${hora}</td>` +
                         `<td>${btnEliminar}${btnEntregar}</td></tr>`;
             });
             html += `</tbody></table>`;


### PR DESCRIPTION
## Summary
- Record `entregado_hr` timestamp when marking a product as delivered
- Expose `entregado_hr` in sale detail and kitchen listing APIs and frontend views
- Show delivery time in mesa, cocina, and venta interfaces

## Testing
- `php -l api/mesas/marcar_entregado.php`
- `php -l api/cocina/cambiar_estado_producto.php`
- `php -l api/ventas/cambiar_estado_producto.php`
- `php -l api/cocina/listar_pendientes.php`
- `php -l api/cocina/listar_entregados.php`
- `php -l api/mesas/detalle_venta.php`
- `php -l api/ventas/detalle_venta.php`
- `node --check vistas/mesas/kanbanMesas.js`
- `node --check vistas/cocina/cocina.js`
- `node --check vistas/cocina/cocina2.js`
- `node --check vistas/ventas/ventas.js`


------
https://chatgpt.com/codex/tasks/task_e_689bf208597c832bb28073aecf92b39c