### PR TITLE
Reiniciar polling de cocina al cambiar filtros o pestañas

### DIFF
--- a/vistas/cocina/cocina2.php
+++ b/vistas/cocina/cocina2.php
@@ -32,19 +32,19 @@ ob_start();
 
 <div id="kanban" class="kanban-container">
   <div class="kanban-board board-pendiente" data-status="pendiente">
-    <h3>Pendiente</h3>
+    <h3 class="kanban-tab" data-target="pendiente">Pendiente</h3>
     <div class="kanban-dropzone" id="col-pendiente"></div>
   </div>
   <div class="kanban-board board-preparacion" data-status="en_preparacion">
-    <h3>En preparación</h3>
+    <h3 class="kanban-tab" data-target="en_preparacion">En preparación</h3>
     <div class="kanban-dropzone" id="col-preparacion"></div>
   </div>
   <div class="kanban-board board-listo" data-status="listo">
-    <h3>Listo</h3>
+    <h3 class="kanban-tab" data-target="listo">Listo</h3>
     <div class="kanban-dropzone" id="col-listo"></div>
   </div>
   <div class="kanban-board board-entregado" data-status="entregado">
-    <h3>Entregado</h3>
+    <h3 class="kanban-tab" data-target="entregado">Entregado</h3>
     <div class="kanban-dropzone" id="col-entregado"></div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Añade marcadores de pestaña en cada columna del kanban para detectar cambios de vista
- Reinicia la escucha long-polling y recarga datos al cambiar filtros o pestañas
- Gestiona una única petición de escucha activa para evitar duplicados

## Testing
- `php -l vistas/cocina/cocina2.php`
- `node --check vistas/cocina/cocina2.js`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a517601a98832b8daafb3b355e3114