### PR TITLE
Limit repartos view by user role

### DIFF
--- a/vistas/repartidores/repartos.php
+++ b/vistas/repartidores/repartos.php
@@ -26,6 +26,8 @@ ob_start();
 </div>
 <!-- Page Header End -->
 
+<div id="user-info" data-usuario-id="<?php echo htmlspecialchars($_SESSION['usuario_id'] ?? '', ENT_QUOTES); ?>" data-rol="<?php echo htmlspecialchars($_SESSION['rol'] ?? '', ENT_QUOTES); ?>" hidden></div>
+<div id="limit-alert" class="alert alert-warning d-none">Vista limitada a tus registros</div>
 
 <div class="container mt-5 mb-5 ">
     <h1 class="section-header">Repartos</h1>


### PR DESCRIPTION
## Summary
- Expose session `usuario_id` and `rol` via hidden data div and show warning banner for non-privileged users
- Gate repartos listing by user role; non-admin/cajero fetch and display only their own records and disable user filter

## Testing
- `php -l vistas/repartidores/repartos.php`
- `node --check vistas/repartidores/repartos.js`


------
https://chatgpt.com/codex/tasks/task_e_689ec4049288832bb4ed243c32b0cf46