### PR TITLE
Add login endpoint with SHA1 or plain password check

### DIFF
--- a/api/usuarios/login.php
+++ b/api/usuarios/login.php
@@ -1,0 +1,44 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+$usuario = $input['usuario'] ?? '';
+$contrasenaIngresada = $input['contrasena'] ?? '';
+
+if ($usuario === '' || $contrasenaIngresada === '') {
+    error('Datos incompletos');
+}
+
+$stmt = $conn->prepare('SELECT id, nombre, usuario, contrasena, rol, activo FROM usuarios WHERE usuario = ?');
+if (!$stmt) {
+    error('Error en la preparación: ' . $conn->error);
+}
+$stmt->bind_param('s', $usuario);
+$stmt->execute();
+$result = $stmt->get_result();
+$usuarioDB = $result->fetch_assoc();
+
+if (!$usuarioDB || (int)$usuarioDB['activo'] !== 1) {
+    error('Usuario o contraseña incorrectos');
+}
+
+$hashIngresado = sha1($contrasenaIngresada);
+
+$valido = false;
+if (hash_equals($usuarioDB['contrasena'], $hashIngresado)) {
+    $valido = true;
+} elseif (hash_equals($usuarioDB['contrasena'], $contrasenaIngresada)) {
+    $valido = true;
+}
+
+if (!$valido) {
+    error('Usuario o contraseña incorrectos');
+}
+
+unset($usuarioDB['contrasena']);
+
+echo json_encode(['success' => true, 'usuario' => $usuarioDB]);
+


### PR DESCRIPTION
## Summary
- Implement login API that validates SHA1 or plaintext passwords and ensures user is active

## Testing
- `php -l api/usuarios/login.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0ec0479c8832bbb15ee85c5b4c423