### PR TITLE
feat: unify product detail search

### DIFF
--- a/vistas/ventas/ventas.js
+++ b/vistas/ventas/ventas.js
@@ -116,6 +116,70 @@ let ticketRequests = [];
 let ventaIdActual = null;
 let mesas = [];
 
+// Utilidades de búsqueda usadas también en kanbanMesas.js
+window.normalizarTexto = window.normalizarTexto || function (str) {
+    return (str || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+};
+
+window.inicializarBuscadorDetalle = window.inicializarBuscadorDetalle || function () {
+    const $input = $('#detalle_buscador');
+    const $select = $('#detalle_producto');
+    const $lista = $('#detalle_lista');
+    if (!$input.length || !$lista.length || $input.data('autocompleteInitialized')) return;
+    $input.data('autocompleteInitialized', true);
+
+    const filtrar = () => {
+        const val = normalizarTexto($input.val().trim());
+        $lista.empty();
+        if (!val) {
+            $lista.hide();
+            return;
+        }
+        const arr = Array.isArray(window.catalogo) ? window.catalogo : [];
+        arr.filter(p => normalizarTexto(p.nombre).includes(val))
+            .slice(0, 50)
+            .forEach(p => {
+                const $li = $('<li/>', {
+                    class: 'list-group-item list-group-item-action',
+                    text: p.nombre
+                });
+                $li.on('click', () => {
+                    $input.val(p.nombre);
+                    if ($select.length) {
+                        let $opt = $select.find(`option[value="${p.id}"]`);
+                        if (!$opt.length) {
+                            $opt = $('<option/>', {
+                                value: p.id,
+                                'data-precio': p.precio,
+                                'data-existencia': p.existencia
+                            });
+                            $select.append($opt);
+                        }
+                        $select.val(p.id).trigger('change');
+                    }
+                    const prod = (window.catalogo || []).find(c => parseInt(c.id) === parseInt(p.id));
+                    const $cant = $('#detalle_cantidad');
+                    if (prod && prod.existencia && $cant.length) {
+                        $cant.attr('max', prod.existencia);
+                    } else if ($cant.length) {
+                        $cant.removeAttr('max');
+                    }
+                    $lista.empty().hide();
+                });
+                $lista.append($li);
+            });
+        $lista.toggle($lista.children().length > 0);
+    };
+
+    $input.on('input', filtrar);
+
+    $(document).off('click.buscadorDetalle').on('click.buscadorDetalle', e => {
+        if (!$(e.target).closest('.selector-producto').length) {
+            $lista.hide();
+        }
+    });
+};
+
 // ==== [INICIO BLOQUE valida: validación para cierre de corte] ====
 const VENTAS_URL = typeof API_LISTAR_VENTAS !== 'undefined' ? API_LISTAR_VENTAS : '../../api/ventas/listar_ventas.php';
 const MESAS_URL = typeof API_LISTAR_MESAS !== 'undefined' ? API_LISTAR_MESAS : '../../api/mesas/listar_mesas.php';


### PR DESCRIPTION
## Summary
- add reusable text normalizer and detail search copied from kanbanMesas.js
- filter detail products case-insensitively with jQuery helpers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c59291e0832b92a11bfbd522fa40