### PR TITLE
feat: add provider modal

### DIFF
--- a/vistas/insumos/insumos.js
+++ b/vistas/insumos/insumos.js
@@ -260,10 +260,20 @@ function mostrarBajoStock(lista) {
 }
 
 async function nuevoProveedor() {
-    const nombre = prompt('Nombre del proveedor:');
-    if (!nombre) return;
-    const telefono = prompt('Teléfono:') || '';
-    const direccion = prompt('Dirección:') || '';
+    const form = document.getElementById('formProveedor');
+    if (form) form.reset();
+    showModal('#modalProveedor');
+}
+
+async function guardarProveedor(ev) {
+    ev.preventDefault();
+    const nombre = document.getElementById('provNombre').value.trim();
+    const telefono = document.getElementById('provTelefono').value.trim();
+    const direccion = document.getElementById('provDireccion').value.trim();
+    if (!nombre) {
+        alert('Nombre requerido');
+        return;
+    }
     try {
         const resp = await fetch('../../api/insumos/agregar_proveedor.php', {
             method: 'POST',
@@ -273,6 +283,9 @@ async function nuevoProveedor() {
         const data = await resp.json();
         if (data.success) {
             alert('Proveedor agregado');
+            hideModal('#modalProveedor');
+            document.querySelectorAll('.modal-backdrop').forEach(b => b.remove());
+            document.body.classList.remove('modal-open');
             cargarProveedores();
         } else {
             alert(data.mensaje);
@@ -447,6 +460,19 @@ document.addEventListener('DOMContentLoaded', () => {
     if (form) {
         form.addEventListener('submit', guardarInsumo);
         document.getElementById('cancelarInsumo').addEventListener('click', cerrarFormulario);
+    }
+    const formProv = document.getElementById('formProveedor');
+    if (formProv) {
+        formProv.addEventListener('submit', guardarProveedor);
+        document.getElementById('cancelarProveedor').addEventListener('click', () => {
+            hideModal('#modalProveedor');
+            document.querySelectorAll('.modal-backdrop').forEach(b => b.remove());
+            document.body.classList.remove('modal-open');
+        });
+        document.getElementById('modalProveedor').addEventListener('hidden.bs.modal', () => {
+            document.querySelectorAll('.modal-backdrop').forEach(b => b.remove());
+            document.body.classList.remove('modal-open');
+        });
     }
     const buscador = document.getElementById('buscarInsumo');
     if (buscador) {

--- a/vistas/insumos/insumos.php
+++ b/vistas/insumos/insumos.php
@@ -188,6 +188,47 @@ ob_start();
 
 
 
+<!-- Modal Nuevo Proveedor -->
+<div class="modal fade" id="modalProveedor" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <form id="formProveedor">
+                <div class="modal-header">
+                    <h5 class="modal-title">Nuevo Proveedor</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                </div>
+                <div class="modal-body">
+                    <div class="drag-container">
+                        <ul class="drag-list">
+                            <li class="drag-column">
+                                <div class="drag-column-header">Datos del proveedor</div>
+                                <ul class="drag-inner-list">
+                                    <li class="drag-item">
+                                        <label class="drag-options-label" for="provNombre">Nombre:
+                                            <input type="text" id="provNombre" class="form-control">
+                                        </label>
+                                        <label class="drag-options-label" for="provTelefono">Teléfono:
+                                            <input type="text" id="provTelefono" class="form-control">
+                                        </label>
+                                        <label class="drag-options-label" for="provDireccion">Dirección:
+                                            <input type="text" id="provDireccion" class="form-control">
+                                        </label>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn custom-btn me-2" type="submit">Guardar</button>
+                    <button class="btn custom-btn me-2" type="button" id="cancelarProveedor" data-dismiss="modal">Cancelar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+<!-- Modal Nuevo Proveedor End -->
+
 <?php require_once __DIR__ . '/../footer.php'; ?>
 <script src="../../utils/js/modal-lite.js"></script>
 <script src="insumos.js"></script>


### PR DESCRIPTION
## Summary
- add modal styled with project cards for registering new suppliers
- send supplier data via JSON to existing API and refresh list on success
- ensure modal backdrop cleans up when closed

## Testing
- `php -l vistas/insumos/insumos.php`
- `node --check vistas/insumos/insumos.js`


------
https://chatgpt.com/codex/tasks/task_e_689ea0ab6cbc832ba7be62f21b6062f2