### PR TITLE
feat: load active couriers on delivery selection

### DIFF
--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -1650,21 +1650,36 @@ function verificarActivacionProductos() {
 }
 
 // Listener tipo_entrega: deja tu lógica de mostrar/ocultar divs y AL FINAL llama a actualizarSelectorUsuario()
-const tipoEntregaEl = document.getElementById('tipo_entrega');
-if (tipoEntregaEl) {
-  tipoEntregaEl.addEventListener('change', function () {
-    const tipo = this.value;
-    const campoMesa = document.getElementById('campoMesa');
-    const campoRepartidor = document.getElementById('campoRepartidor');
-    const campoObservacion = document.getElementById('campoObservacion');
+$('#tipo_entrega').on('change', async function () {
+  const tipo = this.value;
+  const campoMesa = document.getElementById('campoMesa');
+  const campoRepartidor = document.getElementById('campoRepartidor');
+  const campoObservacion = document.getElementById('campoObservacion');
 
-    if (campoMesa) campoMesa.style.display = (tipo === 'mesa') ? 'block' : 'none';
-    if (campoRepartidor) campoRepartidor.style.display = (tipo === 'domicilio') ? 'block' : 'none';
-    if (campoObservacion) campoObservacion.style.display = (tipo === 'domicilio' || tipo === 'rapido') ? 'block' : 'none';
+  if (campoMesa) campoMesa.style.display = (tipo === 'mesa') ? 'block' : 'none';
+  if (campoObservacion) campoObservacion.style.display = (tipo === 'domicilio' || tipo === 'rapido') ? 'block' : 'none';
 
-    actualizarSelectorUsuario();
-  });
-}
+  if (tipo === 'domicilio' || tipo === 'repartidor casa') {
+    if (campoRepartidor) campoRepartidor.style.display = 'block';
+    try {
+      const resp = await fetch('../../api/usuarios/listar.php');
+      const data = await resp.json();
+      const usuarios = (data.resultado || data).filter(u => u.rol === 'repartidor' && parseInt(u.activo) === 1);
+      const select = $('#repartidor_id');
+      select.empty().append(new Option('--Selecciona--', ''));
+      usuarios.forEach(u => {
+        select.append(new Option(u.nombre, u.id));
+      });
+    } catch (err) {
+      console.error('Error al cargar repartidores', err);
+    }
+  } else {
+    if (campoRepartidor) campoRepartidor.style.display = 'none';
+    $('#repartidor_id').empty();
+  }
+
+  actualizarSelectorUsuario();
+});
 
 // Detecta cambios en mesa o repartidor
 document.getElementById('mesa_id').addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- load active `repartidor` users when delivery type is set to `domicilio` or `repartidor casa`
- hide courier field for other delivery types

## Testing
- `composer validate`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a616f0e0832bb347122191fbdfbc