### PR TITLE
feat: add searchable product selector to sale details

### DIFF
--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -1514,10 +1514,13 @@ async function verDetalles(id) {
                 html += `<p>Evidencia:<br><img src="../../uploads/evidencias/${info.foto_entrega}" width="300"></p>`;
             }
             html += `<h4>Agregar producto</h4>`;
-            // html += `<select id="detalle_producto"></select>`;
-            html += `<div class="sel sel--producto"><select id="detalle_producto" name="producto"></select></div>`;
-            html += `<input type="number" id="detalle_cantidad" value="1" min="1">`;
-            html += `<button class="btn custom-btn" id="addDetalle">Agregar</button>`;
+            html += `<div class="selector-producto position-relative">`;
+            html += `  <input type="text" class="form-control buscador-producto" placeholder="Buscar producto...">`;
+            html += `  <select id="detalle_producto" name="producto" class="d-none"></select>`;
+            html += `  <ul class="list-group lista-productos position-absolute w-100"></ul>`;
+            html += `</div>`;
+            html += `<input type="number" id="detalle_cantidad" value="1" min="1" class="d-none">`;
+            html += `<button class="btn custom-btn d-none" id="addDetalle">Agregar</button>`;
             html += ` <button class="btn custom-btn" id="imprimirTicket">Imprimir ticket</button> <button hidden class="btn custom-btn" id="cerrarDetalle" data-dismiss="modal">Cerrar</button>`;
 
             contenedor.innerHTML = html;
@@ -1536,19 +1539,23 @@ async function verDetalles(id) {
             actualizarEstiloSelect(selectProd);
             const cantDetalle = document.getElementById('detalle_cantidad');
             selectProd.addEventListener('change', () => {
-                const exist = selectProd.selectedOptions[0].dataset.existencia;
+                const exist = selectProd.selectedOptions[0]?.dataset.existencia;
                 if (exist) {
                     cantDetalle.max = exist;
                 } else {
                     cantDetalle.removeAttribute('max');
                 }
                 actualizarEstiloSelect(selectProd);
+                cantDetalle.value = 1;
+                agregarDetalle(id);
             });
+            inicializarBuscadorProducto(selectProd);
 
             contenedor.querySelectorAll('.delDetalle').forEach(btn => {
                 btn.addEventListener('click', () => eliminarDetalle(btn.dataset.id, id));
             });
-            document.getElementById('addDetalle').addEventListener('click', () => agregarDetalle(id));
+            const addBtn = document.getElementById('addDetalle');
+            if (addBtn) addBtn.addEventListener('click', () => agregarDetalle(id));
             document.getElementById('cerrarDetalle').addEventListener('click', () => {
                 hideModal('#modal-detalles');
             });


### PR DESCRIPTION
## Summary
- add accent-insensitive product selector to sale detail modal
- auto-add selected product with quantity 1 and price

## Testing
- `node --check vistas/ventas/ventas.js`
- `php -l vistas/ventas/ventas.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6749e67ac832bab5e400596289646