### PR TITLE
Fix price auto-fill and subtotal on product selection in detail view

### DIFF
--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -1092,6 +1092,23 @@ function inicializarBuscadorProducto(select) {
                 select.value = p.id;
                 lista.innerHTML = '';
                 lista.style.display = 'none';
+                // Ubicar la fila activa del detalle
+                const fila = select.closest('tr');
+                const precioInput = fila ? fila.querySelector('.precio') : null;
+                const cantidadInput = fila ? fila.querySelector('.cantidad') : null;
+
+                // Extraer el producto seleccionado del catálogo
+                const prod = productos.find(pr => parseInt(pr.id) === parseInt(p.id));
+                if (precioInput && prod) {
+                    const unitario = parseFloat(prod.precio);
+                    precioInput.dataset.unitario = unitario;
+
+                    // Si hay cantidad, calcular el subtotal; de lo contrario, usar precio unitario
+                    const cant = cantidadInput ? parseFloat(cantidadInput.value) || 0 : 0;
+                    precioInput.value = (cant > 0 ? cant * unitario : unitario).toFixed(2);
+                }
+
+                // Reutilizar lógica de cambio de producto/cantidad
                 select.dispatchEvent(new Event('change'));
             });
             lista.appendChild(li);


### PR DESCRIPTION
## Summary
- Populate price and subtotal when selecting a product through the detail view's search
- Reuse existing subtotal logic for both product and quantity changes

## Testing
- ⚠️ `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6784c44bc832bbc5c70fe78ebeab4