### PR TITLE
Implement long polling for kitchen updates

### DIFF
--- a/api/kitchen/long_polling.php
+++ b/api/kitchen/long_polling.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+$ultimoId = isset($input['ultimo_id']) ? (int)$input['ultimo_id'] : 0;
+
+$start = microtime(true);
+$nueva = null;
+
+do {
+    $stmt = $conn->prepare('SELECT * FROM venta_detalles WHERE id > ? ORDER BY id ASC LIMIT 1');
+    $stmt->bind_param('i', $ultimoId);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    if ($row = $res->fetch_assoc()) {
+        $nueva = $row;
+        break;
+    }
+    usleep(500000); // 0.5 segundos
+} while ((microtime(true) - $start) < 25);
+
+header('Content-Type: application/json');
+if ($nueva) {
+    echo json_encode(['nueva_venta' => true, 'data' => $nueva]);
+} else {
+    echo json_encode(['nueva_venta' => false]);
+}
+?>

--- a/vistas/cocina/cocina.js
+++ b/vistas/cocina/cocina.js
@@ -144,4 +144,28 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelector('a[href="#Entregados"]').addEventListener('click', () => {
         setTimeout(cargarEntregados, 10);
     });
+    escucharNuevasVentas();
 });
+
+function actualizarPantallaCocina(data) {
+    cargarPendientes();
+}
+
+async function escucharNuevasVentas() {
+    try {
+        const resp = await fetch('../../api/kitchen/long_polling.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ultimo_id: ultimoIdVenta })
+        });
+        const data = await resp.json();
+        if (data.nueva_venta) {
+            ultimoIdVenta = data.data.id;
+            actualizarPantallaCocina(data.data);
+        }
+    } catch (err) {
+        console.error('Error escuchando ventas', err);
+    } finally {
+        escucharNuevasVentas();
+    }
+}

--- a/vistas/cocina/cocina.php
+++ b/vistas/cocina/cocina.php
@@ -1,11 +1,14 @@
 <?php
 require_once __DIR__ . '/../../utils/cargar_permisos.php';
+require_once __DIR__ . '/../../config/db.php';
 $path_actual = str_replace('/rest', '', $_SERVER['PHP_SELF']);
 if (!in_array($path_actual, $_SESSION['rutas_permitidas'])) {
     http_response_code(403);
     echo 'Acceso no autorizado';
     exit;
 }
+$row = $conn->query("SELECT MAX(id) AS max_id FROM venta_detalles")->fetch_assoc();
+$ultimo_id_venta = $row['max_id'] ?? 0;
 $title = 'Cocina';
 ob_start();
 ?>
@@ -75,9 +78,13 @@ ob_start();
         <!-- Menu End -->
 
 <?php require_once __DIR__ . '/../footer.php'; ?>
+<script>
+  var ultimoIdVenta = <?php echo (int)$ultimo_id_venta; ?>;
+</script>
 <script src="cocina.js"></script>
     </body>
 </html>
 <?php
 $content = ob_get_clean();
 include __DIR__ . '/../nav.php';
+?>


### PR DESCRIPTION
## Summary
- add `api/kitchen/long_polling.php` to watch `venta_detalles` for new sales
- wire `cocina.js` to long-poll and refresh pending items when new sale detected
- expose last sale id in `cocina.php` for client-side polling

## Testing
- `php -l api/kitchen/long_polling.php`
- `php -l vistas/cocina/cocina.php`
- `node --check vistas/cocina/cocina.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68a38353c614832bbb34e35639e91102