### PR TITLE
Validar diferencia negativa y prefijar pagos

### DIFF
--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -755,11 +755,32 @@ function mostrarModalDesglose(dataApi) {
 
 
     html += '<div id="camposDesglose"></div>';
+    html += '<div><label>Pago Boucher</label><input type="number" id="pagoBoucher" disabled></div>';
+    html += '<div><label>Pago Cheque</label><input type="number" id="pagoCheque" disabled></div>';
     html += '<p>Efectivo contado: $<span id="totalEfectivo">0.00</span> | Dif.: $<span id="difIngresado">0.00</span></p>';
     html += '<button class="btn custom-btn" id="guardarDesglose">Guardar</button> <button class="btn custom-btn" id="cancelarDesglose" data-dismiss="modal">Cancelar</button>';
     html += '</div>';
     body.innerHTML = html;
     showModal('#modalDesglose');
+
+    // Prefill boucher and cheque amounts and disable inputs
+    fetch('../../api/cortes/resumen_corte_actual.php')
+        .then(res => res.json())
+        .then(data => {
+            const boucher = data?.resultado?.boucher?.total ?? 0;
+            const cheque = data?.resultado?.efectivo?.total ?? 0;
+            const inpBoucher = modal.querySelector('#pagoBoucher');
+            const inpCheque = modal.querySelector('#pagoCheque');
+            if (inpBoucher) {
+                inpBoucher.value = boucher;
+                inpBoucher.disabled = true;
+            }
+            if (inpCheque) {
+                inpCheque.value = cheque;
+                inpCheque.disabled = true;
+            }
+        })
+        .catch(err => console.error('Error al prellenar pagos:', err));
 
     document.getElementById('lblFondo').textContent = fondoInicial.toFixed(2);
     document.getElementById('lblTotalDepositos').textContent = (Number.parseFloat(r.total_depositos) || 0).toFixed(2);
@@ -813,6 +834,11 @@ function mostrarModalDesglose(dataApi) {
 
     modal.querySelector('#guardarDesglose').addEventListener('click', async () => {
         calcular();
+        const diferencia = totalIngresado - totalEsperado;
+        if (diferencia < 0) {
+            alert('No se puede cerrar la caja con diferencia negativa');
+            return;
+        }
         const detalle = [];
         cont.querySelectorAll('.grupo-pago').forEach(gr => {
             const inp = gr.querySelector('.cantidad');


### PR DESCRIPTION
## Summary
- Evita cierre de caja cuando la diferencia entre total final y esperado es negativa
- Prellena y bloquea los campos de Pago Boucher y Pago Cheque en el modal de desglose

## Testing
- `npm test` (fails: Could not read package.json)
- `composer test` (fails: Command "test" is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68a2a72b1f08832bb6d86e4123327f0b