### PR TITLE
Fix product selector auto-fill in sales module

### DIFF
--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -122,7 +122,7 @@ ob_start();
             </thead>
             <tbody>
               <tr>
-                <td><select class="form-control producto select-producto"></select></td>
+                <td><select class="form-control select-producto"></select></td>
                 <td><input type="number" class="form-control cantidad"></td>
                 <td><input type="number" step="0.01" class="form-control precio" readonly></td>
               </tr>


### PR DESCRIPTION
## Summary
- Load products via AJAX into global `productosData` and fill product selectors
- Delegate product select changes to auto-set quantity and price
- Ensure new product rows and HTML use `.select-producto`, `.cantidad`, and readonly `.precio`

## Testing
- `node --check vistas/ventas/ventas.js`
- `php -l vistas/ventas/ventas.php`


------
https://chatgpt.com/codex/tasks/task_e_68a600cf30ac832b9a4dea77a9035ee2