### PR TITLE
Normalize recipe modals

### DIFF
--- a/vistas/recetas/recetas.js
+++ b/vistas/recetas/recetas.js
@@ -291,26 +291,23 @@ async function subirImagenProducto() {
 }
 
 function abrirModalCopiar() {
-    const modal = document.getElementById('modal-copiar');
-    let html = '<h3>Copiar receta</h3>';
-    html += '<select id="producto_copiar"><option value="">--Selecciona--</option>';
+    const modal = document.getElementById('modalCopiarReceta');
+    const body = modal.querySelector('.modal-body');
+    const footer = modal.querySelector('.modal-footer');
+    let html = '<select id="producto_copiar" class="form-control"><option value="">--Selecciona--</option>';
     catalogoProductos.forEach(p => {
         html += `<option value="${p.id}">${p.nombre}</option>`;
     });
-    html += '</select> ';
-    html += '<button class="btn custom-btn" id="btnCopiarAhora">Copiar</button> ';
-    html += '<button class="btn custom-btn" id="cerrarCopiar">Cerrar</button>';
-    modal.innerHTML = html;
-    modal.style.display = 'block';
+    html += '</select>';
+    body.innerHTML = html;
+    footer.innerHTML = '<button class="btn custom-btn" id="btnCopiarAhora">Copiar</button> <button class="btn btn-secondary" data-dismiss="modal">Cerrar</button>';
+    showModal('#modalCopiarReceta');
     document.getElementById('btnCopiarAhora').addEventListener('click', () => {
         const id = parseInt(document.getElementById('producto_copiar').value);
         if (!isNaN(id)) {
             copiarReceta(id);
-            modal.style.display = 'none';
+            hideModal('#modalCopiarReceta');
         }
-    });
-    document.getElementById('cerrarCopiar').addEventListener('click', () => {
-        modal.style.display = 'none';
     });
 }
 

--- a/vistas/recetas/recetas.php
+++ b/vistas/recetas/recetas.php
@@ -77,11 +77,28 @@ ob_start();
     <button type="button" id="copiarReceta" class="btn btn-secondary">Copiar receta de otro producto</button>
   </div>
 
-  <div id="modal-copiar" style="display:none;"></div>
+  <!-- MODAL NORMALIZED 2025-08-14 -->
+  <div class="modal fade" id="modalCopiarReceta" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Copiar receta</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body"><!-- contenido dinámico --></div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 
 <?php require_once __DIR__ . '/../footer.php'; ?>
+<script src="../../utils/js/modal-lite.js"></script>
 <script src="recetas.js"></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- Standardize recipe copy modal to match sales pattern
- Include modal-lite utilities and show/hide modal via JS

## Testing
- `php -l vistas/recetas/recetas.php`
- `node --check vistas/recetas/recetas.js && echo "JS syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689e04baa870832b8141dd1224817157