### PR TITLE
feat: replace cancel confirm with custom modal

### DIFF
--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -293,6 +293,19 @@ ob_start();
   </div>
 </div>
 
+<!-- Modal de confirmación de cancelación -->
+<div class="modal fade" id="cancelVentaModal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-body">¿Deseas cancelar la venta?</div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-danger" id="confirmCancelVenta">Cancelar venta</button>
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cerrar</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Modal global de mensajes -->
 <div class="modal fade" id="appMsgModal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog" role="document">


### PR DESCRIPTION
## Summary
- Replace jQuery confirm with a reusable modal to cancel sales
- Handle cancellation via vanilla JS fetch and showModal/hideModal

## Testing
- `node --check vistas/ventas/ventas.js`
- `php -l vistas/ventas/ventas.php`


------
https://chatgpt.com/codex/tasks/task_e_68a17179cc70832bbb61a922fe618c28