### PR TITLE
Actualiza subtotal al cambiar cantidad en ventas

### DIFF
--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -1887,7 +1887,34 @@ document.addEventListener('click', function (e) {
                 } else {
                     alert(data.mensaje || 'Error al actualizar estado');
                 }
-            })
+        })
             .catch(() => alert('Error al actualizar estado'));
+    }
+});
+
+// Actualiza el subtotal al modificar la cantidad
+document.addEventListener('input', function (e) {
+    if (e.target && e.target.classList.contains('cantidad')) {
+        const fila = e.target.closest('tr');
+        const precioInput = fila ? fila.querySelector('.precio') : null;
+        if (!precioInput) return;
+
+        // Validar cantidad mínima de 1
+        let cantidad = parseFloat(e.target.value) || 0;
+        if (cantidad < 1) {
+            cantidad = 1;
+            e.target.value = 1;
+        }
+
+        const precioUnitario = parseFloat(precioInput.dataset.unitario || precioInput.value) || 0;
+        const subtotal = cantidad * precioUnitario;
+
+        // Si existe un campo de subtotal, actualízalo; de lo contrario, usa el campo de precio
+        const subtotalInput = fila.querySelector('.subtotal');
+        if (subtotalInput) {
+            subtotalInput.value = subtotal.toFixed(2);
+        } else {
+            precioInput.value = subtotal.toFixed(2);
+        }
     }
 });


### PR DESCRIPTION
## Summary
- Calcula y actualiza el subtotal de cada producto cuando cambia la cantidad
- Garantiza que la cantidad mínima sea 1 y permite futuros campos de subtotal

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/rest/package.json')*
- `composer test` *(fails: Command "test" is not defined)*
- `node --check vistas/ventas/ventas.js`

------
https://chatgpt.com/codex/tasks/task_e_68a6a812df50832bb6b502240db32172