### PR TITLE
Restrict kitchen view by user role

### DIFF
--- a/api/cocina/listar_productos_cocina.php
+++ b/api/cocina/listar_productos_cocina.php
@@ -1,6 +1,10 @@
 <?php
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/response.php';
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+$rol = $_SESSION['rol'] ?? ($_SESSION['usuario']['rol'] ?? null);
 
 $sql = "SELECT
   d.id                          AS detalle_id,
@@ -79,14 +83,14 @@ WHERE
   (
     d.estado_producto <> 'entregado'
     OR (d.estado_producto = 'entregado' AND DATE(d.created_at) = CURDATE())
-  )
-ORDER BY
-  FIELD(d.estado_producto, 'pendiente','en_preparacion','listo','entregado'),
-  minutos_transcurridos DESC,
-  destino,
-  d.created_at;
+  )";
+if ($rol === 'barra') {
+    $sql .= " AND p.categoria_id = 1";
+} elseif ($rol === 'alimentos') {
+    $sql .= " AND p.categoria_id <> 1";
+}
+$sql .= "\nORDER BY\n  FIELD(d.estado_producto, 'pendiente','en_preparacion','listo','entregado'),\n  minutos_transcurridos DESC,\n  destino,\n  d.created_at;\n";
 
-";
 $res = $conn->query($sql);
 if (!$res) { error('Error al obtener productos: ' . $conn->error); }
 

--- a/vistas/cocina/cocina2.js
+++ b/vistas/cocina/cocina2.js
@@ -16,6 +16,8 @@ window.ultimoDetalleCocina = parseInt(localStorage.getItem('ultimoDetalleCocina'
     entregado: qs('#col-entregado')
   };
 
+  const rolUsuario = document.querySelector('#user-info')?.dataset.rol || '';
+
   const filtroInput = qs('#txtFiltro');
   const tipoEntregaSel = qs('#selTipoEntrega');
   const btnRefrescar = qs('#btnRefrescar');
@@ -45,6 +47,9 @@ window.ultimoDetalleCocina = parseInt(localStorage.getItem('ultimoDetalleCocina'
     const tipo = (tipoEntregaSel.value || '').toLowerCase();
 
     items.forEach(it => {
+      const cat = (it.categoria || '').toLowerCase();
+      if (rolUsuario === 'barra' && cat !== 'bebida') return;
+      if (rolUsuario === 'alimentos' && cat === 'bebida') return;
       if (txt){
         const hay = (it.producto + ' ' + it.destino).toLowerCase().includes(txt);
         if (!hay) return;

--- a/vistas/cocina/cocina2.php
+++ b/vistas/cocina/cocina2.php
@@ -7,8 +7,10 @@ if (!in_array($path_actual, $_SESSION['rutas_permitidas'])) {
     exit;
 }
 $title = 'Cocina (Kanban)';
+$rol_usuario = $_SESSION['rol'] ?? ($_SESSION['usuario']['rol'] ?? '');
 ob_start();
 ?>
+<div id="user-info" data-rol="<?= htmlspecialchars($rol_usuario, ENT_QUOTES); ?>" hidden></div>
 <div class="page-header mb-0">
   <div class="container">
     <div class="row"><div class="col-12"><h2>Módulo de Cocina (Kanban)</h2></div></div>


### PR DESCRIPTION
## Summary
- Filter kitchen product query by session role; barra sees only beverages, alimentos all except beverages
- Expose user role to cocina UI and filter rendering accordingly

## Testing
- `php -l api/cocina/listar_productos_cocina.php`
- `php -l vistas/cocina/cocina2.php`
- `node --check vistas/cocina/cocina2.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae71b4046c832b8bf2c8e6714343ee