### PR TITLE
Add CRUD for rutas and user-route assignments

### DIFF
--- a/api/rutas/agregar_ruta.php
+++ b/api/rutas/agregar_ruta.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+$nombre = trim($input['nombre'] ?? '');
+$path = trim($input['path'] ?? '');
+$tipo = trim($input['tipo'] ?? '');
+$grupo = $input['grupo'] ?? null;
+$orden = isset($input['orden']) ? (int)$input['orden'] : 0;
+
+if ($nombre === '' || $path === '' || $tipo === '') {
+    error('Datos incompletos');
+}
+
+$stmt = $conn->prepare("INSERT INTO rutas (nombre, path, tipo, grupo, orden) VALUES (?, ?, ?, ?, ?)");
+if (!$stmt) {
+    error('Error en la preparación: ' . $conn->error);
+}
+$stmt->bind_param('ssssi', $nombre, $path, $tipo, $grupo, $orden);
+if ($stmt->execute()) {
+    echo json_encode(['success' => true, 'mensaje' => 'Ruta agregada', 'resultado' => []]);
+} else {
+    error('Error al agregar ruta: ' . $stmt->error);
+}

--- a/api/rutas/editar_ruta.php
+++ b/api/rutas/editar_ruta.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+$nombre = trim($input['nombre'] ?? '');
+$nuevo_nombre = trim($input['nuevo_nombre'] ?? $nombre);
+$path = trim($input['path'] ?? '');
+$tipo = trim($input['tipo'] ?? '');
+$grupo = $input['grupo'] ?? null;
+$orden = isset($input['orden']) ? (int)$input['orden'] : 0;
+
+if ($nombre === '' || $path === '' || $tipo === '') {
+    error('Datos incompletos');
+}
+
+$stmt = $conn->prepare("UPDATE rutas SET nombre = ?, path = ?, tipo = ?, grupo = ?, orden = ? WHERE nombre = ?");
+if (!$stmt) {
+    error('Error en la preparación: ' . $conn->error);
+}
+$stmt->bind_param('ssssis', $nuevo_nombre, $path, $tipo, $grupo, $orden, $nombre);
+if ($stmt->execute()) {
+    echo json_encode(['success' => true, 'mensaje' => 'Ruta actualizada', 'resultado' => []]);
+} else {
+    error('Error al actualizar ruta: ' . $stmt->error);
+}

--- a/api/rutas/eliminar_ruta.php
+++ b/api/rutas/eliminar_ruta.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+$nombre = trim($input['nombre'] ?? '');
+
+if ($nombre === '') {
+    error('Nombre requerido');
+}
+
+$stmt = $conn->prepare("DELETE FROM rutas WHERE nombre = ?");
+if (!$stmt) {
+    error('Error en la preparación: ' . $conn->error);
+}
+$stmt->bind_param('s', $nombre);
+if ($stmt->execute()) {
+    echo json_encode(['success' => true, 'mensaje' => 'Ruta eliminada', 'resultado' => []]);
+} else {
+    error('Error al eliminar ruta: ' . $stmt->error);
+}

--- a/api/rutas/listar_rutas.php
+++ b/api/rutas/listar_rutas.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+header('Content-Type: application/json');
+
+$sql = "SELECT nombre, path, tipo, grupo, orden FROM rutas ORDER BY orden";
+$result = $conn->query($sql);
+if (!$result) {
+    error('Error al obtener rutas: ' . $conn->error);
+}
+$rutas = $result->fetch_all(MYSQLI_ASSOC);
+
+echo json_encode([
+    'success' => true,
+    'mensaje' => 'Rutas obtenidas',
+    'resultado' => $rutas
+]);

--- a/api/usuario_ruta/guardar_usuario_rutas.php
+++ b/api/usuario_ruta/guardar_usuario_rutas.php
@@ -1,0 +1,45 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+$usuario = trim($input['usuario'] ?? '');
+$rutas = $input['rutas'] ?? [];
+
+if ($usuario === '' || !is_array($rutas)) {
+    error('Datos incompletos');
+}
+
+$stmt = $conn->prepare("SELECT id FROM usuarios WHERE nombre = ?");
+$stmt->bind_param('s', $usuario);
+$stmt->execute();
+$result = $stmt->get_result();
+if (!$row = $result->fetch_assoc()) {
+    error('Usuario no encontrado');
+}
+$usuario_id = (int)$row['id'];
+
+$conn->begin_transaction();
+try {
+    $stmtDel = $conn->prepare("DELETE FROM usuario_ruta WHERE usuario_id = ?");
+    $stmtDel->bind_param('i', $usuario_id);
+    $stmtDel->execute();
+
+    if (!empty($rutas)) {
+        $stmtIns = $conn->prepare("INSERT INTO usuario_ruta (usuario_id, ruta_id) SELECT ?, id FROM rutas WHERE nombre = ?");
+        foreach ($rutas as $rutaNombre) {
+            $rutaNombre = trim($rutaNombre);
+            if ($rutaNombre === '') continue;
+            $stmtIns->bind_param('is', $usuario_id, $rutaNombre);
+            $stmtIns->execute();
+        }
+    }
+
+    $conn->commit();
+    echo json_encode(['success' => true, 'mensaje' => 'Rutas asignadas', 'resultado' => []]);
+} catch (Exception $e) {
+    $conn->rollback();
+    error('Error al guardar rutas: ' . $e->getMessage());
+}

--- a/api/usuario_ruta/listar_usuario_rutas.php
+++ b/api/usuario_ruta/listar_usuario_rutas.php
@@ -1,0 +1,39 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/response.php';
+
+header('Content-Type: application/json');
+
+$usuario = trim($_GET['usuario'] ?? '');
+if ($usuario === '') {
+    error('Usuario requerido');
+}
+
+$stmt = $conn->prepare("SELECT id FROM usuarios WHERE nombre = ?");
+$stmt->bind_param('s', $usuario);
+$stmt->execute();
+$result = $stmt->get_result();
+if (!$row = $result->fetch_assoc()) {
+    error('Usuario no encontrado');
+}
+$usuario_id = (int)$row['id'];
+
+$sql = "SELECT r.nombre, r.path, r.tipo, r.grupo, r.orden, (ur.id IS NOT NULL) AS asignado
+        FROM rutas r
+        LEFT JOIN usuario_ruta ur ON ur.ruta_id = r.id AND ur.usuario_id = ?
+        ORDER BY r.orden";
+$stmt = $conn->prepare($sql);
+$stmt->bind_param('i', $usuario_id);
+$stmt->execute();
+$res = $stmt->get_result();
+$rutas = [];
+while ($r = $res->fetch_assoc()) {
+    $r['asignado'] = (bool)$r['asignado'];
+    $rutas[] = $r;
+}
+
+echo json_encode([
+    'success' => true,
+    'mensaje' => 'Rutas obtenidas',
+    'resultado' => $rutas
+]);

--- a/vistas/rutas/index.php
+++ b/vistas/rutas/index.php
@@ -1,0 +1,118 @@
+<?php
+require_once __DIR__ . '/../../utils/cargar_permisos.php';
+$path_actual = str_replace('/rest', '', $_SERVER['PHP_SELF']);
+if (!in_array($path_actual, $_SESSION['rutas_permitidas'])) {
+    http_response_code(403);
+    echo 'Acceso no autorizado';
+    exit;
+}
+$title = 'Rutas';
+ob_start();
+?>
+
+<!-- Page Header Start -->
+<div class="page-header mb-0">
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <h2>Rutas</h2>
+            </div>
+            <div class="col-12">
+                <a href="../../index.php">Inicio</a>
+                <a href="">Rutas</a>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- Page Header End -->
+
+<div class="container mt-5 mb-5">
+    <div class="d-flex justify-content-end mb-3">
+        <button class="btn custom-btn" id="btnAgregar">Agregar</button>
+    </div>
+    <div class="table-responsive">
+        <table id="tablaRutas" class="styled-table">
+            <thead>
+                <tr>
+                    <th>Nombre</th>
+                    <th>Path</th>
+                    <th>Tipo</th>
+                    <th>Grupo</th>
+                    <th>Orden</th>
+                    <th>Acciones</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+</div>
+
+<div class="modal fade" id="modalRuta" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <form id="formRuta">
+                <div class="modal-header">
+                    <h5 class="modal-title">Ruta</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" id="nombreOriginal">
+                    <div class="form-group">
+                        <label for="nombre">Nombre:</label>
+                        <input type="text" id="nombre" class="form-control" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="path">Path:</label>
+                        <input type="text" id="path" class="form-control" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="tipo">Tipo:</label>
+                        <select id="tipo" class="form-control">
+                            <option value="link">link</option>
+                            <option value="dropdown">dropdown</option>
+                            <option value="dropdown-item">dropdown-item</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="grupo">Grupo:</label>
+                        <input type="text" id="grupo" class="form-control">
+                    </div>
+                    <div class="form-group">
+                        <label for="orden">Orden:</label>
+                        <input type="number" id="orden" class="form-control" value="0">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn custom-btn">Guardar</button>
+                    <button type="button" class="btn custom-btn" data-dismiss="modal">Cancelar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- Modal global de mensajes -->
+<div class="modal fade" id="appMsgModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Mensaje</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body"></div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php require_once __DIR__ . '/../footer.php'; ?>
+<script src="../../utils/js/modal-lite.js"></script>
+<script src="rutas.js"></script>
+</body>
+</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../nav.php';
+?>

--- a/vistas/rutas/rutas.js
+++ b/vistas/rutas/rutas.js
@@ -1,0 +1,115 @@
+function showAppMsg(msg) {
+    const body = document.querySelector('#appMsgModal .modal-body');
+    if (body) body.textContent = String(msg);
+    showModal('#appMsgModal');
+}
+window.alert = showAppMsg;
+
+let rutas = [];
+
+async function cargarRutas() {
+    try {
+        const resp = await fetch('../../api/rutas/listar_rutas.php');
+        const data = await resp.json();
+        const tbody = document.querySelector('#tablaRutas tbody');
+        tbody.innerHTML = '';
+        if (data.success) {
+            rutas = data.resultado || [];
+            rutas.forEach(r => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${r.nombre}</td><td>${r.path}</td><td>${r.tipo}</td><td>${r.grupo ?? ''}</td><td>${r.orden}</td>`;
+                const tdAcc = document.createElement('td');
+                const btnE = document.createElement('button');
+                btnE.className = 'btn custom-btn me-2';
+                btnE.textContent = 'Editar';
+                btnE.onclick = () => editarRuta(r.nombre);
+                const btnD = document.createElement('button');
+                btnD.className = 'btn custom-btn';
+                btnD.textContent = 'Eliminar';
+                btnD.onclick = () => eliminarRuta(r.nombre);
+                tdAcc.appendChild(btnE);
+                tdAcc.appendChild(btnD);
+                tr.appendChild(tdAcc);
+                tbody.appendChild(tr);
+            });
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar rutas');
+    }
+}
+
+document.getElementById('btnAgregar').onclick = () => {
+    document.getElementById('formRuta').reset();
+    document.getElementById('nombreOriginal').value = '';
+    document.getElementById('orden').value = 0;
+    showModal('#modalRuta');
+};
+
+document.getElementById('formRuta').onsubmit = async ev => {
+    ev.preventDefault();
+    const nombreOriginal = document.getElementById('nombreOriginal').value;
+    const payload = {
+        nombre: nombreOriginal || document.getElementById('nombre').value,
+        nuevo_nombre: document.getElementById('nombre').value,
+        path: document.getElementById('path').value,
+        tipo: document.getElementById('tipo').value,
+        grupo: document.getElementById('grupo').value,
+        orden: parseInt(document.getElementById('orden').value) || 0
+    };
+    let url = '../../api/rutas/agregar_ruta.php';
+    if (nombreOriginal) {
+        url = '../../api/rutas/editar_ruta.php';
+    } else {
+        delete payload.nuevo_nombre; // when adding not needed
+    }
+    try {
+        const resp = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+        const data = await resp.json();
+        alert(data.mensaje);
+        if (data.success) {
+            hideModal('#modalRuta');
+            cargarRutas();
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al guardar ruta');
+    }
+};
+
+function editarRuta(nombre) {
+    const r = rutas.find(x => x.nombre === nombre);
+    if (!r) return;
+    document.getElementById('nombreOriginal').value = r.nombre;
+    document.getElementById('nombre').value = r.nombre;
+    document.getElementById('path').value = r.path;
+    document.getElementById('tipo').value = r.tipo;
+    document.getElementById('grupo').value = r.grupo ?? '';
+    document.getElementById('orden').value = r.orden;
+    showModal('#modalRuta');
+}
+
+async function eliminarRuta(nombre) {
+    if (!confirm('¿Eliminar ruta?')) return;
+    try {
+        const resp = await fetch('../../api/rutas/eliminar_ruta.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ nombre })
+        });
+        const data = await resp.json();
+        alert(data.mensaje);
+        if (data.success) cargarRutas();
+    } catch (err) {
+        console.error(err);
+        alert('Error al eliminar ruta');
+    }
+}
+
+window.addEventListener('DOMContentLoaded', cargarRutas);

--- a/vistas/usuario_ruta/index.php
+++ b/vistas/usuario_ruta/index.php
@@ -1,0 +1,78 @@
+<?php
+require_once __DIR__ . '/../../utils/cargar_permisos.php';
+$path_actual = str_replace('/rest', '', $_SERVER['PHP_SELF']);
+if (!in_array($path_actual, $_SESSION['rutas_permitidas'])) {
+    http_response_code(403);
+    echo 'Acceso no autorizado';
+    exit;
+}
+$title = 'Asignar Rutas';
+ob_start();
+?>
+
+<!-- Page Header Start -->
+<div class="page-header mb-0">
+    <div class="container">
+        <div class="row">
+            <div class="col-12">
+                <h2>Asignar Rutas a Usuarios</h2>
+            </div>
+            <div class="col-12">
+                <a href="../../index.php">Inicio</a>
+                <a href="">Asignar Rutas</a>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- Page Header End -->
+
+<div class="container mt-5 mb-5">
+    <div class="form-group">
+        <label for="usuarioSelect">Usuario:</label>
+        <select id="usuarioSelect" class="form-control"></select>
+    </div>
+    <div class="table-responsive mt-3">
+        <table id="tablaRutasUsuario" class="styled-table">
+            <thead>
+                <tr>
+                    <th>Nombre</th>
+                    <th>Path</th>
+                    <th>Tipo</th>
+                    <th>Grupo</th>
+                    <th>Orden</th>
+                    <th>Asignado</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+    <div class="d-flex justify-content-end mt-3">
+        <button class="btn custom-btn" id="btnGuardar">Guardar</button>
+    </div>
+</div>
+
+<!-- Modal global de mensajes -->
+<div class="modal fade" id="appMsgModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Mensaje</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body"></div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php require_once __DIR__ . '/../footer.php'; ?>
+<script src="../../utils/js/modal-lite.js"></script>
+<script src="usuario_ruta.js"></script>
+</body>
+</html>
+<?php
+$content = ob_get_clean();
+include __DIR__ . '/../nav.php';
+?>

--- a/vistas/usuario_ruta/usuario_ruta.js
+++ b/vistas/usuario_ruta/usuario_ruta.js
@@ -1,0 +1,87 @@
+function showAppMsg(msg) {
+    const body = document.querySelector('#appMsgModal .modal-body');
+    if (body) body.textContent = String(msg);
+    showModal('#appMsgModal');
+}
+window.alert = showAppMsg;
+
+async function cargarUsuarios() {
+    try {
+        const resp = await fetch('../../api/usuarios/listar_usuarios.php');
+        const data = await resp.json();
+        const sel = document.getElementById('usuarioSelect');
+        sel.innerHTML = '';
+        if (data.success) {
+            (data.usuarios || []).forEach(u => {
+                const opt = document.createElement('option');
+                opt.value = u.nombre;
+                opt.textContent = u.nombre;
+                sel.appendChild(opt);
+            });
+            if (sel.value) cargarRutasUsuario(sel.value);
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar usuarios');
+    }
+}
+
+document.getElementById('usuarioSelect').onchange = ev => {
+    const usuario = ev.target.value;
+    cargarRutasUsuario(usuario);
+};
+
+async function cargarRutasUsuario(usuario) {
+    if (!usuario) return;
+    try {
+        const resp = await fetch(`../../api/usuario_ruta/listar_usuario_rutas.php?usuario=${encodeURIComponent(usuario)}`);
+        const data = await resp.json();
+        const tbody = document.querySelector('#tablaRutasUsuario tbody');
+        tbody.innerHTML = '';
+        if (data.success) {
+            (data.resultado || []).forEach(r => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${r.nombre}</td><td>${r.path}</td><td>${r.tipo}</td><td>${r.grupo ?? ''}</td><td>${r.orden}</td>`;
+                const tdCheck = document.createElement('td');
+                const chk = document.createElement('input');
+                chk.type = 'checkbox';
+                chk.checked = !!r.asignado;
+                chk.dataset.nombre = r.nombre;
+                tdCheck.appendChild(chk);
+                tr.appendChild(tdCheck);
+                tbody.appendChild(tr);
+            });
+        } else {
+            alert(data.mensaje);
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Error al cargar rutas');
+    }
+}
+
+async function guardarRutasUsuario() {
+    const usuario = document.getElementById('usuarioSelect').value;
+    if (!usuario) return;
+    const checks = document.querySelectorAll('#tablaRutasUsuario tbody input[type="checkbox"]');
+    const rutas = Array.from(checks).filter(c => c.checked).map(c => c.dataset.nombre);
+    try {
+        const resp = await fetch('../../api/usuario_ruta/guardar_usuario_rutas.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ usuario, rutas })
+        });
+        const data = await resp.json();
+        alert(data.mensaje);
+        if (data.success) cargarRutasUsuario(usuario);
+    } catch (err) {
+        console.error(err);
+        alert('Error al guardar rutas');
+    }
+}
+
+document.getElementById('btnGuardar').onclick = guardarRutasUsuario;
+
+window.addEventListener('DOMContentLoaded', cargarUsuarios);


### PR DESCRIPTION
## Summary
- implement API endpoints to list, add, edit, and delete rutas
- add API to list and save rutas assigned to a usuario
- add views and JavaScript for rutas CRUD and user-route assignment screens

## Testing
- `php -l api/rutas/listar_rutas.php`
- `php -l api/rutas/agregar_ruta.php`
- `php -l api/rutas/editar_ruta.php`
- `php -l api/rutas/eliminar_ruta.php`
- `php -l api/usuario_ruta/listar_usuario_rutas.php`
- `php -l api/usuario_ruta/guardar_usuario_rutas.php`
- `php -l vistas/rutas/index.php`
- `php -l vistas/usuario_ruta/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0efac5bc8832bba559227c68c1916