### PR TITLE
Permitir login con contraseñas SHA1 o texto plano

### DIFF
--- a/api/usuarios/login.php
+++ b/api/usuarios/login.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+$usuario = trim($input['usuario'] ?? '');
+$contrasenaIngresada = $input['contrasena'] ?? '';
+
+if ($usuario === '' || $contrasenaIngresada === '') {
+    echo json_encode(['success' => false, 'mensaje' => 'Faltan datos']);
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT id, nombre, usuario, rol, contrasena, activo FROM usuarios WHERE usuario = ? LIMIT 1');
+if (!$stmt) {
+    echo json_encode(['success' => false, 'mensaje' => 'Error en la preparación']);
+    exit;
+}
+$stmt->bind_param('s', $usuario);
+$stmt->execute();
+$result = $stmt->get_result();
+$usuarioDB = $result->fetch_assoc();
+
+if ($usuarioDB && (int)$usuarioDB['activo'] === 1) {
+    $hash = sha1($contrasenaIngresada);
+    if ($usuarioDB['contrasena'] === $hash || $usuarioDB['contrasena'] === $contrasenaIngresada) {
+        unset($usuarioDB['contrasena']);
+        $usuarioDB['activo'] = (int)$usuarioDB['activo'];
+        echo json_encode(['success' => true, 'usuario' => $usuarioDB]);
+        exit;
+    }
+}
+
+echo json_encode(['success' => false, 'mensaje' => 'Usuario o contraseña incorrectos']);


### PR DESCRIPTION
## Summary
- Añadido endpoint de login que acepta contraseñas almacenadas como hash SHA1 o en texto plano

## Testing
- `php -l api/usuarios/login.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0f140112c832b85e20b418059792f