### PR TITLE
Normalize product search to ignore accents

### DIFF
--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -5,6 +5,10 @@ function showAppMsg(msg) {
 }
 window.alert = showAppMsg;
 
+function normalizarTexto(str) {
+  return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+}
+
 if (typeof catalogoDenominaciones !== 'undefined' && Array.isArray(catalogoDenominaciones) && catalogoDenominaciones.length > 0) {
   console.log('Denominaciones cargadas:', catalogoDenominaciones);
 } else {
@@ -1072,13 +1076,13 @@ function inicializarBuscadorProducto(select) {
     input.dataset.autocompleteInitialized = 'true';
 
     input.addEventListener('input', () => {
-        const val = input.value.toLowerCase();
+        const val = normalizarTexto(input.value);
         lista.innerHTML = '';
         if (!val) {
             lista.style.display = 'none';
             return;
         }
-        const coincidencias = catalogo.filter(p => p.nombre.toLowerCase().includes(val));
+        const coincidencias = catalogo.filter(p => normalizarTexto(p.nombre).includes(val));
         coincidencias.forEach(p => {
             const li = document.createElement('li');
             li.className = 'list-group-item list-group-item-action';


### PR DESCRIPTION
## Summary
- add reusable `normalizarTexto` helper
- normalize product names and search text to ignore accents and case in filter

## Testing
- `node --check vistas/ventas/ventas.js`


------
https://chatgpt.com/codex/tasks/task_e_68a66f7807c4832ba1f0afbb47fbfc35