### PR TITLE
feat: add user management CRUD

### DIFF
--- a/api/usuarios/agregar_usuario.php
+++ b/api/usuarios/agregar_usuario.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+$nombre = trim($input['nombre'] ?? '');
+$usuario = trim($input['usuario'] ?? '');
+$contrasena = $input['contrasena'] ?? '';
+$rol = trim($input['rol'] ?? '');
+$activo = isset($input['activo']) ? (int)$input['activo'] : 1;
+
+if ($nombre === '' || $usuario === '' || $contrasena === '' || $rol === '') {
+    error('Datos incompletos');
+}
+
+$hash = sha1($contrasena);
+
+$stmt = $conn->prepare("INSERT INTO usuarios (nombre, usuario, contrasena, rol, activo) VALUES (?, ?, ?, ?, ?)");
+if (!$stmt) {
+    error('Error en la preparación: ' . $conn->error);
+}
+$stmt->bind_param('ssssi', $nombre, $usuario, $hash, $rol, $activo);
+if ($stmt->execute()) {
+    echo json_encode(['success' => true, 'mensaje' => 'Usuario agregado']);
+} else {
+    error('Error al agregar usuario: ' . $stmt->error);
+}

--- a/api/usuarios/editar_usuario.php
+++ b/api/usuarios/editar_usuario.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+$id = isset($input['id']) ? (int)$input['id'] : 0;
+$nombre = trim($input['nombre'] ?? '');
+$usuario = trim($input['usuario'] ?? '');
+$contrasena = $input['contrasena'] ?? '';
+$rol = trim($input['rol'] ?? '');
+$activo = isset($input['activo']) ? (int)$input['activo'] : 1;
+
+if ($id <= 0 || $nombre === '' || $usuario === '' || $rol === '') {
+    error('Datos incompletos');
+}
+
+if ($contrasena !== '') {
+    $hash = sha1($contrasena);
+    $stmt = $conn->prepare("UPDATE usuarios SET nombre = ?, usuario = ?, contrasena = ?, rol = ?, activo = ? WHERE id = ?");
+    if (!$stmt) {
+        error('Error en la preparación: ' . $conn->error);
+    }
+    $stmt->bind_param('ssssii', $nombre, $usuario, $hash, $rol, $activo, $id);
+} else {
+    $stmt = $conn->prepare("UPDATE usuarios SET nombre = ?, usuario = ?, rol = ?, activo = ? WHERE id = ?");
+    if (!$stmt) {
+        error('Error en la preparación: ' . $conn->error);
+    }
+    $stmt->bind_param('sssii', $nombre, $usuario, $rol, $activo, $id);
+}
+
+if ($stmt->execute()) {
+    echo json_encode(['success' => true, 'mensaje' => 'Usuario actualizado']);
+} else {
+    error('Error al actualizar usuario: ' . $stmt->error);
+}

--- a/api/usuarios/eliminar_usuario.php
+++ b/api/usuarios/eliminar_usuario.php
@@ -1,0 +1,22 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+$id = isset($input['id']) ? (int)$input['id'] : 0;
+if ($id <= 0) {
+    error('ID inválido');
+}
+
+$stmt = $conn->prepare("DELETE FROM usuarios WHERE id = ?");
+if (!$stmt) {
+    error('Error en la preparación: ' . $conn->error);
+}
+$stmt->bind_param('i', $id);
+if ($stmt->execute()) {
+    echo json_encode(['success' => true, 'mensaje' => 'Usuario eliminado']);
+} else {
+    error('Error al eliminar usuario: ' . $stmt->error);
+}

--- a/api/usuarios/listar_usuarios.php
+++ b/api/usuarios/listar_usuarios.php
@@ -2,13 +2,20 @@
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
 
-$result = $conn->query("SELECT id, nombre, rol FROM usuarios WHERE activo = 1 ORDER BY nombre");
+header('Content-Type: application/json');
+
+$result = $conn->query("SELECT id, nombre, usuario, rol, activo FROM usuarios ORDER BY nombre");
 if (!$result) {
     error('Error al obtener usuarios: ' . $conn->error);
 }
 $usuarios = [];
 while ($row = $result->fetch_assoc()) {
+    $row['activo'] = (int) $row['activo'];
     $usuarios[] = $row;
 }
-success($usuarios);
+echo json_encode([
+    'success' => true,
+    'mensaje' => 'Usuarios obtenidos',
+    'usuarios' => $usuarios
+]);
 ?>

--- a/vistas/usuarios/index.php
+++ b/vistas/usuarios/index.php
@@ -1,0 +1,123 @@
+<?php
+require_once __DIR__ . '/../../utils/cargar_permisos.php';
+$path_actual = str_replace('/rest', '', $_SERVER['PHP_SELF']);
+if (!in_array($path_actual, $_SESSION['rutas_permitidas'])) {
+    http_response_code(403);
+    echo 'Acceso no autorizado';
+    exit;
+}
+$title = 'Usuarios';
+ob_start();
+?>
+
+<!-- Page Header Start -->
+<div class="page-header mb-0">
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <h2>Usuarios</h2>
+            </div>
+            <div class="col-12">
+                <a href="../../index.php">Inicio</a>
+                <a href="">Usuarios</a>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- Page Header End -->
+
+<div class="container mt-5 mb-5">
+    <div class="d-flex justify-content-end mb-3">
+        <button class="btn custom-btn" id="btnAgregar">Agregar</button>
+    </div>
+    <div class="table-responsive">
+        <table id="tablaUsuarios" class="styled-table">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Nombre</th>
+                    <th>Usuario</th>
+                    <th>Rol</th>
+                    <th>Activo</th>
+                    <th>Acciones</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+</div>
+
+<div class="modal fade" id="modalUsuario" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <form id="formUsuario">
+                <div class="modal-header">
+                    <h5 class="modal-title">Usuario</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" id="usuarioId">
+                    <div class="form-group">
+                        <label for="nombre">Nombre:</label>
+                        <input type="text" id="nombre" class="form-control" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="usuario">Usuario:</label>
+                        <input type="text" id="usuario" class="form-control" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="contrasena">Contraseña:</label>
+                        <input type="password" id="contrasena" class="form-control">
+                    </div>
+                    <div class="form-group">
+                        <label for="rol">Rol:</label>
+                        <select id="rol" class="form-control">
+                            <option value="cajero">cajero</option>
+                            <option value="mesero">mesero</option>
+                            <option value="admin">admin</option>
+                            <option value="repartidor">repartidor</option>
+                            <option value="cocinero">cocinero</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="activo">Activo:</label>
+                        <select id="activo" class="form-control">
+                            <option value="1">Sí</option>
+                            <option value="0">No</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn custom-btn">Guardar</button>
+                    <button type="button" class="btn custom-btn" data-dismiss="modal">Cancelar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- Modal global de mensajes -->
+<div class="modal fade" id="appMsgModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Mensaje</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body"></div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php require_once __DIR__ . '/../footer.php'; ?>
+<script src="../../utils/js/modal-lite.js"></script>
+<script src="usuarios.js"></script>
+</body>
+</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../nav.php';
+?>

--- a/vistas/usuarios/usuarios.js
+++ b/vistas/usuarios/usuarios.js
@@ -1,0 +1,114 @@
+function showAppMsg(msg) {
+    const body = document.querySelector('#appMsgModal .modal-body');
+    if (body) body.textContent = String(msg);
+    showModal('#appMsgModal');
+}
+window.alert = showAppMsg;
+
+let usuarios = [];
+
+async function cargarUsuarios() {
+    try {
+        const resp = await fetch('../../api/usuarios/listar_usuarios.php');
+        const data = await resp.json();
+        const tbody = document.querySelector('#tablaUsuarios tbody');
+        tbody.innerHTML = '';
+        if (data.success) {
+            usuarios = data.usuarios || [];
+            usuarios.forEach(u => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${u.id}</td><td>${u.nombre}</td><td>${u.usuario}</td><td>${u.rol}</td><td>${u.activo == 1 ? 'Sí' : 'No'}</td>`;
+                const tdAcc = document.createElement('td');
+                const btnE = document.createElement('button');
+                btnE.className = 'btn custom-btn me-2';
+                btnE.textContent = 'Editar';
+                btnE.onclick = () => editarUsuario(u.id);
+                const btnD = document.createElement('button');
+                btnD.className = 'btn custom-btn';
+                btnD.textContent = 'Eliminar';
+                btnD.onclick = () => eliminarUsuario(u.id);
+                tdAcc.appendChild(btnE);
+                tdAcc.appendChild(btnD);
+                tr.appendChild(tdAcc);
+                tbody.appendChild(tr);
+            });
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar usuarios');
+    }
+}
+
+document.getElementById('btnAgregar').onclick = () => {
+    document.getElementById('formUsuario').reset();
+    document.getElementById('usuarioId').value = '';
+    showModal('#modalUsuario');
+};
+
+document.getElementById('formUsuario').onsubmit = async ev => {
+    ev.preventDefault();
+    const id = document.getElementById('usuarioId').value;
+    const payload = {
+        nombre: document.getElementById('nombre').value,
+        usuario: document.getElementById('usuario').value,
+        contrasena: document.getElementById('contrasena').value,
+        rol: document.getElementById('rol').value,
+        activo: parseInt(document.getElementById('activo').value)
+    };
+    let url;
+    if (id) {
+        payload.id = parseInt(id);
+        url = '../../api/usuarios/editar_usuario.php';
+    } else {
+        url = '../../api/usuarios/agregar_usuario.php';
+    }
+    try {
+        const resp = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+        const data = await resp.json();
+        alert(data.mensaje);
+        if (data.success) {
+            hideModal('#modalUsuario');
+            cargarUsuarios();
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al guardar usuario');
+    }
+};
+
+function editarUsuario(id) {
+    const u = usuarios.find(x => x.id == id);
+    if (!u) return;
+    document.getElementById('usuarioId').value = u.id;
+    document.getElementById('nombre').value = u.nombre;
+    document.getElementById('usuario').value = u.usuario;
+    document.getElementById('contrasena').value = '';
+    document.getElementById('rol').value = u.rol;
+    document.getElementById('activo').value = u.activo;
+    showModal('#modalUsuario');
+}
+
+async function eliminarUsuario(id) {
+    if (!confirm('¿Eliminar usuario?')) return;
+    try {
+        const resp = await fetch('../../api/usuarios/eliminar_usuario.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id })
+        });
+        const data = await resp.json();
+        alert(data.mensaje);
+        if (data.success) cargarUsuarios();
+    } catch (err) {
+        console.error(err);
+        alert('Error al eliminar usuario');
+    }
+}
+
+window.addEventListener('DOMContentLoaded', cargarUsuarios);


### PR DESCRIPTION
## Summary
- add PHP endpoints for user CRUD (list, add, edit, delete)
- add users view with table and modal forms
- implement frontend JS to call CRUD APIs

## Testing
- `php -l api/usuarios/listar_usuarios.php`
- `php -l api/usuarios/agregar_usuario.php`
- `php -l api/usuarios/editar_usuario.php`
- `php -l api/usuarios/eliminar_usuario.php`
- `php -l vistas/usuarios/index.php`
- `node -c vistas/usuarios/usuarios.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0e5876f90832b81fca0c881801616