### PR TITLE
Refactor mesa details with shared product search

### DIFF
--- a/utils/js/buscador.js
+++ b/utils/js/buscador.js
@@ -1,0 +1,61 @@
+function normalizarTexto(str) {
+    return (str || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+}
+
+function inicializarBuscadorDetalle() {
+    const input = document.querySelector('#detalle_buscador');
+    const select = document.querySelector('#detalle_producto');
+    const lista = document.querySelector('#detalle_lista');
+    if (!input || !lista || input.dataset.autocompleteInitialized) return;
+    input.dataset.autocompleteInitialized = 'true';
+
+    input.addEventListener('input', () => {
+        const val = normalizarTexto(input.value.trim());
+        lista.innerHTML = '';
+        if (!val) {
+            lista.style.display = 'none';
+            return;
+        }
+        const arr = Array.isArray(window.catalogo) ? window.catalogo : [];
+        arr.filter(p => normalizarTexto(p.nombre).includes(val))
+            .slice(0, 50)
+            .forEach(p => {
+                const li = document.createElement('li');
+                li.className = 'list-group-item list-group-item-action';
+                li.textContent = p.nombre;
+                li.addEventListener('click', () => {
+                    input.value = p.nombre;
+                    if (select) {
+                        let opt = select.querySelector(`option[value="${p.id}"]`);
+                        if (!opt) {
+                            opt = document.createElement('option');
+                            opt.value = p.id;
+                            opt.dataset.precio = p.precio;
+                            opt.dataset.existencia = p.existencia;
+                            select.appendChild(opt);
+                        }
+                        select.value = p.id;
+                        select.dispatchEvent(new Event('change'));
+                    }
+                    const prod = (window.catalogo || []).find(c => parseInt(c.id) === parseInt(p.id));
+                    const cant = document.querySelector('#detalle_cantidad');
+                    if (prod && prod.existencia && cant) {
+                        cant.setAttribute('max', prod.existencia);
+                    } else if (cant) {
+                        cant.removeAttribute('max');
+                    }
+                    lista.innerHTML = '';
+                    lista.style.display = 'none';
+                });
+                lista.appendChild(li);
+            });
+        lista.style.display = lista.children.length ? 'block' : 'none';
+    });
+
+    document.addEventListener('click', e => {
+        const cont = input.closest('.selector-producto');
+        if (!cont || !cont.contains(e.target)) {
+            lista.style.display = 'none';
+        }
+    });
+}

--- a/vistas/mesas/kanbanMesas.js
+++ b/vistas/mesas/kanbanMesas.js
@@ -7,8 +7,11 @@ window.alert = showAppMsg;
 
 let productos = [];
 let meseros = [];
-const meseroSeleccionado = {};
 const usuarioActual = window.usuarioActual || { id: null, rol: '' };
+let ventaIdActual = null;
+let mesaIdActual = null;
+let estadoMesaActual = null;
+let huboCambios = false;
 
 async function cargarMesas() {
     try {
@@ -165,7 +168,7 @@ function renderKanban(listaMeseros, mesas) {
         const btnDetalles = card.querySelector('button.detalles');
         btnDetalles.addEventListener('click', ev => {
             ev.stopPropagation();
-            verVenta(card.dataset.venta, card.dataset.mesa, card.querySelector('h3').textContent, card.dataset.estado, card.dataset.mesero);
+            verDetalles(card.dataset.venta, card.dataset.mesa, card.querySelector('h3').textContent, card.dataset.estado);
         });
 
         const btnTicket = card.querySelector('button.ticket');
@@ -242,100 +245,19 @@ function textoEstado(e) {
 }
 
 
-function renderSelectMeseros(select, seleccionado) {
-    select.innerHTML = '<option value="">Sin mesero asignado</option>';
-    meseros.forEach(m => {
-        const opt = document.createElement('option');
-        opt.value = m.id;
-        opt.textContent = m.nombre;
-        if (seleccionado && parseInt(seleccionado) === parseInt(m.id)) {
-            opt.selected = true;
-        }
-        select.appendChild(opt);
-    });
-}
-
 async function cargarCatalogo() {
     try {
         const resp = await fetch('../../api/inventario/listar_productos.php');
         const data = await resp.json();
         if (data.success) {
             productos = data.resultado;
+            window.catalogo = data.resultado;
         }
     } catch (err) {
         console.error(err);
     }
 }
-
-function renderSelectProductos(select) {
-    select.innerHTML = '<option value="">--Selecciona--</option>';
-    productos.forEach(p => {
-        const opt = document.createElement('option');
-        opt.value = p.id;
-        opt.textContent = `${p.nombre} - $${p.precio}`;
-        opt.dataset.precio = p.precio;
-        select.appendChild(opt);
-    });
-}
-
-function cerrarModal() {
-    document.getElementById('modal-detalle').style.display = 'none';
-}
-
-function mostrarModalDetalle(datos, ventaId, mesaId, estado, meseroId) {
-    const modal = document.getElementById('modal-detalle');
-    let html = `<h3>Mesa ${datos.mesa} - Venta ${ventaId || ''}</h3>`;
-    html += `<table border="1"><thead><tr><th>Producto</th><th>Cantidad</th><th>Precio</th><th>Subtotal</th><th>Estatus</th><th>Hora entrega</th><th></th><th></th></tr></thead><tbody>`;
-    datos.productos.forEach(p => {
-        const est = p.estado_producto;
-        const btnEliminar = (est !== 'en_preparacion' && est !== 'entregado')
-            ? `<button class="eliminar" data-id="${p.id}">Eliminar</button>`
-            : '';
-        const puedeEntregar = est === 'listo';
-        const btnEntregar = est !== 'entregado'
-            ? `<button class="entregar" data-id="${p.id}" ${puedeEntregar ? '' : 'disabled'}>Marcar como entregado</button>`
-            : '';
-        const hora = p.entregado_hr ? p.entregado_hr : '';
-        html += `<tr><td>${p.nombre}</td><td>${p.cantidad}</td><td>${p.precio_unitario}</td><td>${p.subtotal}</td><td>${textoEstado(est)}</td><td>${hora}</td><td>${btnEliminar}</td><td>${btnEntregar}</td></tr>`;
-    });
-    html += `</tbody></table>`;
-    html += `<h4>Mesero</h4>`;
-    html += `<select id="select_mesero" disabled></select>`;
-    html += `<h4>Agregar producto</h4>`;
-    html += `<select id="nuevo_producto"></select>`;
-    html += `<input type="number" id="nuevo_cantidad" value="1" min="1">`;
-    const disabled = !ventaId && estado !== 'ocupada' ? 'disabled' : '';
-    html += `<button id="agregarProductoVenta" data-venta="${ventaId || ''}" data-mesa="${mesaId}" data-estado="${estado}" >Agregar producto</button>`;
-    if (ventaId) {
-        html += ` <button id="guardarMesero" data-venta="${ventaId}" hidden>Actualizar mesero</button>`;
-    }
-    html += ` <button id="cerrarModal">Cerrar</button>`;
-    modal.innerHTML = html;
-    modal.style.display = 'block';
-
-    renderSelectMeseros(document.getElementById('select_mesero'), meseroSeleccionado[mesaId] || meseroId);
-    renderSelectProductos(document.getElementById('nuevo_producto'));
-
-    modal.querySelectorAll('.eliminar').forEach(btn => {
-        btn.addEventListener('click', () => eliminarProducto(btn.dataset.id, ventaId));
-    });
-    modal.querySelectorAll('.entregar').forEach(btn => {
-        btn.addEventListener('click', () => marcarEntregado(btn.dataset.id, ventaId));
-    });
-    const selMesero = modal.querySelector('#select_mesero');
-    selMesero.addEventListener('change', () => {
-        if (!ventaId) {
-            meseroSeleccionado[mesaId] = parseInt(selMesero.value) || null;
-        }
-    });
-    if (ventaId) {
-        modal.querySelector('#guardarMesero').addEventListener('click', () => actualizarMesero(ventaId));
-    }
-    modal.querySelector('#agregarProductoVenta').addEventListener('click', () => agregarProductoVenta(ventaId, mesaId, estado));
-    modal.querySelector('#cerrarModal').addEventListener('click', cerrarModal);
-}
-
-async function eliminarProducto(detalleId, ventaId) {
+async function eliminarDetalle(detalleId, ventaId) {
     if (!confirm('¿Eliminar producto?')) return;
     try {
         const resp = await fetch('../../api/mesas/eliminar_producto_venta.php', {
@@ -345,7 +267,8 @@ async function eliminarProducto(detalleId, ventaId) {
         });
         const data = await resp.json();
         if (data.success) {
-            verVenta(ventaId);
+            huboCambios = true;
+            verDetalles(ventaId, mesaIdActual, '', estadoMesaActual);
         } else {
             alert(data.mensaje);
         }
@@ -364,7 +287,8 @@ async function marcarEntregado(detalleId, ventaId) {
         });
         const data = await resp.json();
         if (data.success) {
-            verVenta(ventaId);
+            huboCambios = true;
+            verDetalles(ventaId, mesaIdActual, '', estadoMesaActual);
         } else {
             alert(data.mensaje);
         }
@@ -373,55 +297,33 @@ async function marcarEntregado(detalleId, ventaId) {
         alert('Error al actualizar');
     }
 }
-
-async function actualizarMesero(ventaId, usuarioId) {
-    const select = document.getElementById('select_mesero');
-    const valor = usuarioId !== undefined ? usuarioId : select.value;
-    try {
-        const resp = await fetch('../../api/ventas/cambiar_mesero.php', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                venta_id: parseInt(ventaId),
-                usuario_id: valor === '' ? null : parseInt(valor)
-            })
-        });
-        const data = await resp.json();
-        if (!data.success) {
-            alert(data.mensaje);
-        }
-    } catch (err) {
-        console.error(err);
-        alert('Error al actualizar mesero');
-    }
-}
-
-async function agregarProductoVenta(ventaId, mesaId, estado) {
-    if (!ventaId && estado !== 'ocupada') {
+async function agregarDetalle() {
+    if (!ventaIdActual && estadoMesaActual !== 'ocupada') {
         alert('La mesa debe estar ocupada para iniciar una venta');
         return;
     }
 
-    const select = document.getElementById('nuevo_producto');
-    const cantidad = parseInt(document.getElementById('nuevo_cantidad').value);
+    const select = document.getElementById('detalle_producto');
+    const cantidad = parseFloat(document.getElementById('detalle_cantidad').value);
     const productoId = parseInt(select.value);
-    const selected = select.selectedOptions[0];
-    const precio = selected ? parseFloat(selected.dataset.precio || '0') : 0;
+    const prod = (window.catalogo || []).find(p => parseInt(p.id) === productoId);
+    const precio = prod ? parseFloat(prod.precio) : parseFloat(select.selectedOptions[0]?.dataset.precio || 0);
 
     if (isNaN(productoId) || isNaN(cantidad) || cantidad <= 0) {
         alert('Producto o cantidad inválida');
         return;
     }
 
-    let currentVentaId = ventaId;
-    const meseroSelect = document.getElementById('select_mesero');
-    const usuarioId = parseInt(meseroSelect.value) || meseroSeleccionado[mesaId];
+    if (prod && prod.existencia && cantidad > parseFloat(prod.existencia)) {
+        alert(`Solo hay ${prod.existencia} disponibles de ${prod.nombre}`);
+        return;
+    }
+
+    let currentVentaId = ventaIdActual;
 
     if (!currentVentaId) {
         try {
-            const corteResp = await fetch('../../api/corte_caja/verificar_corte_abierto.php', {
-                credentials: 'include'
-            });
+            const corteResp = await fetch('../../api/corte_caja/verificar_corte_abierto.php', { credentials: 'include' });
             const corteData = await corteResp.json();
             if (!corteData.success || !corteData.resultado.abierto) {
                 alert('Debe abrir caja antes de iniciar una venta.');
@@ -432,9 +334,8 @@ async function agregarProductoVenta(ventaId, mesaId, estado) {
             alert('Error al verificar caja');
             return;
         }
-        meseroSeleccionado[mesaId] = usuarioId || null;
         const crearPayload = {
-            mesa_id: parseInt(mesaId),
+            mesa_id: parseInt(mesaIdActual),
             productos: [{ producto_id: productoId, cantidad, precio_unitario: precio }]
         };
         try {
@@ -446,6 +347,7 @@ async function agregarProductoVenta(ventaId, mesaId, estado) {
             const data = await resp.json();
             if (data.success) {
                 currentVentaId = data.resultado.venta_id;
+                ventaIdActual = currentVentaId;
             } else {
                 alert(data.mensaje);
                 return;
@@ -456,10 +358,6 @@ async function agregarProductoVenta(ventaId, mesaId, estado) {
             return;
         }
     } else {
-        if (usuarioId && usuarioId !== meseroSeleccionado[mesaId]) {
-            await actualizarMesero(currentVentaId, usuarioId);
-            meseroSeleccionado[mesaId] = usuarioId;
-        }
         const payload = {
             venta_id: currentVentaId,
             producto_id: productoId,
@@ -484,16 +382,19 @@ async function agregarProductoVenta(ventaId, mesaId, estado) {
         }
     }
 
-    verVenta(currentVentaId, mesaId, '', estado, meseroSeleccionado[mesaId]);
+    huboCambios = true;
+    verDetalles(currentVentaId, mesaIdActual, '', estadoMesaActual);
     await cargarMesas();
 }
 
-async function verVenta(ventaId, mesaId, mesaNombre, estado, meseroId) {
+async function verDetalles(ventaId, mesaId, mesaNombre, estado) {
+    ventaIdActual = ventaId;
+    mesaIdActual = mesaId;
+    estadoMesaActual = estado;
+
     if (!ventaId) {
         try {
-            const resp = await fetch('../../api/corte_caja/verificar_corte_abierto.php', {
-                credentials: 'include'
-            });
+            const resp = await fetch('../../api/corte_caja/verificar_corte_abierto.php', { credentials: 'include' });
             const corte = await resp.json();
             if (!corte.success || !corte.resultado.abierto) {
                 alert('Debe abrir caja antes de iniciar una venta.');
@@ -504,9 +405,19 @@ async function verVenta(ventaId, mesaId, mesaNombre, estado, meseroId) {
             alert('Error al verificar caja');
             return;
         }
-        mostrarModalDetalle({ mesa: mesaNombre, mesero: '', productos: [] }, null, mesaId, estado, meseroId);
+    }
+
+    const modal = document.getElementById('modalVenta');
+    const contenedor = modal.querySelector('.modal-body');
+
+    if (!ventaId) {
+        contenedor.innerHTML = `<p>Mesa ${mesaNombre}</p>` + crearTablaProductos([]);
+        inicializarBuscadorDetalle();
+        modal.querySelector('#btnAgregarDetalle').addEventListener('click', agregarDetalle);
+        showModal('#modalVenta');
         return;
     }
+
     try {
         const resp = await fetch('../../api/mesas/detalle_venta.php', {
             method: 'POST',
@@ -515,7 +426,16 @@ async function verVenta(ventaId, mesaId, mesaNombre, estado, meseroId) {
         });
         const data = await resp.json();
         if (data.success) {
-            mostrarModalDetalle(data.resultado, ventaId, mesaId, estado, meseroId);
+            contenedor.innerHTML = `<p>Mesa ${data.resultado.mesa} - Venta ${ventaId}</p>` + crearTablaProductos(data.resultado.productos);
+            contenedor.querySelectorAll('.eliminar').forEach(btn => {
+                btn.addEventListener('click', () => eliminarDetalle(btn.dataset.id, ventaId));
+            });
+            contenedor.querySelectorAll('.entregar').forEach(btn => {
+                btn.addEventListener('click', () => marcarEntregado(btn.dataset.id, ventaId));
+            });
+            inicializarBuscadorDetalle();
+            modal.querySelector('#btnAgregarDetalle').addEventListener('click', agregarDetalle);
+            showModal('#modalVenta');
         } else {
             alert(data.mensaje);
         }
@@ -523,6 +443,32 @@ async function verVenta(ventaId, mesaId, mesaNombre, estado, meseroId) {
         console.error(err);
         alert('Error al obtener detalles');
     }
+}
+
+function crearTablaProductos(productos) {
+    let html = '<table class="styled-table" border="1"><thead><tr><th>Producto</th><th>Cant</th><th>Precio</th><th>Subtotal</th><th>Estatus</th><th>Hora</th><th></th><th></th></tr></thead><tbody>';
+    productos.forEach(p => {
+        const est = textoEstado(p.estado_producto);
+        const btnEliminar = (p.estado_producto !== 'entregado' && p.estado_producto !== 'en_preparacion') ? `<button class="eliminar" data-id="${p.id}">Eliminar</button>` : '';
+        const puedeEntregar = p.estado_producto === 'listo';
+        const btnEntregar = p.estado_producto !== 'entregado' ? `<button class="entregar" data-id="${p.id}" ${puedeEntregar ? '' : 'disabled'}>Entregar</button>` : '';
+        const hora = p.entregado_hr ? p.entregado_hr : '';
+        html += `<tr><td>${p.nombre}</td><td>${p.cantidad}</td><td>${p.precio_unitario}</td><td>${p.subtotal}</td><td>${est}</td><td>${hora}</td><td>${btnEliminar}</td><td>${btnEntregar}</td></tr>`;
+    });
+    html += `<tr id="detalle_nuevo">
+        <td>
+            <div class="selector-producto position-relative">
+                <input type="text" id="detalle_buscador" class="form-control" placeholder="Buscar producto...">
+                <select id="detalle_producto" class="d-none"></select>
+                <ul id="detalle_lista" class="list-group position-absolute w-100 lista-productos"></ul>
+            </div>
+        </td>
+        <td><input type="number" id="detalle_cantidad" class="form-control" min="0.01" step="0.01"></td>
+        <td colspan="4"></td>
+        <td colspan="2"><button class="btn custom-btn" id="btnAgregarDetalle">Agregar</button></td>
+    </tr>`;
+    html += '</tbody></table>';
+    return html;
 }
 
 async function dividirMesa(id) {
@@ -605,6 +551,15 @@ async function reservarMesa(id) {
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
+    const modal = document.getElementById('modalVenta');
+    modal.addEventListener('modal:hidden', () => {
+        const body = modal.querySelector('.modal-body');
+        if (body) body.innerHTML = '';
+        if (huboCambios) {
+            cargarMesas();
+            huboCambios = false;
+        }
+    });
     try {
         await cargarCatalogo();
         await cargarMesas();

--- a/vistas/mesas/mesas.php
+++ b/vistas/mesas/mesas.php
@@ -35,7 +35,20 @@ ob_start();
     <select id="filtro-area"></select>
 </div>
 <div id="tablero"></div>
-<div id="modal-detalle" style="display:none;"></div>
+<div id="modalVenta" class="modal-flotante modal fade" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Detalle de venta</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body"></div>
+            <div class="modal-footer">
+                <button type="button" class="btn custom-btn" data-dismiss="modal">Cerrar</button>
+            </div>
+        </div>
+    </div>
+</div>
 
 <div>
 <section class="section">
@@ -74,6 +87,7 @@ window.usuarioActual = {
     rol: <?= json_encode($_SESSION['rol'] ?? ''); ?>
 };
 </script>
+<script src="../../utils/js/buscador.js"></script>
 <script src="kanbanMesas.js"></script>
 </body>
 </html>

--- a/vistas/ventas/ventas.php
+++ b/vistas/ventas/ventas.php
@@ -349,7 +349,7 @@ ob_start();
 
   <?php require_once __DIR__ . '/../footer.php'; ?>
   
-  <script>
+<script>
     // ID de usuario proveniente de la sesión para operaciones en JS
     window.usuarioId = <?php echo json_encode($_SESSION['usuario_id']); ?>;
     // ID de la venta actualmente consultada en detalle
@@ -360,8 +360,9 @@ ob_start();
     const catalogoDenominaciones = <?php echo json_encode($denominaciones); ?>;
     // Último ID de detalle enviado a cocina almacenado
     window.ultimoDetalleCocina = parseInt(localStorage.getItem('ultimoDetalleCocina') || '0', 10);
-  </script>
-  <script src="ventas.js"></script>
+</script>
+<script src="../../utils/js/buscador.js"></script>
+<script src="ventas.js"></script>
   </body>
 
 </html>


### PR DESCRIPTION
## Summary
- extract `normalizarTexto` and `inicializarBuscadorDetalle` into shared utils/js/buscador.js for local catalog filtering
- switch ventas and mesas views to load shared buscador utility
- replace mesa detail modal with floating modal and local product autocomplete, mirroring sales view

## Testing
- `php -l vistas/ventas/ventas.php`
- `php -l vistas/mesas/mesas.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7bff3645c832b80a9db05ff3beae8