### PR TITLE
Normaliza modales de repartos

### DIFF
--- a/vistas/repartidores/repartos.js
+++ b/vistas/repartidores/repartos.js
@@ -130,16 +130,15 @@ async function marcarEnCamino(id) {
 }
 
 function mostrarDetalle(info) {
-    const contenedor = document.getElementById('modal-detalles');
-    let html = `
-        <div class="container mt-5 mb-5 custom-modal">
-            <h3 style="color:#b80000;">Productos entregados</h3>
-            <ul style="list-style-type: none; padding: 0;">`;
-    
+    const modal = document.getElementById('modal-detalles');
+    const contenedor = modal.querySelector('.modal-body');
+    let html = `<h3 style="color:#b80000;">Productos entregados</h3>`;
+    html += `<ul style="list-style-type: none; padding: 0;">`;
+
     info.productos.forEach(p => {
         const sub = p.cantidad * p.precio_unitario;
-        html += `<li style="padding: 5px 0; border-bottom: 1px solid #ccc; ">
-                    <strong >${p.nombre}</strong> - ${p.cantidad} x $${p.precio_unitario.toFixed(2)} = $${sub.toFixed(2)}
+        html += `<li style="padding: 5px 0; border-bottom: 1px solid #ccc;">
+                    <strong>${p.nombre}</strong> - ${p.cantidad} x $${p.precio_unitario.toFixed(2)} = $${sub.toFixed(2)}
                  </li>`;
     });
 
@@ -150,23 +149,15 @@ function mostrarDetalle(info) {
 
     if (info.foto_entrega) {
         html += `<div style="margin-top: 15px;">
-                    <p >Evidencia:</p>
+                    <p>Evidencia:</p>
                     <img src="../../uploads/evidencias/${info.foto_entrega}" alt="Evidencia" style="max-width: 100%; height: auto; border: 1px solid #ccc;">
                  </div>`;
     }
 
-    html += `<p style="margin-top: 15px; "><strong >Total:</strong> $${info.total.toFixed(2)}</p>
-             <div style="text-align: right; margin-top: 20px;">
-                 <button class="btn custom-btn" id="cerrarDetalle">Cerrar</button>
-             </div>
-        </div>`;
-
+    html += `<p style="margin-top: 15px;"><strong>Total:</strong> $${info.total.toFixed(2)}</p>`;
     contenedor.innerHTML = html;
-    contenedor.style.display = 'block';
 
-    document.getElementById('cerrarDetalle').addEventListener('click', () => {
-        contenedor.style.display = 'none';
-    });
+    showModal('#modal-detalles');
 }
 
 

--- a/vistas/repartidores/repartos.php
+++ b/vistas/repartidores/repartos.php
@@ -85,11 +85,26 @@ ob_start();
 </div>
 
 
-<div id="modal-detalles" style="display:none;"></div>
+<!-- MODAL NORMALIZED 2025-08-14 -->
+<div class="modal fade" id="modal-detalles" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Detalle de reparto</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body"><!-- contenido dinámico --></div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+            </div>
+        </div>
+    </div>
+</div>
 
 
 
 <?php require_once __DIR__ . '/../footer.php'; ?>
+<script src="../../utils/js/modal-lite.js"></script>
 <script src="repartos.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- Normaliza modal de detalles en repartos con estructura Bootstrap y soporte para `modal-lite`
- Actualiza script de repartos para poblar el cuerpo de la modal y mostrarla mediante `showModal`

## Testing
- `php -l vistas/repartidores/repartos.php`
- `node --check vistas/repartidores/repartos.js`


------
https://chatgpt.com/codex/tasks/task_e_689e0a0125d8832b9f18a485e1d6cf24