### PR TITLE
Integrate select2 product auto-fill

### DIFF
--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -1900,3 +1900,29 @@ document.addEventListener('click', function (e) {
             .catch(() => alert('Error al actualizar estado'));
     }
 });
+
+// === Integración de comportamiento de ventas2.js ===
+$(document).ready(function () {
+    $('.select-producto').select2();
+});
+
+$(document).on('DOMNodeInserted', function () {
+    $('.select-producto').select2();
+});
+
+$(document).on('change', '.select-producto', function () {
+    const $select = $(this);
+    const $row = $select.closest('tr');
+
+    const selectedOption = $select.find('option:selected');
+    const precio = parseFloat(selectedOption.data('precio')) || 0;
+
+    if (!selectedOption.val()) {
+        $row.find('.cantidad').val('');
+        $row.find('.precio').val('');
+        return;
+    }
+
+    $row.find('.cantidad').val(1);
+    $row.find('.precio').val(precio.toFixed(2));
+});


### PR DESCRIPTION
## Summary
- auto-initialize select2 for `.select-producto` fields and dynamic rows
- set quantity and price automatically from selected option's `data-precio`
- reset quantity and price when selection is cleared

## Testing
- `composer validate --no-check-all --no-check-publish`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d8ae7a20832b95a629ccc9231c23